### PR TITLE
Bugfix: Use the current Process1 in liftL

### DIFF
--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -286,7 +286,7 @@ object process1 {
     def go(curr: Process1[A,B]): Process1[A \/ C, B \/ C] = {
       receive1Or[A \/ C, B \/ C](curr.disconnect.map(-\/(_))) {
         case -\/(a) =>
-          val (bs, next) = p.feed1(a).unemit
+          val (bs, next) = curr.feed1(a).unemit
           val out =  emitAll(bs).map(-\/(_))
           next match {
             case Halt(rsn) => out fby fail(rsn)

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -222,4 +222,9 @@ object ProcessSpec extends Properties("Process") {
       case (f1, f2) => if (f1 <= 13) Some(((f1, f2), (f2, f1 + f2))) else None
     }.map(_._1).toList == List(0, 1, 1, 2, 3, 5, 8, 13)
   }
+
+  property("pipeO stripW ~= stripW pipe") = secure {
+    val p = logged(range(1, 11).toSource)
+    p.pipeO(sum).stripW.runLog.run == p.stripW.pipe(sum).runLog.run
+  }
 }


### PR DESCRIPTION
While checking if #122 is fixed in `topic/process/append3-merge` I noticed a small bug in `liftL`. This fixes #122
