### PR TITLE
Add io.stdInLines for reading from standard input

### DIFF
--- a/src/main/scala/scalaz/stream/io.scala
+++ b/src/main/scala/scalaz/stream/io.scala
@@ -136,6 +136,13 @@ trait io {
   }
 
   /**
+   * The standard input stream, as `Process`. This `Process` repeatedly awaits
+   * and emits lines from standard input.
+   */
+  def stdInLines: Process[Task,String] =
+    Process.repeatEval(Task.delay { Option(readLine()).getOrElse(throw End) })
+
+  /**
    * The standard output stream, as a `Sink`. This `Sink` does not
    * emit newlines after each element. For that, use `stdOutLines`.
    */


### PR DESCRIPTION
This PR adds a `Process` for reading lines from standard input. Since `readLine` returns `null` when it reaches the end of the input stream, it's result is wrapped as `Option` so that the `Process` is terminated when `readLine` returns `null`.

Here is a simple example:

```
Process("What is your name?")
  .append(io.stdInLines.once.map(name => s"Hello $name!"))
  .through(io.stdOutLines).run.run
```

Which outputs

```
What is your name?
Frank
Hello Frank!
```

where the second line was typed in by me.
