### PR TITLE
Create `scanF` method

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -4,13 +4,12 @@ import scalaz.stream.actor.{WyeActor, message, actors}
 import scala.collection.immutable.{IndexedSeq,SortedMap,Queue,Vector}
 import scala.concurrent.duration._
 
-import scalaz.{Catchable,Functor,Monad,Cobind,MonadPlus,Monoid,Nondeterminism,Semigroup, Applicative}
+import scalaz.{Catchable,Functor,Monad,Cobind,MonadPlus,Monoid,Nondeterminism,Semigroup}
 import scalaz.concurrent.{Strategy, Task}
 import scalaz.Leibniz.===
 import scalaz.{\/,-\/,\/-,~>,Leibniz,Equal}
 import scalaz.std.stream._
 import scalaz.syntax.foldable._
-import scalaz.syntax.applicative._
 import \/._
 import ReceiveY.{ReceiveL,ReceiveR}
 
@@ -701,19 +700,15 @@ sealed abstract class Process[+F[_],+O] {
     this |> process1.scan(b)(f)
 
   /** Like scan, but the function used for scanning can be effectful. */
-  def scanF[F2[x]>:F[x],B](fb: F2[B])(f: (B,O) => F2[B])(implicit app: Applicative[F2]): Process[F2,B] = this match {
-    case Emit(oseq,rest) => Await[F2,B,B](
-      fb,
-      (b:B) =>
-      if (oseq.isEmpty) {
-        rest.scanF[F2,B](b.point[F2])(f)
+  def scanF[F2[x]>:F[x],B](b: B)(f: (B,O) => F2[B]): Process[F2,B] = this match {
+    case Emit(oseq,rest) => if (oseq.isEmpty) {
+        rest.scanF[F2,B](b)(f)
       } else {
         Emit(Seq(b),
-          Await[F2,B,B](f(b,oseq.head), (bnext:B) => emitSeq(oseq.tail, rest).scanF[F2,B](bnext.point[F2])(f) )
+          Await[F2,B,B](f(b,oseq.head), (bnext:B) => emitSeq(oseq.tail, rest).scanF[F2,B](bnext)(f) )
         )
       }
-    )
-    case Await(req, recv, fallback2,cleanup2) => Await(req, recv andThen( _.scanF(fb)(f) ), fallback2.scanF(fb)(f), cleanup2.scanF(fb)(f))
+    case Await(req, recv, fallback2,cleanup2) => Await(req, recv andThen( _.scanF[F2,B](b)(f) ), fallback2.scanF[F2,B](b)(f), cleanup2.scanF[F2,B](b)(f))
     case h@Halt(e) => h
   }
 

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -487,8 +487,7 @@ object ProcessSpec extends Properties("Process1") {
   }
 
   property("scanF works for simple Emit") = secure {
-    val start = 0L.point[LongWriter]
-    val process = Process.emitSeq(1 to 100).scanF[LongWriter,Long](start)( (s, l) => MWriterT.tell[List[Long]](List(l.toLong)).map(_ => (s+l).toLong))
+    val process = Process.emitSeq(1 to 100).scanF[LongWriter,Long](0L)( (s, l) => MWriterT.tell[List[Long]](List(l.toLong)).map(_ => (s+l).toLong))
     val (log, sum): (List[Long], Option[Long]) = process.runLast.run
     (log == (1 to 100).map(_.toLong)) && (sum == Some(100*99/2))
   }
@@ -496,8 +495,7 @@ object ProcessSpec extends Properties("Process1") {
   property("scanF works for Await") = secure {
     val max = 100
     val input = Process.Emit[LongWriter,Long]( (1 to 50).map(_.toLong), Await( None.point[LongWriter], (_:Any) => Process.emitSeq((51 to 100).map(_.toLong)) ) )
-    val start = 0L.point[LongWriter]
-    val process = input.scanF[LongWriter,Long](start)( (s, l) => MWriterT.tell[List[Long]](List(l.toLong)).map(_ => (s+l).toLong))
+    val process = input.scanF[LongWriter,Long](0L)( (s, l) => MWriterT.tell[List[Long]](List(l.toLong)).map(_ => (s+l).toLong))
     val (log, sum): (List[Long], Option[Long]) = process.runLast.run
     (log == (1 to 100).map(_.toLong)) && (sum == Some(100*99/2))
   }


### PR DESCRIPTION
Currently there is a `Process.scan` method which computes (oversimplifying here) a cumulative sum of a process. The function it takes to do this with has type `(B,O) => B`. 

For some stuff I was doing, I needed an alternative version, which does the same thing but with an effectful function of type `(B,O) => F[B]`. This pull request provides that function, currently called `scanF`. 

The implementation can almost certainly be made less ugly, and I'm not sure I'm handling errors correctly. 
