### PR TITLE
toList doesn't throw Kill

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1253,7 +1253,7 @@ object Process {
         cur.step match {
           case Cont(Emit(os),next) => go(next(End), acc fast_++ os)
           case Cont(_,next) => go(next(End),acc)
-          case Done(End) => acc
+          case Done(End) | Done(Kill) => acc
           case Done(rsn) => throw rsn
         }
       }


### PR DESCRIPTION
Fix handling of `Kill` by `toIndexedSeq` and test `ProcessSpec.kill`.
