### PR TITLE
Introduce a LengthExceeded exception for text.lines

### DIFF
--- a/src/test/scala/scalaz/stream/LinesSpec.scala
+++ b/src/test/scala/scalaz/stream/LinesSpec.scala
@@ -7,7 +7,7 @@ import Prop._
 
 import scalaz.concurrent.Task
 import scalaz.stream.Process._
-import scalaz.stream.text.lines
+import scalaz.stream.text.{LengthExceeded, lines}
 
 object LinesSpec extends Properties("text") {
 
@@ -24,17 +24,38 @@ object LinesSpec extends Properties("text") {
   }
 
   property("lines()") = secure {
-    samples.foldLeft(true)((b, s2) => b && checkLine(s2))
+    samples.forall(checkLine)
   }
 
   property("lines(n) should fail for lines with length greater than n") = secure {
-    val error = classOf[java.lang.Exception]
+    val error = classOf[LengthExceeded]
 
     emit("foo\nbar").pipe(lines(3)).toList == List("foo", "bar")    &&   // OK input
-    emitAll(List("foo\n", "bar")).pipe(lines(3)).toList == List("foo", "bar") &&   // OK input
-    emitAll(List("foo", "\nbar")).pipe(lines(3)).toList == List("foo", "bar") &&   // OK input
+    Process("foo\n", "bar").pipe(lines(3)).toList == List("foo", "bar") &&   // OK input
+    Process("foo", "\nbar").pipe(lines(3)).toList == List("foo", "bar") &&   // OK input
     throws(error){ emit("foo").pipe(lines(2)).run[Task].run }       &&
     throws(error){ emit("foo\nbarr").pipe(lines(3)).run[Task].run } &&
     throws(error){ emit("fooo\nbar").pipe(lines(3)).run[Task].run }
+  }
+
+  property("lines(n) can recover from lines longer than n") = {
+    import Gen._
+
+    val stringWithNewlinesGen: Gen[String] =
+      listOf(frequency((5, alphaChar), (1, oneOf('\n', '\r')))).map(_.mkString)
+
+    def rmWhitespace(s: String): String = s.replaceAll("\\s", "")
+
+    forAll(listOf(stringWithNewlinesGen)) { xs: List[String] =>
+      val stripped = rmWhitespace(xs.mkString)
+      val maxLength = Gen.choose(1, stripped.length).sample.getOrElse(1)
+      val nonFailingLines = lines(maxLength).onFailure {
+        case LengthExceeded(_, s) => emitAll(s.grouped(maxLength).toList)
+      }.repeat
+
+      val allLines = emitAll(xs).pipe(nonFailingLines).toList
+      allLines.forall(_.length <= maxLength) &&
+        rmWhitespace(allLines.mkString) == stripped
+    }
   }
 }


### PR DESCRIPTION
This PR introduces a special `LengthExceeded` exception for `text.lines` that includes the `String` that causes `lines` to fail if it is longer than the specified maximum length. The reason for introducing this exception is that I wanted to have a `lines` that can recover from failures without throwing away information.

Let me give an example where `lines` currently throws away information:

``` scala
val p1 = lines(maxLength).onFailure(_ => halt).repeat
```

If `p1` encounters a string `s` that is longer than `maxLength` it will halt, never emit `s`, and repeat the repartitioning into lines. So every input that causes `lines` to throw is lost.

With the `LengthExceeded` exception I can write a never failing process that does not throw away information and that ensures that it's outputs are always less than or equal to `maxLength`:

``` scala
val p2 = lines(maxLength).onFailure {
  case LengthExceeded(_, s) => emitAll(s.grouped(maxLength).toList)
}.repeat
```

Since the string that caused `lines` to fail is included in the exception I've the chance to emit it in the `onFailure` handler. `p2` will hard wrap inputs that are longer than `maxLength` into chunks of this size.

P.S.: If there is currently a way to create a process similar to `p2`, let me know! I wasn't able to come up with one.
