### PR TITLE
collect/filter termination failure

### DIFF
--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -124,6 +124,34 @@ object WyeSpec extends  Properties("Wye"){
     v.size < 1000
   }
 
+  property("interrupt.constant") = secure {
+    val p1 = Process.constant(42)
+    val i1 = Process(false)
+    val v = i1.wye(p1)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
+
+  property("interrupt.constant.collect.all") = secure {
+    val p1 = Process.constant(42).collect { case i if i > 0 => i }
+    val i1 = Process(false)
+    val v = i1.wye(p1)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
+
+  property("interrupt.constant.collect.none") = secure {
+    val p1 = Process.constant(42).collect { case i if i < 0 => i }
+    val i1 = Process(false)
+    val v = i1.wye(p1)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
+
+  property("interrupt.constant.filter.none") = secure {
+    val p1 = Process.constant(42).filter { _ < 0 }
+    val i1 = Process(false)
+    val v = i1.wye(p1)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
+
   property("either.terminate-on-both") = secure {
     val e = (Process.range(0, 20) either Process.range(0, 20)).runLog.timed(1000).run
     (e.collect { case -\/(v) => v } == (0 until 20).toSeq) :| "Left side is merged ok" &&


### PR DESCRIPTION
Adds three failing tests exhibiting collect/filter halt bug #290 
Also adds three passing tests exhibiting situations that are not affected by the bug.

```
[info] + Wye.interrupt-constant.signal-halt: OK, proved property.
[info] + Wye.interrupt-constant.signal-halt.collect-all: OK, proved property.
[info] ! Wye.interrupt-constant.signal-halt.collect-none: Exception raised on property evaluation.
[info] > Exception: java.util.concurrent.TimeoutException: null
[info] ! Wye.interrupt-constant.signal-halt.filter-none: Exception raised on property evaluation.
[info] > Exception: java.util.concurrent.TimeoutException: null
[info] + Wye.interrupt-constant.signal-constant-true.collect-all: OK, proved property.
[info] ! Wye.interrupt-constant.signal-constant-true.collect-none: Exception raised on property evaluation.
[info] > Exception: java.util.concurrent.TimeoutException: null
```
