### PR TITLE
Document transducers that use mutable objects

### DIFF
--- a/src/main/scala/scalaz/stream/compress.scala
+++ b/src/main/scala/scalaz/stream/compress.scala
@@ -7,6 +7,12 @@ import scodec.bits.ByteVector
 import Process._
 import process1._
 
+/**
+ * @define MutableProcess1 [[https://github.com/scalaz/scalaz-stream/blob/master/src/test/scala/scalaz/stream/examples/MutableProcess1.scala `MutableProcess1`]]
+ * @define MutableImpl @note This process uses mutable state as an
+ *   implementation detail which can become observable under certain
+ *   conditions. See $MutableProcess1 for more information.
+ */
 object compress {
   /**
    * Returns a `Process1` that deflates (compresses) its input elements using
@@ -15,6 +21,7 @@ object compress {
    * @param nowrap if true then use GZIP compatible compression
    * @param bufferSize size of the internal buffer that is used by the
    *                   compressor. Default size is 32 KB.
+   * $MutableImpl
    */
   def deflate(level: Int = Deflater.DEFAULT_COMPRESSION,
               nowrap: Boolean = false,
@@ -52,6 +59,7 @@ object compress {
    * @param nowrap if true then support GZIP compatible compression
    * @param bufferSize size of the internal buffer that is used by the
    *                   decompressor. Default size is 32 KB.
+   * $MutableImpl
    */
   def inflate(nowrap: Boolean = false,
               bufferSize: Int = 1024 * 32): Process1[ByteVector,ByteVector] = {

--- a/src/main/scala/scalaz/stream/hash.scala
+++ b/src/main/scala/scalaz/stream/hash.scala
@@ -6,23 +6,47 @@ import scodec.bits.ByteVector
 import Process._
 import process1._
 
+/**
+ * @define MutableProcess1 [[https://github.com/scalaz/scalaz-stream/blob/master/src/test/scala/scalaz/stream/examples/MutableProcess1.scala `MutableProcess1`]]
+ * @define MutableImpl @note This process uses mutable state as an
+ *   implementation detail which can become observable under certain
+ *   conditions. See $MutableProcess1 for more information.
+ */
 object hash {
-  /** Computes the MD2 hash of the input elements. */
+  /**
+   * Computes the MD2 hash of the input elements.
+   * $MutableImpl
+   */
   val md2: Process1[ByteVector,ByteVector] = messageDigest("MD2")
 
-  /** Computes the MD5 hash of the input elements. */
+  /**
+   * Computes the MD5 hash of the input elements.
+   * $MutableImpl
+   */
   val md5: Process1[ByteVector,ByteVector] = messageDigest("MD5")
 
-  /** Computes the SHA-1 hash of the input elements. */
+  /**
+   * Computes the SHA-1 hash of the input elements.
+   * $MutableImpl
+   */
   val sha1: Process1[ByteVector,ByteVector] = messageDigest("SHA-1")
 
-  /** Computes the SHA-256 hash of the input elements. */
+  /**
+   * Computes the SHA-256 hash of the input elements.
+   * $MutableImpl
+   */
   val sha256: Process1[ByteVector,ByteVector] = messageDigest("SHA-256")
 
-  /** Computes the SHA-384 hash of the input elements. */
+  /**
+   * Computes the SHA-384 hash of the input elements.
+   * $MutableImpl
+   */
   val sha384: Process1[ByteVector,ByteVector] = messageDigest("SHA-384")
 
-  /** Computes the SHA-512 hash of the input elements. */
+  /**
+   * Computes the SHA-512 hash of the input elements.
+   * $MutableImpl
+   */
   val sha512: Process1[ByteVector,ByteVector] = messageDigest("SHA-512")
 
   private def messageDigest(algorithm: String): Process1[ByteVector,ByteVector] = {

--- a/src/test/scala/scalaz/stream/examples/MutableProcess1.scala
+++ b/src/test/scala/scalaz/stream/examples/MutableProcess1.scala
@@ -1,0 +1,53 @@
+package scalaz.stream
+package examples
+
+import org.scalacheck._
+import org.scalacheck.Prop._
+import scodec.bits.ByteVector
+
+object MutableProcess1 extends Properties("examples.MutableProcess1") {
+
+  /*
+  Certain transducers like `compress.deflate`, `compress.inflate`, or
+  the hashing processes in the `hash` module have a pure interface but
+  use mutable objects as an implementation detail. This mutable state
+  is not observable as long as these processes are consumed by the
+  various `pipe`-combinators (`pipe`, `pipeO`, `pipeW`, `pipeIn`) or by
+  `wye.attachL` and `wye.attachR`.
+
+  Feeding values explicitly to these combinators (via `process1.feed`
+  or `process1.feed1`) can make the mutable state observable and is
+  therefore discouraged.
+  */
+
+  val bytes1 = ByteVector.view("mutable".getBytes)
+  val bytes2 = ByteVector.view("state".getBytes)
+
+  /*
+  Here is an example that shows how calling `feed1` on `hash.md5`
+  creates a non-referentially transparent `Process1`. `started`
+  contains an instance of a mutable object that is further mutated by
+  using it inside the `pipe` combinator. If `started` would be
+  referentially transparent, the left- and right-hand side of the last
+  expression would be equal.
+  */
+  property("observe mutable state") = secure {
+    val started = hash.md5.feed1(bytes1)
+    val bytes = Process.emit(bytes2)
+
+    bytes.pipe(started).toList != bytes.pipe(started).toList
+  }
+
+  /*
+  As already stated, using `hash.md5` inside `pipe` does not make the
+  mutable state observable. In the left- and right-hand side of the last
+  expression, a mutable object is instantiated for each `Process` that
+  pipes values into `hash.md5`.
+  */
+  property("hash.md5 has a pure interface") = secure {
+    val notStarted = hash.md5
+    val bytes = Process(bytes1, bytes2)
+
+    bytes.pipe(notStarted).toList == bytes.pipe(notStarted).toList
+  }
+}


### PR DESCRIPTION
This is a first attempt to fix #139. Unfortunately I wasn't able to use one `@define` macro for both files, `compress.scala` and `hash.scala`. 
