### PR TITLE
Added mergeHaltL,R,Both, fixed termination behaviour of Exchange.run

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -22,6 +22,7 @@ import scalaz.stream.ReceiveY.ReceiveL
 import scalaz.\/-
 import scalaz.-\/
 import scalaz.stream.ReceiveY.ReceiveR
+import scalaz.stream.wye.AwaitL
 
 /**
  * A `Process[F,O]` represents a stream of `O` values which can interleave
@@ -1625,6 +1626,9 @@ object Process {
 
     private[stream] def contramapR_[I3](f: I3 => I2): Wye[I, I3, O] =
       self.attachR(process1.lift(f))
+
+
+
   }
 
   implicit class ChannelSyntax[F[_],I,O](self: Channel[F,I,O]) {

--- a/src/test/scala/scalaz/stream/ExchangeSpec.scala
+++ b/src/test/scala/scalaz/stream/ExchangeSpec.scala
@@ -4,6 +4,8 @@ import Process._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 import scalaz.concurrent.Task
+import concurrent.duration._
+import scalaz.stream.wye.Request
 
 
 object ExchangeSpec extends Properties("Exchange") {
@@ -59,6 +61,24 @@ object ExchangeSpec extends Properties("Exchange") {
     val ch: Channel[Task, Int, Process[Task, (Int, Int)]] = constant((i: Int) => Task.now(emitSeq(xs).toSource.map((i, _))))
     val l = Exchange.loopBack[Int, Int](process1.id).map(_.through(ch))
     l.flatMap(_.run(emitSeq(xs))).take(xs.size * xs.size).runLog.run == xs.map(i => xs.map(i2 => (i, i2))).flatten
+  }
+
+  property("run.terminate.on.read") = secure {
+    val ex = Exchange[Int,Int](Process.range(1,10),Process.constant(i => Task.now(())))
+    ex.run(Process.sleep(1 minute)).runLog.timed(3000).run == (1 until 10).toVector
+  }
+
+
+  property("run.terminate.on.write") = secure {
+    val ex = Exchange[Int,Int](Process.sleep(1 minute),Process.constant(i => Task.now(())))
+    ex.run(Process.range(1,10), Request.R).runLog.timed(3000).run == Vector()
+  }
+
+  property("run.terminate.on.read.or.write") = secure {
+    val exL = Exchange[Int,Int](Process.range(1,10),Process.constant(i => Task.now(())))
+    val exR = Exchange[Int,Int](Process.sleep(1 minute),Process.constant(i => Task.now(())))
+    ("left side terminated" |: exL.run(Process.sleep(1 minute), Request.Both).runLog.timed(3000).run == (1 until 10).toVector) &&
+      ("right side terminated" |: exR.run(Process.range(1,10), Request.Both).runLog.timed(3000).run == Vector())
   }
 
 }

--- a/src/test/scala/scalaz/stream/NioSpec.scala
+++ b/src/test/scala/scalaz/stream/NioSpec.scala
@@ -26,7 +26,7 @@ object NioServer {
     val srv =
       nio.server(address).map {
         _.flatMap {
-          ex => ex.readThrough(w).runReceive
+          ex => ex.readThrough(w).run()
         }
       }
 


### PR DESCRIPTION
@pchiusano I was trying to implement `wye.haltOnL`, `wye.haltOnR`, `wye.HaltOnAny/Both` combinator, but it seems it is impossible to implement them now given current signature of receiveL/R and awaitL/R. do you have some ideas perhaps? 

I just add them for `merge` for now, but would like to explore them in generic way. That will allow us to have the generic contract for wye that any wye will terminate after both sides terminate, but that could be altered  with way.haltOnL, haltOnR or haltOnAny combinators. 
