### PR TITLE
Add Scaladoc links for process1 aliases

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -570,129 +570,177 @@ sealed abstract class Process[+F[_],+O] {
     go(this, halt)
   }
 
-  /** Alias for `this |> process1.buffer(n)`. */
+  /** Alias for `this |> [[process1.buffer]](n)`. */
   def buffer(n: Int): Process[F,O] =
     this |> process1.buffer(n)
 
-  /** Alias for `this |> process1.bufferBy(f)`. */
-  def bufferBy(f: O => Boolean): Process[F,O] =
-    this |> process1.bufferBy(f)
-
-  /** Alias for `this |> process1.bufferAll`. */
+  /** Alias for `this |> [[process1.bufferAll]]`. */
   def bufferAll: Process[F,O] =
     this |> process1.bufferAll
 
-  /** Alias for `this |> process1.chunk(n)`. */
+  /** Alias for `this |> [[process1.bufferBy]](f)`. */
+  def bufferBy(f: O => Boolean): Process[F,O] =
+    this |> process1.bufferBy(f)
+
+  /** Alias for `this |> [[process1.chunk]](n)`. */
   def chunk(n: Int): Process[F,Vector[O]] =
     this |> process1.chunk(n)
 
-  /** Alias for `this |> process1.chunkBy(f)`. */
-  def chunkBy(f: O => Boolean): Process[F,Vector[O]] =
-    this |> process1.chunkBy(f)
-
-  /** Alias for `this |> process1.chunkBy2(f)`. */
-  def chunkBy2(f: (O, O) => Boolean): Process[F,Vector[O]] =
-    this |> process1.chunkBy2(f)
-
-  /** Alias for `this |> process1.collect(pf)`. */
-  def collect[O2](pf: PartialFunction[O,O2]): Process[F,O2] =
-    this |> process1.collect(pf)
-
-  /** Alias for `this |> process1.collectFirst(pf)`. */
-  def collectFirst[O2](pf: PartialFunction[O,O2]): Process[F,O2] =
-    this |> process1.collectFirst(pf)
-
-  /** Alias for `this |> process1.split(f)` */
-  def split(f: O => Boolean): Process[F,Vector[O]] =
-    this |> process1.split(f)
-
-  /** Alias for `this |> process1.splitOn(f)` */
-  def splitOn[P >: O](p: P)(implicit P: Equal[P]): Process[F,Vector[P]] =
-    this |> process1.splitOn(p)
-
-  /** Alias for `this |> process1.splitWith(f)` */
-  def splitWith(f: O => Boolean): Process[F,Vector[O]] =
-    this |> process1.splitWith(f)
-
-  /** Alias for `this |> process1.chunkAll`. */
+  /** Alias for `this |> [[process1.chunkAll]]`. */
   def chunkAll: Process[F,Vector[O]] =
     this |> process1.chunkAll
 
-  /** Alias for `this |> process1.window(n)` */
-  def window(n: Int): Process[F, Vector[O]] =
-    this |> process1.window(n)
+  /** Alias for `this |> [[process1.chunkBy]](f)`. */
+  def chunkBy(f: O => Boolean): Process[F,Vector[O]] =
+    this |> process1.chunkBy(f)
 
-  /** Ignores the first `n` elements output from this `Process`. */
+  /** Alias for `this |> [[process1.chunkBy2]](f)`. */
+  def chunkBy2(f: (O, O) => Boolean): Process[F,Vector[O]] =
+    this |> process1.chunkBy2(f)
+
+  /** Alias for `this |> [[process1.collect]](pf)`. */
+  def collect[O2](pf: PartialFunction[O,O2]): Process[F,O2] =
+    this |> process1.collect(pf)
+
+  /** Alias for `this |> [[process1.collectFirst]](pf)`. */
+  def collectFirst[O2](pf: PartialFunction[O,O2]): Process[F,O2] =
+    this |> process1.collectFirst(pf)
+
+  /** Alias for `this |> [[process1.drop]](n)`. */
   def drop(n: Int): Process[F,O] =
     this |> process1.drop[O](n)
 
