### PR TITLE
Generalize toChannel to all Sink[F: Functor, _]

### DIFF
--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -323,4 +323,8 @@ object ProcessSpec extends Properties("Process") {
 
   }
 
+  property("SinkSyntax.toChannel") = forAll { p0: Process0[Int] =>
+    val channel = io.channel((_: Int) => Task.now(())).toChannel
+    p0.liftIO.through(channel).runLog.run.toList == p0.toList
+  }
 }


### PR DESCRIPTION
`SinkTaskSyntax.toChannel` only works for `Sink[Task, _]` but actually it only requires that the request type is a `Functor`.
