### PR TITLE
Require a Monoid if a method is called xxxMonoid

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -680,7 +680,7 @@ sealed abstract class Process[+F[_],+O] {
     this |> process1.reduce(f)
 
   /** Alias for `this |> [[process1.reduceMap]](f)(M)`. */
-  def reduceMap[M](f: O => M)(implicit M: Monoid[M]): Process[F,M] =
+  def reduceMap[M](f: O => M)(implicit M: Semigroup[M]): Process[F,M] =
     this |> process1.reduceMap(f)(M)
 
   /** Alias for `this |> [[process1.reduceMonoid]](M)`. */
@@ -716,7 +716,7 @@ sealed abstract class Process[+F[_],+O] {
     this |> process1.scan1(f)
 
   /** Alias for `this |> [[process1.scan1Map]](f)(M)`. */
-  def scan1Map[M](f: O => M)(implicit M: Monoid[M]): Process[F,M] =
+  def scan1Map[M](f: O => M)(implicit M: Semigroup[M]): Process[F,M] =
     this |> process1.scan1Map(f)(M)
 
   /** Alias for `this |> [[process1.scan1Monoid]](M)`. */

--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -336,10 +336,11 @@ trait process1 {
     reduce(M.append(_,_))
 
   /**
-   * Like `reduce` only uses `f` to map `A` to `B` and uses Monoid `M` for associative operation
+   * Like `reduce` only uses `f` to map `A` to `B` and uses Semigroup `M` for
+   * associative operation.
    */
-  def reduceMap[A,B](f: A => B)(implicit M: Monoid[B]): Process1[A,B] =
-    id[A].map(f).reduceMonoid(M)
+  def reduceMap[A,B](f: A => B)(implicit M: Semigroup[B]): Process1[A,B] =
+    id[A].map(f).reduceSemigroup(M)
 
   /**
    * Repartitions the input with the function `p`. On each step `p` is applied
@@ -414,10 +415,11 @@ trait process1 {
     scan1(M.append(_,_))
 
   /**
-   * Like `scan1` only uses `f` to map `A` to `B` and uses Monoid `M` for associative operation
+   * Like `scan1` only uses `f` to map `A` to `B` and uses Semigroup `M` for
+   * associative operation.
    */
-  def scan1Map[A,B](f:A => B)(implicit M: Monoid[B]): Process1[A,B] =
-    id[A].map(f).scan1Monoid(M)
+  def scan1Map[A,B](f:A => B)(implicit M: Semigroup[B]): Process1[A,B] =
+    id[A].map(f).scanSemigroup(M)
 
   /**
    * Emit the given values, then echo the rest of the input.


### PR DESCRIPTION
This PR changes `fold1Monoid` and `reduceMonoid` to require a `Monoid` instead of a `Semigroup`. It also fixes a copy & pasted typo in some docstrings.