-  /** Ignores elements from the output of this `Process` until `f` tests false. */
+  /** Alias for `this |> [[process1.dropWhile]](f)`. */
   def dropWhile(f: O => Boolean): Process[F,O] =
     this |> process1.dropWhile(f)
 
-  /** Skips any output elements not matching the predicate. */
+  /** Alias for `this |> [[process1.exists]](f)` */
+  def exists(f: O => Boolean): Process[F,Boolean] =
+    this |> process1.exists(f)
+
+  /** Alias for `this |> [[process1.filter]](f)`. */
   def filter(f: O => Boolean): Process[F,O] =
     this |> process1.filter(f)
 
-  /** Alias for `this |> process1.find(f)` */
+  /** Alias for `this |> [[process1.find]](f)` */
   def find(f: O => Boolean): Process[F,O] =
     this |> process1.find(f)
 
-  /** Alias for `this |> process1.exists(f)` */
-  def exists(f: O => Boolean): Process[F, Boolean] =
-    this |> process1.exists(f)
-
-  /** Alias for `this |> process1.forall(f)` */
-  def forall(f: O => Boolean): Process[F, Boolean] =
+  /** Alias for `this |> [[process1.forall]](f)` */
+  def forall(f: O => Boolean): Process[F,Boolean] =
     this |> process1.forall(f)
 
-  /** Connect this `Process` to `process1.fold(b)(f)`. */
+  /** Alias for `this |> [[process1.fold]](b)(f)`. */
   def fold[O2 >: O](b: O2)(f: (O2,O2) => O2): Process[F,O2] =
     this |> process1.fold(b)(f)
 
-  /** Alias for `this |> process1.foldMonoid(M)` */
-  def foldMonoid[O2 >: O](implicit M: Monoid[O2]): Process[F,O2] =
-    this |> process1.foldMonoid(M)
-
-  /** Alias for `this |> process1.foldMap(f)(M)`. */
+  /** Alias for `this |> [[process1.foldMap]](f)(M)`. */
   def foldMap[M](f: O => M)(implicit M: Monoid[M]): Process[F,M] =
     this |> process1.foldMap(f)(M)
 
-  /** Connect this `Process` to `process1.fold1(f)`. */
-  def fold1[O2 >: O](f: (O2,O2) => O2): Process[F,O2] =
-    this |> process1.fold1(f)
+  /** Alias for `this |> [[process1.foldMonoid]](M)` */
+  def foldMonoid[O2 >: O](implicit M: Monoid[O2]): Process[F,O2] =
+    this |> process1.foldMonoid(M)
 
-  /** Alias for `this |> process1.fold1Monoid(M)` */
-  def fold1Monoid[O2 >: O](implicit M: Monoid[O2]): Process[F,O2] =
-    this |> process1.fold1Monoid(M)
-
-  /** Alias for `this |> process1.fold1Semigroup(M)`. */
+  /** Alias for `this |> [[process1.foldSemigroup]](M)`. */
   def foldSemigroup[O2 >: O](implicit M: Semigroup[O2]): Process[F,O2] =
     this |> process1.foldSemigroup(M)
 
-  /** Alias for `this |> process1.fold1Map(f)(M)`. */
+  /** Alias for `this |> [[process1.fold1]](f)`. */
+  def fold1[O2 >: O](f: (O2,O2) => O2): Process[F,O2] =
+    this |> process1.fold1(f)
+
+  /** Alias for `this |> [[process1.fold1Map]](f)(M)`. */
   def fold1Map[M](f: O => M)(implicit M: Monoid[M]): Process[F,M] =
     this |> process1.fold1Map(f)(M)
 
-  /** Alias for `this |> process1.reduce(f)`. */
+  /** Alias for `this |> [[process1.fold1Monoid]](M)` */
+  def fold1Monoid[O2 >: O](implicit M: Monoid[O2]): Process[F,O2] =
+    this |> process1.fold1Monoid(M)
+
+  /** Alias for `this |> [[process1.intersperse]](sep)`. */
+  def intersperse[O2>:O](sep: O2): Process[F,O2] =
+    this |> process1.intersperse(sep)
+
+  /** Alias for `this |> [[process1.last]]`. */
+  def last: Process[F,O] =
+    this |> process1.last
+
+  /** Alias for `this |> [[process1.reduce]](f)`. */
   def reduce[O2 >: O](f: (O2,O2) => O2): Process[F,O2] =
     this |> process1.reduce(f)
 
