### PR TITLE
map speedup

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -47,7 +47,6 @@ sealed trait Process[+F[_], +O]
       case Halt(_) => this.asInstanceOf[Process[F, O2]]
       case Emit(os) if os.isEmpty => this.asInstanceOf[Process[F, O2]]
       case Emit(os) => {
-        var rest = os
         var err: Option[Exception] = None
         val result = new scala.collection.mutable.ListBuffer[O2]()
         try {


### PR DESCRIPTION
So this big fugly pull request probably conflicts with the internal philosophy of scalaz-stream. On the other hand, _users_ of the library will not notice the difference, they'll notice only the performance improvement. 

If there is a less java-like way to get the same result, I'd love to see it. 

Motivation: the current implementation of `map` will result in `map(x => x)` transforming `Emit(Seq(1,2,3))` into `Emit(Vector(1)) ++ Emit(Vector(2)) ++ Emit(Vector(3)`, not to mention unnecessary calls to `Util.Try`. This new version results in Emit(Seq(1,2,3))`. 

The net result is a big speedup: 

```
Time (new map): 195 
Time (old map) 1961
```

In the benchmark code below, `map` is the new version and `map2` is the old version. 

  def benchmark {
    val x = (1 to (1024*1024)).map(x => x.toLong).toSeq

```
(Process.emitAll(x) : Process[Task,Long]).map(x => x % 7).runLast.run //warm up jvm
val startTimeMap = System.currentTimeMillis
(Process.emitAll(x) : Process[Task,Long]).map(x => x % 7).runLast.run
println("End time: " + (System.currentTimeMillis - startTimeMap))

(Process.emitAll(x) : Process[Task,Long]).map2(x => x % 7).runLast.run //warm up jvm
val startTimeMap2 = System.currentTimeMillis
(Process.emitAll(x) : Process[Task,Long]).map2(x => x % 7).runLast.run
println("End time: " + (System.currentTimeMillis - startTimeMap2))
```

  }
