### PR TITLE
Properly check for terminated print streams.

### DIFF
--- a/src/main/scala/scalaz/stream/io.scala
+++ b/src/main/scala/scalaz/stream/io.scala
@@ -1,6 +1,6 @@
 package scalaz.stream
 
-import java.io.{BufferedOutputStream,BufferedInputStream,FileInputStream,FileOutputStream,InputStream,OutputStream}
+import java.io.{BufferedOutputStream,BufferedInputStream,FileInputStream,FileOutputStream,InputStream,OutputStream,PrintStream}
 
 import scala.io.{Codec, Source}
 import scalaz.concurrent.Task
@@ -121,6 +121,28 @@ trait io {
     }
 
   /**
+   * Turn a print stream into a `Sink`. This `Sink` does not
+   * emit newlines after each element. For that, use `printLines`.
+   */
+  def print(out: PrintStream): Sink[Task,String] =
+    channel((s: String) => Task.delay {
+      out.print(s)
+      if (out.checkError)
+        throw End
+    })
+
+  /**
+   * Turn a print stream into a `Sink`. This `Sink` emits
+   * newlines after each element. If this is not desired, use `print`.
+   */
+  def printLines(out: PrintStream): Sink[Task,String] =
+    channel((s: String) => Task.delay {
+      out.println(s)
+      if (out.checkError)
+        throw End
+    })
+
+  /**
    * Generic combinator for producing a `Process[Task,O]` from some
    * effectful `O` source. The source is tied to some resource,
    * `R` (like a file handle) that we want to ensure is released.
@@ -142,6 +164,13 @@ trait io {
 
   /**
    * The standard input stream, as `Process`. This `Process` repeatedly awaits
+   * and emits chunks of bytes  from standard input.
+   */
+  def stdInBytes: Channel[Task, Int, ByteVector] =
+    io.chunkR(System.in)
+
+  /**
+   * The standard input stream, as `Process`. This `Process` repeatedly awaits
    * and emits lines from standard input.
    */
   def stdInLines: Process[Task,String] =
@@ -152,14 +181,20 @@ trait io {
    * emit newlines after each element. For that, use `stdOutLines`.
    */
   def stdOut: Sink[Task,String] =
-    channel((s: String) => Task.delay { print(s) })
+    print(System.out)
+
+  /**
+   * The standard output stream, as a `ByteVector` `Sink`.
+   */
+  def stdOutBytes: Sink[Task, ByteVector] =
+    chunkW(System.out)
 
   /**
    * The standard output stream, as a `Sink`. This `Sink` emits
    * newlines after each element. If this is not desired, use `stdOut`.
    */
   def stdOutLines: Sink[Task,String] =
-    channel((s: String) => Task.delay { println(s) })
+    printLines(System.out)
 
   /**
    * Creates a `Channel[Task,Array[Byte],Array[Byte]]` from an `InputStream` by

--- a/src/test/scala/scalaz/stream/PrintSpec.scala
+++ b/src/test/scala/scalaz/stream/PrintSpec.scala
@@ -1,0 +1,42 @@
+package scalaz.stream
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+
+import org.scalacheck.Prop.secure
+import org.scalacheck.Properties
+
+import scalaz.concurrent.Task
+
+object PrintSpec extends Properties("io.print") {
+  property("print terminates on process close") = secure {
+    terminates { out =>
+      Process
+        .constant("word").repeat
+        .to(io.print(out)).run.run
+    }
+  }
+
+  property("printLines terminates on process close") = secure {
+    terminates { out =>
+      Process
+        .constant("word").repeat
+        .to(io.printLines(out)).run.run
+    }
+  }
+
+  def terminates(run: PrintStream => Unit): Boolean = {
+    val baos = new ByteArrayOutputStream
+    val out = new PrintStream(baos)
+
+    /* Close the output stream after it receives some input
+       this should cause a well behaved process to terminate */
+    Task.fork(Task.delay({
+      while (baos.toByteArray.length < 10000) Thread.sleep(100)
+      baos.close
+      out.close
+    })).timed(5000).runAsync(_ => ())
+
+    Task.delay(run(out)).timed(1000).run
+    true
+  }
+}


### PR DESCRIPTION
All PrintStreams need to be checked for termination via
the checkError method (i.e. they do not throw exceptions
if the underlying resource is closed they just swallow
the error). To do this this change extracts print and
printLines combinators (partially so this can be tested,
but also because they are generally useful).

To demonstrate this issue it is possible to construct
an application from a process of:

```
  Process.constant("y").to(io.stdOutLines).run.run
```

And then try to run the app with something that closes
the output stream, for example:

```
  java -cp ... yes | head
```

The correct behaviour for this is the program should
exit after printing "y" 10 times. However, before this
change the program would print "y" 10 times then run
forever.

This fix was worked out by @jedws.
