### PR TITLE
'scalaz.stream.hash'es don't hash the entire stream

### DIFF
--- a/src/main/scala/scalaz/stream/hash.scala
+++ b/src/main/scala/scalaz/stream/hash.scala
@@ -29,7 +29,7 @@ object hash {
     def go(digest: MessageDigest): Process1[ByteVector,ByteVector] =
       await1[ByteVector].flatMap { bytes =>
         digest.update(bytes.toArray)
-        go(digest) orElse emitLazy(ByteVector.view(digest.digest()))
+        go(digest) orElse emitLazy(ByteVector.view(digest.clone().asInstanceOf[MessageDigest].digest()))
       }
     suspend1(go(MessageDigest.getInstance(algorithm)))
   }

--- a/src/test/scala/scalaz/stream/HashSpec.scala
+++ b/src/test/scala/scalaz/stream/HashSpec.scala
@@ -1,5 +1,6 @@
 package scalaz.stream
 
+import java.io.ByteArrayInputStream
 import java.security.MessageDigest
 import org.scalacheck._
 import org.scalacheck.Prop._
@@ -9,10 +10,16 @@ import Process._
 import hash._
 
 import TestInstances._
+import scala.util.Random
+import scalaz._
+import scalaz.syntax.id._
 
 object HashSpec extends Properties("hash") {
   def digest(algo: String, str: String): List[Byte] =
     MessageDigest.getInstance(algo).digest(str.getBytes).toList
+
+  def digest(algo: String, content: Array[Byte]): List[Byte] =
+    MessageDigest.getInstance(algo).digest(content).toList
 
   def checkDigest(h: Process1[ByteVector,ByteVector], algo: String, str: String): Boolean = {
     val n = Gen.choose(1, str.length).sample.getOrElse(1)
@@ -49,4 +56,28 @@ object HashSpec extends Properties("hash") {
 
     vec.map(_.runLast.run).forall(_ == res)
   }
+
+  property("hashes over all of stream") = forAll { (b: LargeContent) =>
+      ("md2"    |: checkDigest(md2,    "MD2",     b)) &&
+      ("md5"    |: checkDigest(md5,    "MD5",     b)) &&
+      ("sha1"   |: checkDigest(sha1,   "SHA-1",   b)) &&
+      ("sha256" |: checkDigest(sha256, "SHA-256", b)) &&
+      ("sha384" |: checkDigest(sha384, "SHA-384", b)) &&
+      ("sha512" |: checkDigest(sha512, "SHA-512", b))
+  }
+
+  def checkDigest(h: Process1[ByteVector, ByteVector], algo: String, content: Array[Byte]): Boolean = {
+    val n = Gen.choose(1, content.length).sample.getOrElse(1)
+    val p =
+      Process.constant(n)
+        .through(io.chunkR(new ByteArrayInputStream(content)))
+
+    p.pipe(h).map(_.toArray.toList).runLast.run == Some(digest(algo, content))
+  }
+
+  sealed trait Large
+  type LargeContent = Array[Byte] @@ Large
+  implicit def arbitraryLargeContent: Arbitrary[LargeContent] = Arbitrary(
+    Gen.chooseNum(1, 1000000).map(size => new Array[Byte](size) <| ((new Random).nextBytes)).map(Tag.apply)
+  )
 }


### PR DESCRIPTION
Piping a stream with more than one Emit state (e.g. generated by io.chunkR) through the hashers doesn't appear to hash the entire stream; instead it appears to emit the hash for only the bytes in the current Emit state. Perhaps that was the intent, but it doesn't seem too useful to me.

It appears the problem is due to the digest.digest() call in emitLazy being called for each emission. Calling digest() resets the state of the MessageDigest.

One 'solution' would be to clone the digest before calling digest(), but that only works if the MessageDigest implementation implements Cloneable. Another possibility may be for the hash transducers to return the MessageDigest itself, and let the stream consumer call digest (but that's also ugly too).
