### PR TITLE
Add Monoid instance for Bytes

### DIFF
--- a/src/main/scala/scalaz/stream/Bytes.scala
+++ b/src/main/scala/scalaz/stream/Bytes.scala
@@ -7,6 +7,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable.IndexedSeq
 import scala.collection.{mutable, IndexedSeqOptimized}
 import scala.reflect.ClassTag
+import scalaz.Monoid
 
 /**
  * Simple `immutability` wrapper to allow easy and effective working with Array[Byte]
@@ -393,7 +394,7 @@ object BytesN {
 
 
 
-object Bytes {
+object Bytes extends BytesInstances {
 
   val empty: Bytes = Bytes1(Array.emptyByteArray, 0, 0)
 
@@ -454,6 +455,11 @@ object Bytes {
     val sz = if (size == Int.MaxValue) a.size else size
     Bytes1(a, pos, sz)
   }
+}
 
-  //todo: place instances here
+sealed abstract class BytesInstances {
+  implicit val bytesInstance = new Monoid[Bytes] {
+    def append(f1: Bytes, f2: => Bytes) = f1 ++ f2
+    def zero = Bytes.empty
+  }
 }

--- a/src/test/scala/scalaz/stream/BytesSpec.scala
+++ b/src/test/scala/scalaz/stream/BytesSpec.scala
@@ -3,6 +3,7 @@ package scalaz.stream
 import org.scalacheck.Prop._
 import org.scalacheck.{Gen, Arbitrary, Properties}
 import scalaz._
+import scalaz.scalacheck.ScalazProperties._
 import scalaz.syntax.equal._
 import scalaz.syntax.show._
 import scalaz.std.list._
@@ -71,6 +72,9 @@ object BytesSpec extends Properties("Bytes") {
     }
   }
 
+  implicit val arbitraryBytes: Arbitrary[Bytes] = Arbitrary {
+    Gen.oneOf(arbitraryBytes1.arbitrary, arbitraryBytesN.arbitrary)
+  }
 
   def fullstack[A](f: => A): A = try f catch {case t: Throwable => t.printStackTrace(); throw t }
 
@@ -213,5 +217,5 @@ object BytesSpec extends Properties("Bytes") {
       b.toArray.toList === baa.toList
   }
 
-
+  property("monoid-laws") = monoid.laws[Bytes]
 }


### PR DESCRIPTION
A monoid instance for `Bytes` would be handy for the `linesIn` process I've written for my Subprocess adventure: https://github.com/fthomas/scalaz-stream/blob/c8d54905d6fd33986874c7aff605257819574d87/src/main/scala/scalaz/stream/Subprocess.scala#L164
So here it is ...
