### PR TITLE
More tests for compress.{deflate,inflate}

### DIFF
--- a/src/test/scala/scalaz/stream/CompressSpec.scala
+++ b/src/test/scala/scalaz/stream/CompressSpec.scala
@@ -52,4 +52,20 @@ object CompressSpec extends Properties("compress") {
 
     foldBytes(input) == foldBytes(inflated)
   }
+
+  property("deflate.compresses input") = secure {
+    val uncompressed = getBytes(
+      """"
+        |"A type system is a tractable syntactic method for proving the absence
+        |of certain program behaviors by classifying phrases according to the
+        |kinds of values they compute."
+        |-- Pierce, Benjamin C. (2002). Types and Programming Languages""")
+    val compressed = foldBytes(emit(uncompressed).pipe(deflate(9)).toList)
+
+    compressed.length < uncompressed.length
+  }
+
+  property("inflate.bad input") = secure {
+    emit(getBytes("Hello")).pipe(inflate()).toList.isEmpty
+  }
 }


### PR DESCRIPTION
The current tests for `compress.{deflate,inflate}` pass, if both are replaced by

``` scala
def deflate = id
def inflate = id
```

This is kind of embarrassing. Sorry about that. This PR therefore adds a test that actually shows that `deflate` compresses its input. It also shows how `inflate` reacts to non-compressed input.
