### PR TITLE
Reduce eagerness of linesR

### DIFF
--- a/src/main/scala/scalaz/stream/io.scala
+++ b/src/main/scala/scalaz/stream/io.scala
@@ -106,7 +106,7 @@ trait io {
    * using the `resource` combinator to ensure the `InputStream` is closed
    * when processing the stream of lines is finished.
    */
-  def linesR(in: InputStream)(implicit codec: Codec): Process[Task,String] =
+  def linesR(in: => InputStream)(implicit codec: Codec): Process[Task,String] =
     linesR(Source.fromInputStream(in)(codec))
 
   /**
@@ -114,7 +114,7 @@ trait io {
    * using the `resource` combinator to ensure the `Source` is closed
    * when processing the stream of lines is finished.
    */
-  def linesR(src: Source): Process[Task,String] =
+  def linesR(src: => Source): Process[Task,String] =
     resource(Task.delay(src))(src => Task.delay(src.close)) { src =>
       lazy val lines = src.getLines // A stateful iterator
       Task.delay { if (lines.hasNext) lines.next else throw End }


### PR DESCRIPTION
The current implementation of linesR evaluates its arguments too early, wasting system resources unnecessarily and creating a risk of user-unexpected Exceptions being thrown. This commit fixes that, to the extent possible, by delaying resource-opening and allowing resources to be re-opened when we know how.
