### PR TITLE
Add Process.iterate[A](start: A)(f: A => A)

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -897,6 +897,16 @@ object Process {
     go(n max 0)
   }
 
+  /**
+   * An infinite `Process` that repeatedly applies a given function
+   * to a start value.
+   */
+  def iterate[A](start: A)(f: A => A): Process[Task,A] = {
+    def go(a: A): Process[Task,A] =
+      await(Task.now(a))(a => Emit(List(a), go(f(a))))
+    go(start)
+  }
+
   /** Produce a (potentially infinite) source from an unfold. */
   def unfold[S,A](s0: S)(f: S => Option[(A,S)]): Process[Task,A] =
     await(Task.delay(f(s0)))(o =>

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -120,8 +120,12 @@ object ProcessSpec extends Properties("Process1") {
     })
   }
 
-   property("fill") = forAll(Gen.choose(0,30).map2(Gen.choose(0,50))((_,_))) {
+  property("fill") = forAll(Gen.choose(0,30).map2(Gen.choose(0,50))((_,_))) {
     case (n,chunkSize) => Process.fill(n)(42, chunkSize).runLog.run.toList == List.fill(n)(42)
+  }
+
+  property("iterate") = secure {
+    Process.iterate(0)(_ + 1).take(100).runLog.run.toList == List.iterate(0, 100)(_ + 1)
   }
 
   import scalaz.concurrent.Task


### PR DESCRIPTION
`Process.iterate[A](start: A)(f: A => A): Process[Task,A]` creates an infinite Process which emits `start`, `f(start)`, `f(f(start))`, ...
