### PR TITLE
generalize iterate method

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -918,6 +918,9 @@ object Process {
   def iterate[A](start: A)(f: A => A): Process0[A] =
     emit(start) ++ iterate(f(start))(f)
 
+  def iterateEval[F[_], A](start: A)(f: A => F[A]): Process[F, A] =
+    emit(start) ++ await(f(start))(iterateEval(_)(f))
+
   /** Promote a `Process` to a `Writer` that writes nothing. */
   def liftW[F[_], A](p: Process[F, A]): Writer[F, Nothing, A] =
    p.map(right)

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -134,6 +134,10 @@ object ProcessSpec extends Properties("Process") {
     Process.iterate(0)(_ + 1).take(100).toList == List.iterate(0, 100)(_ + 1)
   }
 
+  property("iterateEval") = secure {
+    Process.iterateEval(0)(i => Task.delay(i + 1)).take(100).runLog.run == List.iterate(0, 100)(_ + 1)
+  }
+
   property("kill executes cleanup") = secure {
     import TestUtil._
     val cleanup = new SyncVar[Int]


### PR DESCRIPTION
Add `iterateEval[F[_], A](a: A)(f: A => F[A]): Process[F, A]`. It is useful while the the next value depends on a context `F`.  
