### PR TITLE
Enable compilation with Scala 2.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 scala:
-  - 2.10.3
+  - 2.10.4
+  - 2.11.0
 jdk:
   - oraclejdk7
   - openjdk7

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ version := "snapshot-0.4"
 
 scalaVersion := "2.10.4"
 
+crossScalaVersions := Seq("2.10.4", "2.11.0")
+
 scalacOptions ++= Seq(
   "-feature",
   "-language:implicitConversions",
@@ -54,5 +56,3 @@ OsgiKeys.importPackage := Seq(
   """scalaz.*;version="$<range;[===,=+);$<@>>"""",
   "*"
 )
-
-ScctPlugin.instrumentSettings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,3 @@ resolvers += Resolver.url(
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")
-
-addSbtPlugin("com.sqality.scct" % "sbt-scct" % "0.3")


### PR DESCRIPTION
Removed the sbt-scct plugin since it is not available for 2.11.0.
