### PR TITLE
Add "import scalaz.stream._" to sbt's initialCommands

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,3 +63,5 @@ parallelExecution in Test := false
 autoAPIMappings := true
 
 apiURL := Some(url(s"http://docs.typelevel.org/api/scalaz-stream/stable/${version.value}/doc/"))
+
+initialCommands := "import scalaz.stream._"


### PR DESCRIPTION
This PR adds `import scalaz.stream._` to sbt's `initialCommands`, see http://www.scala-sbt.org/0.13.2/docs/Howto/scala.html#initial for documentation of this setting. This means that `scalaz.stream._` is automatically imported when entering the Scala REPL via sbt's `console` task. This is very handy when playing around with the library in the REPL, since one does not need to type this import statement again and again.
