### PR TITLE
Remove io and process1 traits

### DIFF
--- a/src/main/scala/scalaz/stream/Exchange.scala
+++ b/src/main/scala/scalaz/stream/Exchange.scala
@@ -1,7 +1,7 @@
 package scalaz.stream
 
 import Process._
-import processes._
+import process1._
 import scalaz.\/._
 import scalaz._
 import scalaz.concurrent.{Strategy, Task}

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -618,7 +618,7 @@ sealed abstract class Process[+F[_],+O] extends Process1Ops[F,O] {
     condition.tee(this)(scalaz.stream.tee.until)
 }
 
-object processes extends process1 with tee with wye with io
+object processes extends tee with wye
 
 object Process {
 

--- a/src/main/scala/scalaz/stream/io.scala
+++ b/src/main/scala/scalaz/stream/io.scala
@@ -10,7 +10,7 @@ import Process._
 /**
  * Module of `Process` functions and combinators for file and network I/O.
  */
-trait io {
+object io {
 
   // NB: methods are in alphabetical order
 
@@ -187,5 +187,3 @@ trait io {
       }}
     }
 }
-
-object io extends io

--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -6,7 +6,7 @@ import scalaz.syntax.equal._
 
 import Process._
 
-trait process1 {
+object process1 {
 
   // nb: methods are in alphabetical order, there are going to be so many that
   // any other order will just going get confusing
@@ -595,8 +595,6 @@ trait process1 {
     go(z)
   }
 }
-
-object process1 extends process1
 
 private[stream] trait Process1Ops[+F[_],+O] {
   self: Process[F,O] =>

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -67,8 +67,8 @@ object ProcessSpec extends Properties("Process") {
 
   property("enqueue") = secure {
     val tasks = Process.range(0,1000).map(i => Task { Thread.sleep(1); 1 })
-    tasks.sequence(50).pipe(processes.sum[Int].last).runLog.run.head == 1000 &&
-    tasks.gather(50).pipe(processes.sum[Int].last).runLog.run.head == 1000
+    tasks.sequence(50).pipe(sum[Int].last).runLog.run.head == 1000 &&
+    tasks.gather(50).pipe(sum[Int].last).runLog.run.head == 1000
   }
 
   // ensure that wye terminates

--- a/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
+++ b/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
@@ -67,9 +67,9 @@ object ResourceSafetySpec extends Properties("resource-safety") {
   property("handle") = secure {
     case object Err extends RuntimeException
     val tasks = Process(Task(1), Task(2), Task(throw Err), Task(3))
-    (try { tasks.eval.pipe(processes.sum).runLog.run; false }
+    (try { tasks.eval.pipe(process1.sum).runLog.run; false }
      catch { case Err => true }) &&
-    (tasks.eval.pipe(processes.sum).
+    (tasks.eval.pipe(process1.sum).
       handle { case e: Throwable => Process.emit(-6) }.
       runLog.run.last == -6)
   }


### PR DESCRIPTION
@pchiusano in https://github.com/scalaz/scalaz-stream/pull/124#discussion_r10483028 you said you wanted to phase out the trait mixins. This PR therefore turns the `io` and `process1` traits into regular objects.
