### PR TITLE
Add the scct sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,3 +43,5 @@ OsgiKeys.importPackage := Seq(
   """scalaz.*;version="$<range;[===,=+);$<@>>"""",
   "*"
 )
+
+ScctPlugin.instrumentSettings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ resolvers += Resolver.url(
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")
+
+addSbtPlugin("com.sqality.scct" % "sbt-scct" % "0.3")


### PR DESCRIPTION
This PR adds the sbt-scct plugin. SCCT is a code coverage tool. see https://github.com/sqality/scct for details. This should help us identify the parts that needs more testing.
