### PR TITLE
Implement distinctConsecutiveBy in terms of filterBy2

### DIFF
--- a/src/test/scala/scalaz/stream/Process1Spec.scala
+++ b/src/test/scala/scalaz/stream/Process1Spec.scala
@@ -64,6 +64,7 @@ object Process1Spec extends Properties("Process1") {
         , "feed-emit-first" |: ((List(1, 2, 3) ++ li) === process1.feed(li)(emitAll(List(1, 2, 3)) ++ id[Int]).unemit._1.toList)
         , "find" |: pi.find(_ % 2 === 0).toList === li.find(_ % 2 === 0).toList
         , "filter" |: pi.filter(g).toList === li.filter(g)
+        , "filterBy2" |: pi.filterBy2(_ < _).toList.sliding(2).dropWhile(_.size < 2).forall(l => l(0) < l(1))
         , "fold" |: pi.fold(0)(_ + _).toList === List(li.fold(0)(_ + _))
         , "foldMap" |: pi.foldMap(_.toString).toList.lastOption.toList === List(li.map(_.toString).fold(sm.zero)(sm.append(_, _)))
         , "forall" |: pi.forall(g).toList === List(li.forall(g))


### PR DESCRIPTION
I realized that `distinctConsecutiveBy` can be implemented in terms of  a more generic function by abstracting over the predicate that compares consecutive elements. I extracted this function as `filterBy2`. The predicate that is given to this function uses the previously emitted and current elements.

Here is a simple example:

``` scala
Process(1, 1, 3, 2, 5, 4).filterBy2(_ < _).toList == List(1, 3, 5)
```
