### PR TITLE
Simplify process1.stripNone and improve process1.collect

### DIFF
--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -88,7 +88,13 @@ trait process1 {
    *
    */
   def collect[I,I2](pf: PartialFunction[I,I2]): Process1[I,I2] =
-    id[I].flatMap(pf andThen(emit) orElse { case _ => halt })
+    await1[I].flatMap {
+      pf.andThen {
+        i => emit(i) fby collect(pf)
+      } orElse {
+        case _ => collect(pf)
+      }
+    }
 
   /**
    * Like `collect`, but emits only the first element of this process on which


### PR DESCRIPTION
While glancing again over `process1`, I noticed that `stripNone` can be simplified by using `collect`. I then [benchmarked](https://github.com/fthomas/scalaz-stream/blob/benchmarks/src/test/scala/scalaz/stream/performance/results.txt) this new implementation and it was slower than the original. So I improved the performance of `collect` and now `stripNone` is even slightly faster than the original. :fireworks:
