### PR TITLE
Fix Process.state deadlock

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1002,6 +1002,7 @@ object Process {
    */
   def state[S](s0: S): Process[Task, (S, S => Task[Unit])] = suspend {
     val v = async.localRef[S]
+    v.set(s0)
     v.signal.continuous.take(1).map(s => (s, (s: S) => Task.delay(v.set(s)))).repeat
   }
 

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -185,6 +185,17 @@ object ProcessSpec extends Properties("Process1") {
     i == 1
   }
 
+  property("state") = secure {
+    val s = Process.state((0, 1))
+    val fib = Process(0, 1) ++ s.flatMap { case (get, set) =>
+      val (prev0, prev1) = get
+      val next = prev0 + prev1
+      eval(set((prev1, next))).drain ++ emit(next)
+    }
+    val l = fib.take(10).runLog.run.toList
+    l === List(0, 1, 1, 2, 3, 5, 8, 13, 21, 34)
+  }
+
   property("chunkBy2") = secure {
     val s = Process(3, 5, 4, 3, 1, 2, 6)
     s.chunkBy2(_ < _).toList == List(Vector(3, 5), Vector(4), Vector(3), Vector(1, 2, 6)) &&


### PR DESCRIPTION
`Process.state(s0)` resulted in a process that could never emit anything, because the ref was never set with the initial state value `s0`. (And the only other way to write to the ref was by consuming the stream first.)
