### PR TITLE
Speed up some Sink - cleaner version

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.ScheduledExecutorService
 import scala.annotation.tailrec
 import scala.collection.SortedMap
 import scala.concurrent.duration._
-import scalaz.{Catchable, Functor, Monad, MonadPlus, Monoid, Nondeterminism, \/, -\/, ~>}
+import scalaz.{Catchable, Functor, Monad, MonadPlus, Monoid, Nondeterminism, \/, -\/, ~>, @@, Tag}
 import scalaz.\/._
 import scalaz.concurrent.{Actor, Strategy, Task}
 import scalaz.stream.process1.Await1
@@ -513,7 +513,6 @@ sealed trait Process[+F[_], +O]
 
 object Process {
 
-
   import scalaz.stream.Util._
 
   //////////////////////////////////////////////////////////////////////////////////////
@@ -842,17 +841,22 @@ object Process {
     })
   }
 
-
   /**
    * The infinite `Process`, always emits `a`.
    * If for performance reasons it is good to emit `a` in chunks,
    * specify size of chunk by `chunkSize` parameter
    */
-  def constant[A](a: A, chunkSize: Int = 1): Process0[A] = {
+  sealed trait ConstantProcess
+  def constant[A](a: A, chunkSize: Int = 1): Process0[A] @@ ConstantProcess = {
     lazy val go: Process0[A] =
       if (chunkSize.max(1) == 1) emit(a) fby go
       else emitAll(List.fill(chunkSize)(a)) fby go
-    go
+    Tag[Process0[A], ConstantProcess](go)
+  }
+
+  implicit class ConstantProcessOps[A](self: Process0[A] @@ ConstantProcess) {
+    def runConst[F2[_], F[_],B,C](f: (A, Process[F,B]) => Process[F2,C])(p: Process[F,B]): Process[F2,C] =
+      self.take(1).flatMap(a => f(a, p))
   }
 
   /**
@@ -1124,6 +1128,10 @@ object Process {
     /** Attaches `Sink` to this  `Process`  */
     def to[F2[x]>:F[x]](f: Sink[F2,O]): Process[F2,Unit] =
       through(f)
+
+    /** Attaches `Sink` to this  `Process`  */
+    def to[F2[x]>:F[x]](f: Process0[O => F2[Unit]] @@ ConstantProcess): Process[F2,Unit] =
+      f.runConst( (ff:O=>F2[Unit], s: Process[F,O]) => s.map(x => ff(x)).eval )(self)
 
     /** A faster variation of the above, for the case of constant sinks */
     def to[F2[x]>:F[x]](f: O => F2[Unit]): Process[F2,Unit] =

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -78,6 +78,13 @@ object ProcessSpec extends Properties("Process") {
     p1.to(pch).runLog.run.size == 3
   }
 
+  property("sinked with const") = secure {
+    val p1 = Process.constant(1).take(25).toSource
+    val pch: Process0[Int => Task[Unit]] @@ Process.ConstantProcess = Process.constant((i:Int) => Task.now(()))
+
+    p1.to(pch).runLog.run.size == 25
+  }
+
   property("duration") =  {
     val firstValueDiscrepancy = duration.take(1).runLast.run.get
     val reasonableError = 200 * 1000000 // 200 millis


### PR DESCRIPTION
Constant processes are special. You can skip a lot of object creation with them. We can tag a constant process with a scalaz tagged type and then build custom methods to handle that case. 

Without the optimization, this benchark takes 15-20 seconds to run, with the optimization it takes 7. We can do similar things for `zipWith`, etc.

```
def benchmark {
  val p = emitRange(1,1024*1024)

  var i = 0
  def f(t: Int): Task[Unit] = { Task { i = (i + t) % 127 } }
  val fp = Process.constant(f _)

  p.to(fp).run.run
  val startTimeMap = System.currentTimeMillis
  p.to(fp).run.run
  println("End time: " + (System.currentTimeMillis - startTimeMap))
}
```

To turn off the optimization, just throw away the type information:

```
- val fp = Process.constant(f _)
+ val fp = Process.constant(f _): Process[Int => Task[Unit]]
```

Ignore the previous (now closed) pull req, that was fugly, this one actually has a clean implementation. 
