### PR TITLE
Make jar an osgi bundle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,5 +29,17 @@ publishMavenStyle := true
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
-bintray.Keys.packageLabels in bintray.Keys.bintray := 
+bintray.Keys.packageLabels in bintray.Keys.bintray :=
   Seq("stream processing", "functional I/O", "iteratees", "functional programming", "scala")
+
+osgiSettings
+
+OsgiKeys.bundleSymbolicName := "org.scalaz.stream"
+
+OsgiKeys.exportPackage := Seq("scalaz.stream.*")
+
+OsgiKeys.importPackage := Seq(
+  """scala.*;version="$<range;[===,=+);$<@>>"""",
+  """scalaz.*;version="$<range;[===,=+);$<@>>"""",
+  "*"
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,4 @@ resolvers += Resolver.url(
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.0")
 
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")


### PR DESCRIPTION
This patch adds OSGi metadata to the jar manifest. It sets the version range on the scala library and scalaz package imports to [epoch.major.minor, epoch.major+1), which aligns with the binary compatibility versioning policy from each project.
