### PR TITLE
Do not require an immutable.IndexedSeq for process1.repartition

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -692,7 +692,7 @@ sealed abstract class Process[+F[_],+O] {
     this |> process1.reduceSemigroup(M)
 
   /** Alias for `this |> [[process1.repartition]](p)(S)` */
-  def repartition[O2 >: O](p: O2 => IndexedSeq[O2])(implicit S: Semigroup[O2]): Process[F,O2] =
+  def repartition[O2 >: O](p: O2 => collection.IndexedSeq[O2])(implicit S: Semigroup[O2]): Process[F,O2] =
     this |> process1.repartition(p)(S)
 
   /** Alias for `this |> [[process1.scan]](b)(f)`. */

--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -346,11 +346,11 @@ trait process1 {
    * are emitted. The last element is then prepended to the next input using the
    * Semigroup `I`. For example,
    * {{{
-   * Process("Hel", "l", "o Wor", "ld").repartition(_.split(" ").toIndexedSeq) ==
+   * Process("Hel", "l", "o Wor", "ld").repartition(_.split(" ")) ==
    *   Process("Hello", "World")
    * }}}
    */
-  def repartition[I](p: I => IndexedSeq[I])(implicit I: Semigroup[I]): Process1[I,I] = {
+  def repartition[I](p: I => collection.IndexedSeq[I])(implicit I: Semigroup[I]): Process1[I,I] = {
     def go(carry: Option[I]): Process1[I,I] =
       await1[I].flatMap { i =>
         val next = carry.fold(i)(c => I.append(c, i))

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -160,7 +160,7 @@ object ProcessSpec extends Properties("Process1") {
   }
 
   property("repartition") = secure {
-    Process("Lore", "m ip", "sum dolo", "r sit amet").repartition(_.split(" ").toIndexedSeq).toList ==
+    Process("Lore", "m ip", "sum dolo", "r sit amet").repartition(_.split(" ")).toList ==
       List("Lorem", "ipsum", "dolor", "sit", "amet") &&
     Process("hel", "l", "o Wor", "ld").repartition(_.grouped(2).toVector).toList ==
       List("he", "ll", "o ", "Wo", "rl", "d") &&


### PR DESCRIPTION
This PR changes `process1.repartition` to require a split function of type `I => scala.collection.IndexedSeq[I]` instead of `I => scala.collection.immutable.IndexedSeq[I]`. This allows to use for example `(_: String).split("\n")` (which has type `String => Array[String]`) as parameter for `repartition` without the need to convert the `Array` into an `immutable.IndexedSeq`
