### PR TITLE
Add distinctConsecutive{,By} to process1

### DIFF
--- a/src/test/scala/scalaz/stream/Process1Spec.scala
+++ b/src/test/scala/scalaz/stream/Process1Spec.scala
@@ -124,6 +124,14 @@ object Process1Spec extends Properties("Process1") {
     pi.pipe(unchunk).toList == pi.toList.flatten
   }
 
+  property("distinctConsecutive") = secure {
+    Process[Int]().distinctConsecutive.toList === List.empty[Int] &&
+      Process(1, 2, 3, 4).distinctConsecutive.toList === List(1, 2, 3, 4) &&
+      Process(1, 1, 2, 2, 3, 3, 4, 3).distinctConsecutive.toList === List(1, 2, 3, 4, 3) &&
+      Process("1", "2", "33", "44", "5", "66")
+        .distinctConsecutiveBy(_.length).toList === List("1", "33", "5", "66")
+  }
+
   property("drainLeading") = secure {
     val p = emit(1) ++ await1[Int]
     Process().pipe(p).toList === List(1) &&


### PR DESCRIPTION
This one adds `distinctConsecutive` and `distinctConsecutiveBy(f)` to `process1` which remove consecutive duplicates from the input such that the first element of those duplicates is emitted.

RxJava has the same operation and they call it [distinctUntilChanged](https://github.com/ReactiveX/RxJava/wiki/Filtering-Observables#distinctuntilchanged). Suggestions for better names are welcome!
