### PR TITLE
Fix chunk(n).eval bug

### DIFF
--- a/src/test/scala/scalaz/stream/Process1Spec.scala
+++ b/src/test/scala/scalaz/stream/Process1Spec.scala
@@ -15,6 +15,7 @@ import Process._
 import process1._
 
 import TestInstances._
+import scalaz.concurrent.Task
 
 object Process1Spec extends Properties("process1") {
   property("all") = forAll { (pi: Process0[Int], ps: Process0[String], n: Int) =>
@@ -159,6 +160,15 @@ object Process1Spec extends Properties("process1") {
 
   property("unchunk") = forAll { pi: Process0[List[Int]] =>
     pi.pipe(unchunk).toList == pi.toList.flatten
+  }
+
+  property("evalChunks") = secure {
+    val trues = for { i <- 1 until 50
+                      j <- 1 until i + 1 }
+      yield  { Process.range(0, i).chunk(j).map(Task(_)).eval.runLog.run.length ==
+               Process.range(0, i).chunk(j)                  .runLog.run.length }
+
+    trues.reduce(_ && _) == true
   }
 
   property("last") = secure {

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -66,9 +66,9 @@ object ProcessSpec extends Properties("Process") {
   import scalaz.concurrent.Task
 
   property("enqueue") = secure {
-    val tasks = Process.range(0,1000).map(i => Task { Thread.sleep(1); 1 })
-    tasks.sequence(50).pipe(processes.sum[Int].last).runLog.run.head == 1000 &&
-    tasks.gather(50).pipe(processes.sum[Int].last).runLog.run.head == 1000
+    val tasks = Process.range(0,1001).map(i => Task { Thread.sleep(1); 1 })
+    tasks.sequence(50).pipe(processes.sum[Int].last).runLog.run.head == 1001 &&
+    tasks.gather(50).pipe(processes.sum[Int].last).runLog.run.head == 1001
   }
 
   // ensure that wye terminates


### PR DESCRIPTION
Patch in reference to https://groups.google.com/forum/#!topic/scalaz/k9-NP-BlHdA
An example of the bug can be seen by

``` scala
Process.range(0, 6).chunk(4).map(Task(_)).eval.runLog.run.length ==
Process.range(0, 6).chunk(4).runLog.run.length
```

The changes to the spec will cause the bug to pop without the patch.
