### PR TITLE
Fix pipeIn so it uses only one instance of original sink

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1560,20 +1560,20 @@ object Process {
   /** Syntax for Sink, that is specialized for Task */
   implicit class SinkTaskSyntax[I](val self: Sink[Task,I]) extends AnyVal {
     /** converts sink to channel, that will perform the side effect and echo its input **/
-    def toChannel:Channel[Task,I,I] = self.map(f => (i:I) => f(i).map(_ =>i))
+    def toChannel: Channel[Task, I, I] = self.map(f => (i: I) => f(i).map(_ => i))
 
-    /** converts channel to channel that first pipes received `I0` to supplied p1 **/
-    def pipeIn[I0](p1:Process1[I0,I]):Sink[Task,I0] = {
-      constant {
-        @volatile var cur: Process1[I0, I] = p1 //safe here hence at no moment 2 threads may access this at same time
-        (i0:I0) => {
-          val (piped, next) = cur.feed1(i0).unemit
-          cur = next
-          (emitSeq(piped).toSource to self).run
-        }
+    def pipeIn[I0](p1: Process1[I0, I]): Sink[Task, I0] = {
+      // Note: Function `f` from sink `self` may be used for more than 1 element emitted by `p1`.
+      @volatile var cur: Process1[I0, I] = p1
+      self.map {
+        (f: I => Task[Unit]) =>
+          (i0: I0) =>
+            val (piped, next) = cur.feed1(i0).unemit
+            cur = next
+            import scalaz.Scalaz._
+            piped.toList.traverse_(f)
       }
     }
-
   }
 
   /**


### PR DESCRIPTION
`written` in the included test originally contained only number `4`.
