### PR TITLE
Fixed cleanup of nested flatMaps

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -75,7 +75,7 @@ sealed abstract class Process[+F[_],+O] {
         case Emit(o, t) =>
           if (o.isEmpty) go(t, fallback, cleanup)
           else
-            try { f(o.head) ++ go(emitSeq(o.tail, t), fallback, cleanup) }
+            try { (f(o.head) onFailure (cleanup flatMap f)) ++ go(emitSeq(o.tail, t), fallback, cleanup) }
             catch {
               case End => fallback.flatMap(f)
               case e: Throwable => cleanup.flatMap(f).causedBy(e)
@@ -267,6 +267,7 @@ sealed abstract class Process[+F[_],+O] {
   final def onFailure[F2[x]>:F[x],O2>:O](p2: => Process[F2,O2]): Process[F2,O2] = this match {
     case Await(req,recv,fb,c) => Await(req, recv andThen (_.onFailure(p2)), fb, c onComplete p2)
     case Emit(h, t) => Emit(h, t.onFailure(p2))
+    case h@Halt(End) => this
     case h@Halt(e) =>
       try p2.causedBy(e)
       catch { case End => h


### PR DESCRIPTION
@pchiusano We have discovered this issue in cleantup. Can you take a look? In fact we have also found the bug in onFailure that evaluated process also in case of `End` termination. 

I think we need to go through the various cleanup // fallback combinators and verify them and validate their defintion. 

What do you think? I was thinking its maybe a good time to foxus on either trampolined or lazy version of the Await, and maybe we will need to touch Emit as well. 

what do you think?
