### PR TITLE
Process.every doesn't work

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -889,10 +889,15 @@ object Process {
    * If you'd like a discrete stream that will actually block until `d` has elapsed,
    * use `awakeEvery` instead.
    */
-  def every(d: Duration): Process[Task, Boolean] =
-    duration zip (emit(0 milliseconds) ++ duration) map {
-      case (cur, prev) => (cur - prev) > d
-    }
+  def every(d: Duration): Process[Task, Boolean] = {
+    def go(lastSpikeNanos: Long): Process[Task, Boolean] =
+      suspend {
+        val now = System.nanoTime
+        if ((now - lastSpikeNanos) > d.toNanos) emit(true) ++ go(now)
+        else emit(false) ++ go(lastSpikeNanos)
+      }
+    go(0)
+  }
 
   // pool for event scheduling
   // threads are just used for timing, no logic is run on this Thread

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -255,4 +255,35 @@ object ProcessSpec extends Properties("Process1") {
     v == List(1,2,3,4,6)
   }
   */
+
+  import scala.concurrent.duration._
+  val smallDelay = Gen.choose(10, 300) map {_.millis}
+  property("every") =
+    forAll(smallDelay) { delay: Duration =>
+      type BD = (Boolean, Duration)
+      val durationSinceLastTrue: Process1[BD, BD] = {
+        def go(lastTrue: Duration): Process1[BD,BD] = {
+          await1 flatMap { pair:(Boolean, Duration) => pair match {
+            case (true , d) => emit((true , d - lastTrue)) fby go(d)
+            case (false, d) => emit((false, d - lastTrue)) fby go(lastTrue)
+          } }
+        }
+        go(0.seconds)
+      }
+
+      val draws = (600.millis / delay) min 10 // don't take forever
+
+      val durationsSinceSpike = every(delay).
+                   tee(duration)(tee zipWith {(a,b) => (a,b)}).
+                   take(draws.toInt) |>
+                   durationSinceLastTrue
+
+      val result = durationsSinceSpike.runLog.run.toList
+      val (head :: tail) = result
+
+      head._1 :| "every always emits true first" &&
+      tail.filter   (_._1).map(_._2).forall { _ >= delay } :| "true means the delay has passed" &&
+      tail.filterNot(_._1).map(_._2).forall { _ <= delay } :| "false means the delay has not passed"
+  }
+
 }


### PR DESCRIPTION
every(d: Duration) is intended to spike true once per duration, and say false otherwise.

Before the duration fix #52, every said true at first and then always false. 

After the duration fix, its value was determined at first request and then repeated over and over, because it was comparing two durations that differed only by that initial distance.

Now it works (in my interpretation), returning true first and then false until duration has passed, then true. It is true if the delay has passed since the last request, false otherwise.

The test isn't pretty. Perhaps someone else has a more elegant property design for it.
