### PR TITLE
toList doesn't throw Kill

### DIFF
--- a/src/main/scala/scalaz/stream2/Process.scala
+++ b/src/main/scala/scalaz/stream2/Process.scala
@@ -1264,7 +1264,7 @@ object Process {
         cur.step match {
           case Cont(Emit(os),next) => go(next(End), acc fast_++ os)
           case Cont(_,next) => go(next(End),acc)
-          case Done(End) => acc
+          case Done(End) | Done(Kill) => acc
           case Done(rsn) => throw rsn
         }
       }


### PR DESCRIPTION
Fix how `toList` behaves to `Kill`. This fixes `ProcessSpec.kill` test.
