### PR TITLE
Throw IllegalArgumentException for bad arguments instead of RuntimeException

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1057,14 +1057,17 @@ object Process {
    *
    * Note: The last emitted range may be truncated at `stopExclusive`. For
    * instance, `ranges(0,5,4)` results in `(0,4), (4,5)`.
+   *
+   * @throws IllegalArgumentException if `size` <= 0
    */
-  def ranges(start: Int, stopExclusive: Int, size: Int): Process[Task, (Int, Int)] =
-    if (size <= 0) sys.error("size must be > 0, was: " + size)
-    else unfold(start)(lower =>
+  def ranges(start: Int, stopExclusive: Int, size: Int): Process[Task, (Int, Int)] = {
+    require(size > 0, "size must be > 0, was: " + size)
+    unfold(start)(lower =>
       if (lower < stopExclusive)
         Some((lower -> ((lower+size) min stopExclusive), lower+size))
       else
         None)
+  }
 
   /**
    * A supply of `Long` values, starting with `initial`.

--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -42,13 +42,13 @@ trait process1 {
    * Groups inputs into chunks of size `n`. The last chunk may have size
    * less then `n`, depending on the number of elements in the input.
    *
-   * @throws RuntimeException if `n` <= 0
+   * @throws IllegalArgumentException if `n` <= 0
    */
   def chunk[I](n: Int): Process1[I,Vector[I]] = {
+    require(n > 0, "chunk size must be > 0, was: " + n)
     def go(m: Int, acc: Vector[I]): Process1[I,Vector[I]] =
       if (m <= 0) emit(acc) ++ go(n, Vector())
       else await1[I].flatMap(i => go(m-1, acc :+ i)).orElse(emit(acc))
-    if (n <= 0) sys.error("chunk size must be > 0, was: " + n)
     go(n, Vector())
   }
 
@@ -452,15 +452,15 @@ trait process1 {
   /**
    * Outputs a sliding window of size `n` onto the input.
    *
-   * @throws RuntimeException if `n` <= 0
+   * @throws IllegalArgumentException if `n` <= 0
    */
   def window[I](n: Int): Process1[I,Vector[I]] = {
+    require(n > 0, "window size must be > 0, was: " + n)
     def go(acc: Vector[I], c: Int): Process1[I,Vector[I]] =
       if (c > 0)
         await1[I].flatMap { i => go(acc :+ i, c - 1) } orElse emit(acc)
       else
         emit(acc) fby go(acc.tail, 1)
-    if (n <= 0) sys.error("window size must be > 0, was: " + n)
     go(Vector(), n)
   }
 


### PR DESCRIPTION
`p: Process[Frank, MinorHousekeepingPullRequest]; p.once.run`: This PR uses `require` from `scala.Predef` to check the validity of arguments instead of using an `if` and `sys.error`. The advantage is that you get a more specific `IllegalArgumentException` instead of a `RuntimeException`.
