### PR TITLE
Replace await1[A].flatMap with receive1?

### DIFF
--- a/src/main/scala/scalaz/stream/compress.scala
+++ b/src/main/scala/scalaz/stream/compress.scala
@@ -30,7 +30,7 @@ object compress {
       }
 
     def go(deflater: Deflater, buf: Array[Byte]): Process1[ByteVector,ByteVector] =
-      await1[ByteVector].flatMap { bytes =>
+      receive1 { bytes =>
         deflater.setInput(bytes.toArray)
         val chunks = collect(deflater, buf, Deflater.NO_FLUSH)
         emitAll(chunks) fby go(deflater, buf)
@@ -65,7 +65,7 @@ object compress {
       }
 
     def go(inflater: Inflater, buf: Array[Byte]): Process1[ByteVector,ByteVector] =
-      await1[ByteVector].flatMap { bytes =>
+      receive1 { bytes =>
         inflater.setInput(bytes.toArray)
         val chunks = collect(inflater, buf, Vector.empty)
         emitAll(chunks) fby go(inflater, buf)

--- a/src/main/scala/scalaz/stream/hash.scala
+++ b/src/main/scala/scalaz/stream/hash.scala
@@ -27,7 +27,7 @@ object hash {
 
   private def messageDigest(algorithm: String): Process1[ByteVector,ByteVector] = {
     def go(digest: MessageDigest): Process1[ByteVector,ByteVector] =
-      await1[ByteVector].flatMap { bytes =>
+      receive1 { bytes =>
         digest.update(bytes.toArray)
         go(digest)
       }

--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -84,7 +84,7 @@ object process1 {
         if (f(last, i)) go(acc :+ i, i)
         else emit(acc) fby go(Vector(i), i)
       }
-    await1[I].flatMap(i => go(Vector(i), i))
+    receive1(i => go(Vector(i), i))
   }
 
   /**
@@ -112,7 +112,7 @@ object process1 {
    * if it has consumed at least one input element.
    */
   def drainLeading[A, B](p: Process1[A, B]): Process1[A, B] =
-    await1[A].flatMap(a => feed1(a)(p))
+    receive1(a => feed1(a)(p))
 
   /** Skips the first `n` elements of the input, then passes through the rest. */
   def drop[I](n: Int): Process1[I, I] =
@@ -129,7 +129,7 @@ object process1 {
       receive1Or[I,I](if (p(prev)) halt else emit(prev)) { i =>
         emit(prev) fby go(i)
       }
-    await1[I].flatMap(go)
+    receive1(go)
   }
 
   /**
@@ -137,7 +137,7 @@ object process1 {
    * then passes through the remaining inputs.
    */
   def dropWhile[I](f: I => Boolean): Process1[I, I] =
-    await1[I] flatMap (i => if (f(i)) dropWhile(f) else emit(i) fby id)
+    receive1(i => if (f(i)) dropWhile(f) else emit(i) fby id)
 
   /** Feed a single input to a `Process1`. */
   def feed1[I, O](i: I)(p: Process1[I, O]): Process1[I, O] =
@@ -168,7 +168,7 @@ object process1 {
    * element and terminate
    */
   def find[I](f: I => Boolean): Process1[I, I] =
-    await1[I] flatMap (i => if (f(i)) emit(i) else find(f))
+    receive1(i => if (f(i)) emit(i) else find(f))
 
   /**
    * Halts with `true` as soon as a matching element is received.
@@ -256,7 +256,7 @@ object process1 {
   /** Skip all but the last element of the input. */
   def last[I]: Process1[I, I] = {
     def go(prev: I): Process1[I, I] = receive1Or[I,I](emit(prev))(go)
-    await1[I].flatMap(go)
+    receive1(go)
   }
 
   /**
@@ -438,7 +438,7 @@ object process1 {
    * It will always emit `z`, even when the Process of `A` is empty
    */
   def scan[A, B](z: B)(f: (B, A) => B): Process1[A, B] =
-    emit(z) fby await1[A].flatMap(a => scan(f(z, a))(f))
+    emit(z) fby receive1(a => scan(f(z, a))(f))
 
   /**
    * Like `scan` but uses Monoid for associative operation
@@ -461,7 +461,7 @@ object process1 {
    * }}}
    */
   def scan1[A](f: (A, A) => A): Process1[A, A] =
-    await1[A].flatMap(a => scan(a)(f))
+    receive1(a => scan(a)(f))
 
   /** Like `scan1` but uses Monoid `M` for associative operation. */
   def scan1Monoid[A](implicit M: Monoid[A]): Process1[A, A] =
@@ -486,7 +486,7 @@ object process1 {
 
   /** Reads a single element of the input, emits nothing, then halts. */
   def skip: Process1[Any, Nothing] =
-    await1[Any].flatMap(_ => halt)
+    receive1(_ => halt)
 
   /**
    * Break the input into chunks where the delimiter matches the predicate.
@@ -525,7 +525,7 @@ object process1 {
          if (cur == last) go(acc :+ i, cur)
          else emit(acc) fby go(Vector(i), cur)
       }
-    await1[I].flatMap(i => go(Vector(i), f(i)))
+    receive1(i => go(Vector(i), f(i)))
   }
 
   /** Remove any `None` inputs. */
@@ -543,11 +543,11 @@ object process1 {
 
   /** Passes through elements of the input as long as the predicate is true, then halts. */
   def takeWhile[I](f: I => Boolean): Process1[I, I] =
-    await1[I] flatMap (i => if (f(i)) emit(i) fby takeWhile(f) else halt)
+    receive1 (i => if (f(i)) emit(i) fby takeWhile(f) else halt)
 
   /** Like `takeWhile`, but emits the first value which tests false. */
   def takeThrough[I](f: I => Boolean): Process1[I, I] =
-    await1[I] flatMap (i => if (f(i)) emit(i) fby takeThrough(f) else emit(i))
+    receive1 (i => if (f(i)) emit(i) fby takeThrough(f) else emit(i))
 
   /** Wraps all inputs in `Some`, then outputs a single `None` before halting. */
   def terminated[A]: Process1[A, Option[A]] =
@@ -605,7 +605,7 @@ object process1 {
 
   /** Zips the input with state that begins with `z` and is updated by `next`. */
   def zipWithState[A,B](z: B)(next: (A, B) => B): Process1[A,(A,B)] =
-    await1[A].flatMap(a => emit((a, z)) fby zipWithState(next(a, z))(next))
+    receive1(a => emit((a, z)) fby zipWithState(next(a, z))(next))
 
 
   object Await1 {


### PR DESCRIPTION
For the new `Process` representation constructs like `await1[A].flatMap(p1).orElse(p2)` were rewritten as `receive1Or[A,B](p2)(p1)`. So why don't we rewrite `await1[A].flatMap(p1)` as `receive1[A,B](p1)`? The tests indicate that there is no observable difference and in all cases type inference allows us to leave off the types for `receive1` (in contrast to `await1[A]` where we always have to specify the type parameter).
