### PR TITLE
Tests for awaitOption, chunk, chunkBy, and terminated

### DIFF
--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -59,6 +59,9 @@ trait process1 {
   /**
    * Like `chunk`, but emits a chunk whenever the predicate switches from
    * true to false.
+   * {{{
+   * Process(1,2,-1,3,4).chunkBy(_ > 0).toList == List(Vector(1, 2, -1), Vector(3, 4))
+   * }}}
    */
   def chunkBy[I](f: I => Boolean): Process1[I,Vector[I]] = {
     def go(acc: Vector[I], last: Boolean): Process1[I,Vector[I]] =
@@ -165,14 +168,15 @@ trait process1 {
 
   /**
    * `Process1` form of `List.fold`.
-   *  Folds the elements of this Process using the specified associative binary operator.
+   * Folds the elements of this Process using the specified associative binary operator.
    *
-   *  Unlike List.fold the order is always from the `left` side, i.e. it will always
-   *  honor order of `A`.
+   * Unlike List.fold the order is always from the `left` side, i.e. it will always
+   * honor order of `A`.
    *
-   *  If Process of `A` is empty, it will just emit `z` and terminate
-   *
-   *  `Process(1,2,3,4) |> fold(0)(_ + _) == Process(10)`
+   * If Process of `A` is empty, it will just emit `z` and terminate
+   * {{{
+   * Process(1,2,3,4) |> fold(0)(_ + _) == Process(10)
+   * }}}
    */
   def fold[A,B](z: B)(f: (B,A) => B): Process1[A,B] =
     scan(z)(f).last
@@ -180,12 +184,12 @@ trait process1 {
   /**
    * `Process1` form of `List.reduce`.
    *
-   *  Reduces the elements of this Process using the specified associative binary operator.
-   *
-   *  `Process(1,2,3,4) |> reduce(_ + _) == Process(10)`
-   *  `Process(1) |> reduce(_ + _) == Process(1)`
-   *  `Process() |> reduce(_ + _) == Process()`
-   *
+   * Reduces the elements of this Process using the specified associative binary operator.
+   * {{{
+   * Process(1,2,3,4) |> reduce(_ + _) == Process(10)
+   * Process(1) |> reduce(_ + _) == Process(1)
+   * Process() |> reduce(_ + _) == Process()
+   * }}}
    */
   def fold1[A](f: (A,A) => A): Process1[A,A] =
     reduce(f)
@@ -228,7 +232,9 @@ trait process1 {
 
   /**
    * Add `separator` between elements of the input. For example,
-   * `Process(1,2,3,4) |> intersperse(0) == Process(1,0,2,0,3,0,4)`.
+   * {{{
+   * Process(1,2,3,4) |> intersperse(0) == Process(1,0,2,0,3,0,4)
+   * }}}
    */
   def intersperse[A](separator: A): Process1[A,A] =
     await1[A].flatMap(head => emit(head) ++ id[A].flatMap(a => Process(separator, a)))
@@ -298,14 +304,14 @@ trait process1 {
   /**
    * `Process1` form of `List.reduce`.
    *
-   *  Reduces the elements of this Process using the specified associative binary operator.
+   * Reduces the elements of this Process using the specified associative binary operator.
+   * {{{
+   * Process(1,2,3,4) |> reduce(_ + _) == Process(10)
+   * Process(1) |> reduce(_ + _) == Process(1)
+   * Process() |> reduce(_ + _) == Process()
+   * }}}
    *
-   *  `Process(1,2,3,4) |> reduce(_ + _) == Process(10)`
-   *  `Process(1) |> reduce(_ + _) == Process(1)`
-   *  `Process() |> reduce(_ + _) == Process()`
-   *
-   *  Unlike `List.reduce` will not fail when Process is empty.
-   *
+   * Unlike `List.reduce` will not fail when Process is empty.
    */
   def reduce[A](f: (A,A) => A): Process1[A,A] =
     scan1(f).last
@@ -357,11 +363,11 @@ trait process1 {
 
   /**
    * Similar to `scan`, but unlike it it won't emit the `z` even when there is no input of `A`.
-   *
-   *  `Process(1,2,3,4) |> scan1(_ + _) == Process(1,3,6,10)`
-   *  `Process(1) |> scan1(_ + _) == Process(1)`
-   *  `Process() |> scan1(_ + _) == Process()`
-   *
+   * {{{
+   * Process(1,2,3,4) |> scan1(_ + _) == Process(1,3,6,10)
+   * Process(1) |> scan1(_ + _) == Process(1)
+   * Process() |> scan1(_ + _) == Process()
+   * }}}
    */
   def scan1[A](f: (A,A) => A): Process1[A,A] = {
     def go(a: A): Process1[A,A] = emit(a) fby await1[A].flatMap(a2 => go(f(a,a2)))

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -120,12 +120,30 @@ object ProcessSpec extends Properties("Process1") {
     })
   }
 
+  property("awaitOption") = secure {
+    Process().pipe(awaitOption).toList == List(None) &&
+    Process(1, 2).pipe(awaitOption).toList == List(Some(1))
+  }
+
+  property("chunk") = secure {
+    Process(0, 1, 2, 3, 4).chunk(2).toList == List(Vector(0, 1), Vector(2, 3), Vector(4))
+  }
+
+  property("chunkBy") = secure {
+    emitSeq("foo bar baz").chunkBy(_ != ' ').toList.map(_.mkString) ==
+      List("foo ", "bar ", "baz")
+  }
+
   property("fill") = forAll(Gen.choose(0,30).map2(Gen.choose(0,50))((_,_))) {
     case (n,chunkSize) => Process.fill(n)(42, chunkSize).runLog.run.toList == List.fill(n)(42)
   }
 
   property("iterate") = secure {
     Process.iterate(0)(_ + 1).take(100).runLog.run.toList == List.iterate(0, 100)(_ + 1)
+  }
+
+  property("terminated") = secure {
+    Process(1, 2, 3).terminated.toList == List(Some(1), Some(2), Some(3), None)
   }
 
   property("unfold") = secure {


### PR DESCRIPTION
This PR adds simple tests for `awaitOption`, `chunk`, `chunkBy`, and `terminated`. It also uses scaladoc's syntax for multiline code blocks for code examples in docstrings. Otherwise scaladoc renders this

```
Process(1,2,3,4) |> reduce(_ + _) == Process(10)
Process(1) |> reduce(_ + _) == Process(1)
Process() |> reduce(_ + _) == Process()
```

as

```
Process(1,2,3,4) |> reduce(_ + _) == Process(10) Process(1) |> reduce(_ + _) == Process(1) Process() |> reduce(_ + _) == Process()
```
