### PR TITLE
generalise runFoldMap implementation to runFoldLeft

### DIFF
--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -342,4 +342,11 @@ object ProcessSpec extends Properties("Process") {
     cnt == 1
   }
 
+  property("runFoldLeft") = secure {
+    Process.iterate(1)(_ + 1).take(10).runFoldLeft(0L)(_ + _).run == 55L
+  }
+
+  property("runFoldMap") = secure {
+    Process.iterate(1)(_ + 1).take(10).runFoldMap(_.toLong).run == 55L
+  }
 }


### PR DESCRIPTION
generalise runFoldMap implementation to runFoldLeft then implement the former in terms of the latter.

`runFoldMap` may be too restrictive a signature, as it requires a Monoid where a Monoid isn't strictly necessary, as the zero is only called once and the accumulation is left-associative in practice.

this may lead the naïve and silly (ie. me) to do things that later cause regret and shame https://twitter.com/ezyang/status/457791221017366528
