### PR TITLE
Fix bugs in copyToArray. Make implementations private so they can't be p...

### DIFF
--- a/src/main/scala/scalaz/stream/Bytes.scala
+++ b/src/main/scala/scalaz/stream/Bytes.scala
@@ -92,7 +92,7 @@ final class BytesBuilder extends mutable.Builder[Byte, Bytes] {
 
 
 /** Bytes instance with only one segment **/
-private final case class Bytes1 private[stream](
+final case class Bytes1 private[stream](
   private[stream] val src: Array[Byte]
   , private[stream] val pos: Int
   , val length: Int
@@ -198,13 +198,13 @@ private final case class Bytes1 private[stream](
     s"Bytes1: pos=$pos, length=$length, src: ${src.take(10 min length).mkString("(",",",if(length > 10) "..." else ")" )}"
 }
 
-private object Bytes1 {
+object Bytes1 {
 
   //todo: place instances here
 }
 
 /** Bytes instance with N segments **/
-private final case class BytesN private[stream](private[stream] val seg: Vector[Bytes1]) extends Bytes {
+final case class BytesN private[stream](private[stream] val seg: Vector[Bytes1]) extends Bytes {
 
   def append(that: Bytes): Bytes =
     if (that.isEmpty) this
@@ -379,7 +379,7 @@ private final case class BytesN private[stream](private[stream] val seg: Vector[
   override def foreach[@specialized U](f: (Byte) => U): Unit = seg.foreach(_.foreach(f))
 }
 
-private object BytesN {
+object BytesN {
 
   //todo: place instances here
 

--- a/src/test/scala/scalaz/stream/BytesSpec.scala
+++ b/src/test/scala/scalaz/stream/BytesSpec.scala
@@ -35,11 +35,11 @@ object BytesSpec extends Properties("Bytes") {
     override def shows(f: Array[Byte]): String = f.toList.toString()
   }
 
-  private implicit val showBytes1: Show[Bytes1] = new Show[Bytes1] {
+  implicit val showBytes1: Show[Bytes1] = new Show[Bytes1] {
     override def shows(f: Bytes1): String = s"Bytes1: pos=${f.pos }, sz=${f.length }, src:${f.src.show }"
   }
 
-  private implicit val showBytesN: Show[BytesN] = new Show[BytesN] {
+  implicit val showBytesN: Show[BytesN] = new Show[BytesN] {
     override def shows(f: BytesN): String = f.seg.map(_.shows).mkString("\nBytesN: (", ";\n         ", ")")
   }
 
@@ -50,7 +50,7 @@ object BytesSpec extends Properties("Bytes") {
     }
   }
 
-  private def genBytes1(min: Int, max: Int) =
+  def genBytes1(min: Int, max: Int) =
     for {
       n <- Gen.choose(min, max)
       b <- Gen.containerOfN[Array, Byte](n, Arbitrary.arbitrary[Byte])
@@ -61,11 +61,11 @@ object BytesSpec extends Properties("Bytes") {
     }
 
 
-  private implicit val arbitraryBytes1: Arbitrary[Bytes1] = Arbitrary {
+  implicit val arbitraryBytes1: Arbitrary[Bytes1] = Arbitrary {
     Gen.sized { s => genBytes1(0, s) }
   }
 
-  private implicit val arbitraryBytesN: Arbitrary[BytesN] = Arbitrary {
+  implicit val arbitraryBytesN: Arbitrary[BytesN] = Arbitrary {
     Gen.sized { s =>
       for {
         chunks <- Gen.choose(1, s)


### PR DESCRIPTION
fixes issue #89
Fix bug in copyToArray implementation. Fix the Bytes.decode tests to work on windows and nix. Make the Bytes implementations private so the package object unapply method cannot expose the mutable underlying Array[Byte] in a pattern match.
