### PR TITLE
Made process.apply not silently fail

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1225,8 +1225,12 @@ object Process {
   implicit class Process1Syntax[I,O](self: Process1[I,O]) {
 
     /** Apply this `Process` to an `Iterable`. */
-    def apply(input: Iterable[I]): IndexedSeq[O] =
-      Process(input.toSeq: _*).pipe(self.bufferAll).unemit._1.toIndexedSeq
+    def apply(input: Iterable[I]): IndexedSeq[O] = {
+      Process(input.toSeq: _*).pipe(self.bufferAll).unemit match {
+        case (_, Halt(Error(e))) => throw e
+        case (v, _) => v.toIndexedSeq
+      }
+    }
 
     /**
      * Transform `self` to operate on the left hand side of an `\/`, passing

--- a/src/test/scala/scalaz/stream/Process1Spec.scala
+++ b/src/test/scala/scalaz/stream/Process1Spec.scala
@@ -125,6 +125,17 @@ object Process1Spec extends Properties("Process1") {
     }
   }
 
+  property("apply-does-not-silently-fail") = forAll { xs: List[Int] =>
+    val err = 1 #:: ((throw new scala.Exception("FAIL")):Stream[Int])
+    try {
+      Process.emitAll(err)(xs)
+      false
+    } catch {
+      case e: scala.Exception => true
+      case _: Throwable => false
+    }
+  }
+
   property("unchunk") = forAll { pi: Process0[List[Int]] =>
     pi.pipe(unchunk).toList == pi.toList.flatten
   }


### PR DESCRIPTION
We found that Process.apply was silently throwing away fatal errors. This patch will rethrow the error if it's an abnormal termination.
