### PR TITLE
Fix scaladoc errors

### DIFF
--- a/src/main/scala/scalaz/stream/Exchange.scala
+++ b/src/main/scala/scalaz/stream/Exchange.scala
@@ -22,7 +22,7 @@ import scalaz.stream.ReceiveY.ReceiveR
  * Exchange allows combining this pattern with Processes and
  * allows to use different combinators to specify the Exchange behaviour.
  *
- * Exchange is currently specialized to [[scalaz.concurrent.Task]]
+ * Exchange is currently specialized to `scalaz.concurrent.Task`
  *
  * @param read Process reading values from remote system
  * @param write Process writing values to remote system

--- a/src/main/scala/scalaz/stream/async/mutable/Queue.scala
+++ b/src/main/scala/scalaz/stream/async/mutable/Queue.scala
@@ -76,7 +76,7 @@ trait Queue[A] {
  * Queue also has signal that signals size of queue whenever that changes.
  * This may be used for example as additional flow control signalling outside this queue.
  *
- * Please see [[scalaz.stream.actor.MergeStrategy.boundedQ]] for more details.
+ * Please see [[scalaz.stream.merge.JunctionStrategies.boundedQ]] for more details.
  *
  */
 trait BoundedQueue[A] {

--- a/src/main/scala/scalaz/stream/merge/Junction.scala
+++ b/src/main/scala/scalaz/stream/merge/Junction.scala
@@ -771,7 +771,7 @@ trait Junction[+W, -I, +O] {
   /**
    * Creates task, that when evaluated will make Junction to receive Seq of `I`.
    * This will complete _after_ Junction confirms that more `I` are needed
-   * by JunctionStrategy emitting [[scalaz.stream.actor.MergeStrategy.More]].
+   * by JunctionStrategy emitting [[scalaz.stream.merge.Junction.More]].
    *
    * Please note this creates upstream reference that has no notion of
    * being `open` or `done` like with references from upstream source.

--- a/src/main/scala/scalaz/stream/merge/JunctionStrategies.scala
+++ b/src/main/scala/scalaz/stream/merge/JunctionStrategies.scala
@@ -131,7 +131,7 @@ protected[stream] object JunctionStrategies {
 
 
   /**
-   * MergeN strategy for mergeN combinator. Please see [[scalaz.stream.merge.mergeN]] for more details.
+   * MergeN strategy for mergeN combinator. Please see [[scalaz.stream.merge]] for more details.
    */
   def mergeN[A](max:Int):JunctionStrategy[Nothing,A,A] = {
 


### PR DESCRIPTION
`sbt publishLocal` currently fails because of Scaladoc errors. This PR fixes these.
