### PR TITLE
Put all examples in the examples package

### DIFF
--- a/src/test/scala/scalaz/stream/examples/CreatingStreams.scala
+++ b/src/test/scala/scalaz/stream/examples/CreatingStreams.scala
@@ -1,4 +1,5 @@
 package scalaz.stream
+package examples
 
 import scalaz.concurrent.Task
 import scalaz._

--- a/src/test/scala/scalaz/stream/examples/ReadingUTF8.scala
+++ b/src/test/scala/scalaz/stream/examples/ReadingUTF8.scala
@@ -1,4 +1,5 @@
 package scalaz.stream
+package examples
 
 import java.io._
 import org.scalacheck._

--- a/src/test/scala/scalaz/stream/examples/StartHere.scala
+++ b/src/test/scala/scalaz/stream/examples/StartHere.scala
@@ -1,4 +1,5 @@
 package scalaz.stream
+package examples
 
 import org.scalacheck._
 import Prop._

--- a/src/test/scala/scalaz/stream/examples/WritingAndLogging.scala
+++ b/src/test/scala/scalaz/stream/examples/WritingAndLogging.scala
@@ -1,8 +1,7 @@
 package scalaz.stream
+package examples
 
 import scalaz.concurrent.Task
-import scalaz.\/
-import scalaz.\/._
 
 import org.scalacheck._
 import Prop._


### PR DESCRIPTION
This PR moves the examples into the `scalaz.stream.examples` package so that the package name corresponds to their directory structure. It also removes unnecessary imports in `WritingAndLogging.scala`.