-  /** Alias for `this |> process1.reduceMonoid(M)`. */
-  def reduceMonoid[O2 >: O](implicit M: Monoid[O2]): Process[F,O2] =
-    this |> process1.reduceMonoid(M)
-
-  /** Alias for `this |> process1.reduceSemigroup(M)`. */
-  def reduceSemigroup[O2 >: O](implicit M: Semigroup[O2]): Process[F,O2] =
-    this |> process1.reduceSemigroup(M)
-
-  /** Alias for `this |> process1.reduceMap(f)(M)`. */
+  /** Alias for `this |> [[process1.reduceMap]](f)(M)`. */
   def reduceMap[M](f: O => M)(implicit M: Monoid[M]): Process[F,M] =
     this |> process1.reduceMap(f)(M)
 
-  /** Insert `sep` between elements emitted by this `Process`. */
-  def intersperse[O2>:O](sep: O2): Process[F,O2] =
-    this |> process1.intersperse(sep)
+  /** Alias for `this |> [[process1.reduceMonoid]](M)`. */
+  def reduceMonoid[O2 >: O](implicit M: Monoid[O2]): Process[F,O2] =
+    this |> process1.reduceMonoid(M)
+
+  /** Alias for `this |> [[process1.reduceSemigroup]](M)`. */
+  def reduceSemigroup[O2 >: O](implicit M: Semigroup[O2]): Process[F,O2] =
+    this |> process1.reduceSemigroup(M)
+
+  /** Alias for `this |> [[process1.repartition]](p)(S)` */
+  def repartition[O2 >: O](p: O2 => IndexedSeq[O2])(implicit S: Semigroup[O2]): Process[F,O2] =
+    this |> process1.repartition(p)(S)
+
+  /** Alias for `this |> [[process1.scan]](b)(f)`. */
+  def scan[B](b: B)(f: (B,O) => B): Process[F,B] =
+    this |> process1.scan(b)(f)
+
+  /** Alias for `this |> [[process1.scanMap]](f)(M)`. */
+  def scanMap[M](f: O => M)(implicit M: Monoid[M]): Process[F,M] =
+    this |> process1.scanMap(f)(M)
+
+  /** Alias for `this |> [[process1.scanMonoid]](M)`. */
+  def scanMonoid[O2 >: O](implicit M: Monoid[O2]): Process[F,O2] =
+    this |> process1.scanMonoid(M)
+
+  /** Alias for `this |> [[process1.scanSemigroup]](M)`. */
+  def scanSemigroup[O2 >: O](implicit M: Semigroup[O2]): Process[F,O2] =
+    this |> process1.scanSemigroup(M)
+
+  /** Alias for `this |> [[process1.scan1]](f)`. */
+  def scan1[O2 >: O](f: (O2,O2) => O2): Process[F,O2] =
+    this |> process1.scan1(f)
+
+  /** Alias for `this |> [[process1.scan1Map]](f)(M)`. */
+  def scan1Map[M](f: O => M)(implicit M: Monoid[M]): Process[F,M] =
+    this |> process1.scan1Map(f)(M)
+
+  /** Alias for `this |> [[process1.scan1Monoid]](M)`. */
+  def scan1Monoid[O2 >: O](implicit M: Monoid[O2]): Process[F,O2] =
+    this |> process1.scan1Monoid(M)
+
+  /** Alias for `this |> [[process1.split]](f)` */
+  def split(f: O => Boolean): Process[F,Vector[O]] =
+    this |> process1.split(f)
+
+  /** Alias for `this |> [[process1.splitOn]](p)` */
+  def splitOn[P >: O](p: P)(implicit P: Equal[P]): Process[F,Vector[P]] =
+    this |> process1.splitOn(p)
+
+  /** Alias for `this |> [[process1.splitWith]](f)` */
+  def splitWith(f: O => Boolean): Process[F,Vector[O]] =
+    this |> process1.splitWith(f)
+
+  /** Alias for `this |> [[process1.take]](n)`. */
+  def take(n: Int): Process[F,O] =
+    this |> process1.take[O](n)
+
+  /** Alias for `this |> [[process1.takeWhile]](f)`. */
+  def takeWhile(f: O => Boolean): Process[F,O] =
+    this |> process1.takeWhile(f)
+
+  /** Alias for `this |> [[process1.terminated]]`. */
+  def terminated: Process[F,Option[O]] =
+    this |> process1.terminated
+
+  /** Alias for `this |> [[process1.window]](n)`. */
+  def window(n: Int): Process[F,Vector[O]] =
+    this |> process1.window(n)
 
   /** Alternate emitting elements from `this` and `p2`, starting with `this`. */
   def interleave[F2[x]>:F[x],O2>:O](p2: Process[F2,O2]): Process[F2,O2] =
