### PR TITLE
Update scodec-bits to version 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snap
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.0.6",
   "org.scalaz" %% "scalaz-concurrent" % "7.0.6",
-  "org.typelevel" %% "scodec-bits" % "1.0.0-RC2",
+  "org.typelevel" %% "scodec-bits" % "1.0.0",
   "org.scalaz" %% "scalaz-scalacheck-binding" % "7.0.6" % "test",
   "org.scalacheck" %% "scalacheck" % "1.10.1" % "test"
 )


### PR DESCRIPTION
The update to scodec-bits 1.0.0 requires only the version bump in `build.sbt`.
