### PR TITLE
Add a test for io.resource

### DIFF
--- a/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
+++ b/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
@@ -70,4 +70,12 @@ object ResourceSafetySpec extends Properties("resource-safety") {
       runLog.run.last == -6)
   }
 
+  property("io.resource") = secure {
+    // Check that the cleanup task is called after normal termination
+    var cleanedUp = false
+    val a = io.resource(Task.now(()))(_ => Task.delay(cleanedUp = true))(_ => Task.delay(cleanedUp = false))
+    a.take(1).run.run
+    cleanedUp
+  }
+
 }


### PR DESCRIPTION
While debugging some code that used `scalaz.stream.io.resource`, I wrote this simple spec for that function, to convince myself that it was behaving as I expected. I thought this might be worth contributing.