@@ -700,53 +748,6 @@ sealed abstract class Process[+F[_],+O] {
 
   /** Halts this `Process` after emitting 1 element. */
   def once: Process[F,O] = take(1)
-
-  /** Skips all elements emitted by this `Process` except the last. */
-  def last: Process[F,O] = this |> process1.last
-
-  /** Alias for `this |> process1.repartition(p)` */
-  def repartition[O2 >: O](p: O2 => IndexedSeq[O2])(implicit S: Semigroup[O2]): Process[F,O2] =
-    this |> process1.repartition(p)
-
-  /** Connect this `Process` to `process1.scan(b)(f)`. */
-  def scan[B](b: B)(f: (B,O) => B): Process[F,B] =
-    this |> process1.scan(b)(f)
-
-  /** Connect this `Process` to `process1.scanMonoid(M)`. */
-  def scanMonoid[O2 >: O](implicit M: Monoid[O2]): Process[F,O2] =
-    this |> process1.scanMonoid(M)
-
-  /** Alias for `this |> process1.scanMap(f)(M)`. */
-  def scanMap[M](f: O => M)(implicit M: Monoid[M]): Process[F,M] =
-    this |> process1.scanMap(f)(M)
-
-  /** Connect this `Process` to `process1.scan1(f)`. */
-  def scan1[O2 >: O](f: (O2,O2) => O2): Process[F,O2] =
-    this |> process1.scan1(f)
-
-  /** Connect this `Process` to `process1.scan1Monoid(M)`. */
-  def scan1Monoid[O2 >: O](implicit M: Monoid[O2]): Process[F,O2] =
-    this |> process1.scan1Monoid(M)
-
-  /** Connect this `Process` to `process1.scan1Semigroup(M)`. */
-  def scanSemigroup[O2 >: O](implicit M: Semigroup[O2]): Process[F,O2] =
-    this |> process1.scanSemigroup(M)
-
-  /** Alias for `this |> process1.scan1Map(f)(M)`. */
-  def scan1Map[M](f: O => M)(implicit M: Monoid[M]): Process[F,M] =
-    this |> process1.scan1Map(f)(M)
-
-  /** Halts this `Process` after emitting `n` elements. */
-  def take(n: Int): Process[F,O] =
-    this |> processes.take[O](n)
-
-  /** Halts this `Process` as soon as the predicate tests false. */
-  def takeWhile(f: O => Boolean): Process[F,O] =
-    this |> processes.takeWhile(f)
-
-  /** Wraps all outputs in `Some`, then outputs a single `None` before halting. */
-  def terminated: Process[F,Option[O]] =
-    this |> processes.terminated
 
   /** Call `tee` with the `zipWith` `Tee[O,O2,O3]` defined in `tee.scala`. */
   def zipWith[F2[x]>:F[x],O2,O3](p2: Process[F2,O2])(f: (O,O2) => O3): Process[F2,O3] =


### PR DESCRIPTION
This PR adds Scaladoc links for all `process1` aliases in `Process`. It also reorders them alphabetically.
