### PR TITLE
Fix premature disconnect of side in wye.haltL/R

### DIFF
--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -65,6 +65,18 @@ object WyeSpec extends  Properties("Wye"){
 
   }
 
+  property("haltL") = secure {
+    val w = wye.haltL(Kill)(wye.feedR(Seq(0,1))(wye.merge[Int]))
+    val x = Process.emit(-1).wye(Process.range(2,5))(w).runLog.run
+    x.toList == List(0,1)
+  }
+
+  property("haltR") = secure {
+    val w = wye.haltR(Kill)(wye.feedL(Seq(0,1))(wye.merge[Int]))
+    val x = Process.range(2,5).wye(Process.emit(-1))(w).runLog.run
+    x.toList == List(0,1)
+  }
+
   // ensure that wye terminates when once side of it is infinite
   // and other side of wye is either empty, or one.
   property("infinite.one.side") = secure {


### PR DESCRIPTION
Use complete definition of `haltL/R` to ensure side is not disconnected until `HaltL/R` has been sent. See #271 
