### PR TITLE
Fix continuous signal so it always returns newest value

### DIFF
--- a/src/main/scala/scalaz/stream/async/mutable/Signal.scala
+++ b/src/main/scala/scalaz/stream/async/mutable/Signal.scala
@@ -110,7 +110,7 @@ object Signal {
     new mutable.Signal[A] {
       def changed: Process[Task, Boolean] = discrete.map(_ => true) merge Process.constant(false)
       def discrete: Process[Task, A] = junction.downstreamW
-      def continuous: Process[Task, A] = discrete.wye(Process.constant(()))(wye.echoLeft)(S)
+      def continuous: Process[Task, A] = repeatEval(get)
       def changes: Process[Task, Unit] = discrete.map(_ => ())
       def sink: Process.Sink[Task, Msg[A]] = junction.upstreamSink
       def get: Task[A] = discrete.take(1).runLast.flatMap {


### PR DESCRIPTION
The output of the test was originally `List(1, 1, 2)` now it is `List(1, 4, 4)` - `continuous` emits newest value of the signal.
