### PR TITLE
Add process1.sliding, a well-behaved version of window

### DIFF
--- a/src/test/scala/scalaz/stream/Process1Spec.scala
+++ b/src/test/scala/scalaz/stream/Process1Spec.scala
@@ -153,6 +153,11 @@ object Process1Spec extends Properties("Process1") {
       }.toList === List("h", "e", "l", "lo")
   }
 
+  property("sliding") = forAll { p: Process0[Int] =>
+    val n = Gen.choose(1, 10).sample.get
+    p.sliding(n).toList.map(_.toList) === p.toList.sliding(n).toList
+  }
+
   property("splitOn") = secure {
     Process(0, 1, 2, 3, 4).splitOn(2).toList === List(Vector(0, 1), Vector(3, 4)) &&
       Process(2, 0, 1, 2).splitOn(2).toList === List(Vector(), Vector(0, 1), Vector()) &&


### PR DESCRIPTION
This one adds `process1.sliding` that behaves like `sliding` of the Scala collections. It is similar to the current `window` but without its surprising behaviour.

Here is an comparison of `sliding` and `window`:

``` scala
range(0,0).window(1).toList  == List(Vector())
range(0,0).sliding(1).toList == List()

range(0,3).window(1).toList  == List(Vector(0), Vector(1), Vector(2), Vector())
range(0,3).sliding(1).toList == List(Vector(0), Vector(1), Vector(2))

range(0,4).window(2).toList  == List(Vector(0, 1), Vector(1, 2), Vector(2, 3), Vector(3))
range(0,4).sliding(2).toList == List(Vector(0, 1), Vector(1, 2), Vector(2, 3))

range(0,2).sliding(5).toList == List(Vector(0, 1))
range(0,2).window(5).toList  == List(Vector(0, 1))
```

There are two reasons why I think the behaviour of `window` is a little bit odd:
1. If it receives no input, an empty `Vector` is emitted. So it produces something out of thin air. (This required to use `drainLeading` for the implementation of `zipWithNext`, for example.)
2. For a window size of `n`, the last element emitted has always size `n - 1` (in case of `n = 1` that means that the last element is empty)

My goal is to replace `window` with `sliding`. Adding `sliding` is the first step towards this goal. Therefore, if this PR gets merged, I would then take care of removing `window`.
