### PR TITLE
Added a link to the additional resources page

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ For questions about the library, use the [scalaz mailing list](https://groups.go
 
 The API documentation of the latest release is available on [docs.typelevel.org](http://docs.typelevel.org/api/scalaz-stream/stable/latest/doc/).
 
+Blog posts and other external resources are listed on the [Additional Resources](https://github.com/scalaz/scalaz-stream/wiki/Additional-Resources)  page.
+
 ### Projects using scalaz-stream ###
 
 If you have a project you'd like to include in this list, send a message to the [scalaz mailing list](https://groups.google.com/forum/#!forum/scalaz) and we'll add a link to it here.


### PR DESCRIPTION
I didn't know about the Additional Resources page until someone on the mailing list suggested I add my blog post to it.  It'd be useful to link to it from the README.
