### PR TITLE
Replace id[A].map(f) with lift(f)

### DIFF
--- a/src/main/scala/scalaz/stream/merge/JunctionStrategies.scala
+++ b/src/main/scala/scalaz/stream/merge/JunctionStrategies.scala
@@ -189,7 +189,7 @@ protected[stream] object JunctionStrategies {
   object writers {
 
     /** writer that only echoes `A` on `O` side **/
-    def echoO[A]: Writer1[Nothing, A, A] = process1.id[A].map(right)
+    def echoO[A]: Writer1[Nothing, A, A] = process1.lift(right)
 
     /** Writer1 that interprets the Signal messages to provide discrete source of `A` **/
     def signal[A]: Writer1[A, Signal.Msg[A], Nothing] = {

--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -221,7 +221,7 @@ trait process1 {
    * Like `fold` only uses `f` to map `A` to `B` and uses Monoid `M` for associative operation
    */
   def foldMap[A,B](f: A => B)(implicit M: Monoid[B]): Process1[A,B] =
-   id[A].map(f).foldMonoid(M)
+   lift(f).foldMonoid(M)
 
   /**
    * Like `fold` but uses Monoid for folding operation
@@ -378,7 +378,7 @@ trait process1 {
    * associative operation.
    */
   def reduceMap[A,B](f: A => B)(implicit M: Semigroup[B]): Process1[A,B] =
-    id[A].map(f).reduceSemigroup(M)
+    lift(f).reduceSemigroup(M)
 
   /**
    * Repartitions the input with the function `p`. On each step `p` is applied
@@ -446,7 +446,7 @@ trait process1 {
    * Like `scan` only uses `f` to map `A` to `B` and uses Monoid `M` for associative operation
    */
   def scanMap[A,B](f:A => B)(implicit M: Monoid[B]): Process1[A,B] =
-    id[A].map(f).scanMonoid(M)
+    lift(f).scanMonoid(M)
 
   /**
    * Similar to `scan`, but unlike it it won't emit the `z` even when there is no input of `A`.
@@ -474,7 +474,7 @@ trait process1 {
    * associative operation.
    */
   def scan1Map[A,B](f:A => B)(implicit M: Semigroup[B]): Process1[A,B] =
-    id[A].map(f).scanSemigroup(M)
+    lift(f).scanSemigroup(M)
 
   /**
    * Emit the given values, then echo the rest of the input.


### PR DESCRIPTION
This is a dogfooding PR that replaces all occurrences of `id[A].map(f)` with `lift(f)`.
