### PR TITLE
Add process1.collectFirst

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -576,6 +576,10 @@ sealed abstract class Process[+F[_],+O] {
   def collect[O2](pf: PartialFunction[O,O2]): Process[F,O2] =
     this |> process1.collect(pf)
 
+  /** Alias for `this |> process1.collectFirst(pf)`. */
+  def collectFirst[O2](pf: PartialFunction[O,O2]): Process[F,O2] =
+    this |> process1.collectFirst(pf)
+
   /** Alias for `this |> process1.split(f)` */
   def split(f: O => Boolean): Process[F,Vector[O]] =
     this |> process1.split(f)

--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -92,6 +92,13 @@ trait process1 {
   def collect[I,I2](pf: PartialFunction[I,I2]): Process1[I,I2] =
     id[I].flatMap(pf andThen(emit) orElse { case _ => halt })
 
+  /**
+   * Like `collect`, but emits only the first element of this process on which
+   * the partial function is defined.
+   */
+  def collectFirst[I,I2](pf: PartialFunction[I,I2]): Process1[I,I2] =
+    collect(pf).take(1)
+
   /** Skips the first `n` elements of the input, then passes through the rest. */
   def drop[I](n: Int): Process1[I,I] =
     if (n <= 0) id[I]

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -103,6 +103,9 @@ object ProcessSpec extends Properties("Process1") {
     ("collect" |: {
       p.collect(pf).toList == p.toList.collect(pf)
     }) &&
+    ("collectFirst" |: {
+      p.collectFirst(pf).toList == p.toList.collectFirst(pf).toList
+    }) &&
     ("fold" |: {
       p.fold(0)(_ + _).toList == List(p.toList.fold(0)(_ + _))
     }) &&


### PR DESCRIPTION
This PR adds `collectFirst` to `process1`. It is just an abbreviation for `collect(pf).take(1)`, but since the Scala collections have it and I just used it in my own project, I thought it would be a nice addition. 
