### PR TITLE
add http4s to the list of projects using scalaz-stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For questions about the library, use the [scalaz mailing list](https://groups.go
 
 If you have a project you'd like to include in this list, send a message to the [scalaz mailing list](https://groups.google.com/forum/#!forum/scalaz) and we'll add a link to it here.
 
+* [http4s](http://www.http4s.org): Minimal, idiomatic Scala interface for HTTP services using scalaz-stream
 * [scalaz-stream-mongodb](https://github.com/Spinoco/scalaz-stream-mongodb): Bindings to [MongoDB](http://www.mongodb.org/) that use scalaz-stream
 
 ### Related projects ###


### PR DESCRIPTION
http4s offers lower level HTTP server, and in the near future, client capabilities using scalaz-stream as the conduit to offer fully asynchronous operations while remaining composable and maintaining type safety.
We would like to have the project added to the list of projects currently using scalaz-stream.
