### PR TITLE
Significant performance improvements

### DIFF
--- a/core/src/main/scala/fs2/StreamCore.scala
+++ b/core/src/main/scala/fs2/StreamCore.scala
@@ -156,19 +156,19 @@ object StreamCore {
   }
 
   sealed trait NT[-F[_],+G[_]] {
-    def same: Either[Sub1[F,G], F ~> G]
+    val same: Either[Sub1[F,G], F ~> G]
     def andThen[H[_]](f: NT[G,H]): NT[F,H]
     def apply[A](f: F[A]): G[A]
   }
 
   object NT {
     case class Id[F[_]]() extends NT[F,F] {
-      def same = Left(Sub1.sub1[F])
+      val same = Left(Sub1.sub1[F])
       def andThen[H[_]](f: NT[F,H]): NT[F,H] = f
       def apply[A](f: F[A]): F[A] = f
     }
     case class T[F[_],G[_]](u: F ~> G) extends NT[F,G] {
-      def same = Right(u)
+      val same = Right(u)
       def apply[A](f: F[A]): G[A] = u(f)
       def andThen[H[_]](f: NT[G,H]): NT[F,H] = f.same.fold(
         f => T(u andThen f.uf1),
@@ -176,17 +176,32 @@ object StreamCore {
       )
     }
     def convert[F[_],G[_],O](s: StreamCore[F,O])(u: NT[F,G]): StreamCore[G,O] =
-      u.same.fold(sub => Sub1.substStreamCore(s)(sub), u => s.translate(NT.T(u)))
+      u.same match {
+        case Left(sub) => Sub1.substStreamCore(s)(sub)
+        case Right(u) => s.translate(NT.T(u))
+      }
     def convert[F[_],G[_],O1,O2](f: O1 => StreamCore[F,O2])(u: NT[F,G]): O1 => StreamCore[G,O2] =
-      u.same.fold(sub => Sub1.substStreamCoreF(f)(sub), u => o1 => f(o1).translate(NT.T(u)))
+      u.same match {
+        case Left(sub) => Sub1.substStreamCoreF(f)(sub)
+        case Right(u) => o1 => f(o1).translate(NT.T(u))
+      }
     def convert[F[_],G[_],O](s: Segment[F,O])(u: NT[F,G]): Segment[G,O] =
-      u.same.fold(sub => Sub1.substSegment(s)(sub), u => s.translate(NT.T(u)))
+      u.same match {
+        case Left(sub) => Sub1.substSegment(s)(sub)
+        case Right(u) => s.translate(NT.T(u))
+      }
     def convert[F[_],G[_],O](s: Catenable[Segment[F,O]])(u: NT[F,G]): Catenable[Segment[G,O]] = {
       type f[g[_],x] = Catenable[Segment[g,x]]
-      u.same.fold(sub => Sub1.subst[f,F,G,O](s)(sub), _ => s.map(_ translate u))
+      u.same match {
+        case Left(sub) => Sub1.subst[f,F,G,O](s)(sub)
+        case Right(_) => s.map(_ translate u)
+      }
     }
     def convert[F[_],G[_],O](s: Scope[F,O])(u: NT[F,G]): Scope[G,O] =
-      u.same.fold(Sub1.subst[Scope,F,G,O](s)(_), s translate _)
+      u.same match {
+        case Left(sub) => Sub1.subst[Scope,F,G,O](s)(sub)
+        case Right(u) => s translate u
+      }
   }
 
   case object Interrupted extends Exception { override def fillInStackTrace = this }
@@ -327,11 +342,14 @@ object StreamCore {
   sealed trait Segment[F[_],O1] {
     import Segment._
 
-    def translate[G[_]](u: NT[F,G]): Segment[G,O1] = this match {
-      case Append(s) => Append(s translate u)
-      case Handler(h) => Handler(NT.convert(h)(u))
-      case Emit(c) => Emit(c)
-      case Fail(e) => Fail(e)
+    def translate[G[_]](u: NT[F,G]): Segment[G,O1] = u.same match {
+      case Left(sub) => Sub1.substSegment(this)(sub)
+      case Right(uu) => this match {
+        case Append(s) => Append(s translate u)
+        case Handler(h) => Handler(NT.convert(h)(u))
+        case Emit(c) => Emit(c)
+        case Fail(e) => Fail(e)
+      }
     }
 
     def mapChunks[O2](f: Chunk[O1] => Chunk[O2]): Segment[F, O2] = this match {
@@ -445,6 +463,4 @@ object StreamCore {
       (tl,hd) => hd flatMap { _.fold(e => tl flatMap { _ => Free.pure(Left(e)) }, _ => tl) }
     )
   }
-
 }
-

--- a/core/src/main/scala/fs2/util/Free.scala
+++ b/core/src/main/scala/fs2/util/Free.scala
@@ -55,6 +55,7 @@ sealed trait Free[+F[_],+A] {
   @annotation.tailrec
   private[fs2] final def step: Free[F,A] = this match {
     case Bind(Bind(x, f), g) => (x flatMap (a => f(a) flatMap g)).step
+    case Bind(Pure(x), f) => f(x).step
     case _ => this
   }
 }


### PR DESCRIPTION
Performance results with these changes:

```
[info] Running fs2.StreamPerformanceSpec
left-associated ++ (2) took 100.90099 milliseconds
left-associated ++ (3) took 0.452885 milliseconds
left-associated ++ (100) took 11.502514 milliseconds
left-associated ++ (200) took 23.225736 milliseconds
left-associated ++ (400) took 48.364769 milliseconds
left-associated ++ (800) took 42.50048 milliseconds
left-associated ++ (1600) took 48.212221 milliseconds
left-associated ++ (3200) took 32.330704 milliseconds
left-associated ++ (6400) took 42.676909 milliseconds
left-associated ++ (12800) took 67.175394 milliseconds
left-associated ++ (25600) took 88.04291 milliseconds
left-associated ++ (51200) took 150.376675 milliseconds
left-associated ++ (102400) took 198.918004 milliseconds
right-associated ++ (2) took 1.667262 milliseconds
right-associated ++ (3) took 0.207398 milliseconds
right-associated ++ (100) took 1.347827 milliseconds
right-associated ++ (200) took 2.137269 milliseconds
right-associated ++ (400) took 3.765369 milliseconds
right-associated ++ (800) took 7.340312 milliseconds
right-associated ++ (1600) took 21.266396 milliseconds
right-associated ++ (3200) took 19.005068 milliseconds
right-associated ++ (6400) took 41.651738 milliseconds
right-associated ++ (12800) took 26.836072 milliseconds
right-associated ++ (25600) took 43.353556 milliseconds
right-associated ++ (51200) took 97.908173 milliseconds
right-associated ++ (102400) took 217.502147 milliseconds
left-associated flatMap 1 (2) took 1.365797 milliseconds
left-associated flatMap 1 (3) took 1.175917 milliseconds
left-associated flatMap 1 (100) took 2.118123 milliseconds
left-associated flatMap 1 (200) took 3.13781 milliseconds
left-associated flatMap 1 (400) took 4.084476 milliseconds
left-associated flatMap 1 (800) took 7.72804 milliseconds
left-associated flatMap 1 (1600) took 8.984853 milliseconds
left-associated flatMap 1 (3200) took 23.842773 milliseconds
left-associated flatMap 1 (6400) took 36.536544 milliseconds
left-associated flatMap 1 (12800) took 34.117195 milliseconds
left-associated flatMap 1 (25600) took 62.573908 milliseconds
left-associated flatMap 1 (51200) took 50.83411 milliseconds
left-associated flatMap 1 (102400) took 106.770693 milliseconds
right-associated flatMap 1 (2) took 1.431503 milliseconds
right-associated flatMap 1 (3) took 0.08036 milliseconds
right-associated flatMap 1 (100) took 0.365807 milliseconds
right-associated flatMap 1 (200) took 0.506313 milliseconds
right-associated flatMap 1 (400) took 1.621592 milliseconds
right-associated flatMap 1 (800) took 1.219288 milliseconds
right-associated flatMap 1 (1600) took 2.703354 milliseconds
right-associated flatMap 1 (3200) took 4.929905 milliseconds
right-associated flatMap 1 (6400) took 10.119435 milliseconds
right-associated flatMap 1 (12800) took 17.31765 milliseconds
right-associated flatMap 1 (25600) took 18.765952 milliseconds
right-associated flatMap 1 (51200) took 56.085108 milliseconds
right-associated flatMap 1 (102400) took 69.704284 milliseconds
left-associated flatMap 2 (2) took 3.327199 milliseconds
left-associated flatMap 2 (3) took 0.550064 milliseconds
left-associated flatMap 2 (100) took 4.148573 milliseconds
left-associated flatMap 2 (200) took 4.67958 milliseconds
left-associated flatMap 2 (400) took 7.573661 milliseconds
left-associated flatMap 2 (800) took 26.05139 milliseconds
left-associated flatMap 2 (1600) took 24.425528 milliseconds
left-associated flatMap 2 (3200) took 61.117754 milliseconds
left-associated flatMap 2 (6400) took 58.270002 milliseconds
left-associated flatMap 2 (12800) took 67.383277 milliseconds
left-associated flatMap 2 (25600) took 84.854793 milliseconds
left-associated flatMap 2 (51200) took 148.426129 milliseconds
left-associated flatMap 2 (102400) took 309.788228 milliseconds
right-associated flatMap 1 (2) took 1.435427 milliseconds
right-associated flatMap 1 (3) took 0.096189 milliseconds
right-associated flatMap 1 (100) took 0.268916 milliseconds
right-associated flatMap 1 (200) took 0.476203 milliseconds
right-associated flatMap 1 (400) took 0.992379 milliseconds
right-associated flatMap 1 (800) took 1.200326 milliseconds
right-associated flatMap 1 (1600) took 2.25612 milliseconds
right-associated flatMap 1 (3200) took 4.298299 milliseconds
right-associated flatMap 1 (6400) took 5.130295 milliseconds
right-associated flatMap 1 (12800) took 8.089782 milliseconds
right-associated flatMap 1 (25600) took 16.64671 milliseconds
right-associated flatMap 1 (51200) took 37.010944 milliseconds
right-associated flatMap 1 (102400) took 112.022775 milliseconds
transduce (id) 2 took 28.868573 milliseconds
transduce (id) 3 took 1.140736 milliseconds
transduce (id) 100 took 12.220112 milliseconds
transduce (id) 200 took 14.521891 milliseconds
transduce (id) 400 took 20.608341 milliseconds
transduce (id) 800 took 32.974041 milliseconds
transduce (id) 1600 took 45.559123 milliseconds
transduce (id) 3200 took 47.74146 milliseconds
transduce (id) 6400 took 46.931841 milliseconds
transduce (id) 12800 took 64.366881 milliseconds
transduce (id) 25600 took 66.169543 milliseconds
transduce (id) 51200 took 146.945482 milliseconds
transduce (id) 102400 took 297.522112 milliseconds
+ StreamPerformance.left-associated ++: OK, proved property.
+ StreamPerformance.right-associated ++: OK, proved property.
+ StreamPerformance.left-associated flatMap 1: OK, proved property.
+ StreamPerformance.right-associated flatMap 1: OK, proved property.
+ StreamPerformance.left-associated flatMap 2: OK, proved property.
+ StreamPerformance.right-associated flatMap 1: OK, proved property.
+ StreamPerformance.transduce (id): OK, proved property.
+ StreamPerformance.bracket + onError (1): OK, proved property.
```

Before these changes:

```

[info] Running fs2.StreamPerformanceSpec
left-associated ++ (2) took 75.246876 milliseconds
left-associated ++ (3) took 0.830255 milliseconds
left-associated ++ (100) took 22.570404 milliseconds
left-associated ++ (200) took 22.802691 milliseconds
left-associated ++ (400) took 28.159892 milliseconds
left-associated ++ (800) took 42.725371 milliseconds
left-associated ++ (1600) took 53.761296 milliseconds
left-associated ++ (3200) took 76.382123 milliseconds
left-associated ++ (6400) took 94.282045 milliseconds
left-associated ++ (12800) took 73.244505 milliseconds
left-associated ++ (25600) took 97.222956 milliseconds
left-associated ++ (51200) took 180.900915 milliseconds
left-associated ++ (102400) took 357.673415 milliseconds         276 ms slower
right-associated ++ (2) took 3.442529 milliseconds
right-associated ++ (3) took 0.245946 milliseconds
right-associated ++ (100) took 1.668051 milliseconds
right-associated ++ (200) took 2.495322 milliseconds
right-associated ++ (400) took 4.663968 milliseconds
right-associated ++ (800) took 9.489743 milliseconds
right-associated ++ (1600) took 21.458249 milliseconds
right-associated ++ (3200) took 26.033654 milliseconds
right-associated ++ (6400) took 46.195686 milliseconds
right-associated ++ (12800) took 36.959851 milliseconds
right-associated ++ (25600) took 87.907892 milliseconds
right-associated ++ (51200) took 144.445033 milliseconds
right-associated ++ (102400) took 382.177559 milliseconds         279 ms slower
left-associated flatMap 1 (2) took 4.460745 milliseconds
left-associated flatMap 1 (3) took 1.268501 milliseconds
left-associated flatMap 1 (100) took 1.52671 milliseconds
left-associated flatMap 1 (200) took 4.699749 milliseconds
left-associated flatMap 1 (400) took 4.857277 milliseconds
left-associated flatMap 1 (800) took 8.563109 milliseconds
left-associated flatMap 1 (1600) took 18.029835 milliseconds
left-associated flatMap 1 (3200) took 24.227465 milliseconds
left-associated flatMap 1 (6400) took 54.269528 milliseconds
left-associated flatMap 1 (12800) took 76.30574 milliseconds
left-associated flatMap 1 (25600) took 52.95557 milliseconds
left-associated flatMap 1 (51200) took 71.673194 milliseconds
left-associated flatMap 1 (102400) took 140.726979 milliseconds     100 ms slower
right-associated flatMap 1 (2) took 2.718228 milliseconds
right-associated flatMap 1 (3) took 0.225339 milliseconds
right-associated flatMap 1 (100) took 0.448023 milliseconds
right-associated flatMap 1 (200) took 0.911694 milliseconds
right-associated flatMap 1 (400) took 1.646401 milliseconds
right-associated flatMap 1 (800) took 5.606337 milliseconds
right-associated flatMap 1 (1600) took 2.346586 milliseconds
right-associated flatMap 1 (3200) took 6.062391 milliseconds
right-associated flatMap 1 (6400) took 11.775021 milliseconds
right-associated flatMap 1 (12800) took 13.779227 milliseconds
right-associated flatMap 1 (25600) took 29.047967 milliseconds
right-associated flatMap 1 (51200) took 82.062843 milliseconds
right-associated flatMap 1 (102400) took 142.572234 milliseconds     104 ms slower
left-associated flatMap 2 (2) took 21.022484 milliseconds
left-associated flatMap 2 (3) took 0.684127 milliseconds
left-associated flatMap 2 (100) took 6.485711 milliseconds
left-associated flatMap 2 (200) took 16.105121 milliseconds
left-associated flatMap 2 (400) took 16.048992 milliseconds
left-associated flatMap 2 (800) took 17.512115 milliseconds
left-associated flatMap 2 (1600) took 32.655903 milliseconds
left-associated flatMap 2 (3200) took 51.575308 milliseconds
left-associated flatMap 2 (6400) took 63.401891 milliseconds
left-associated flatMap 2 (12800) took 88.553019 milliseconds
left-associated flatMap 2 (25600) took 109.931972 milliseconds
left-associated flatMap 2 (51200) took 227.681048 milliseconds
left-associated flatMap 2 (102400) took 450.086516 milliseconds       313 ms slower
right-associated flatMap 1 (2) took 3.664762 milliseconds
right-associated flatMap 1 (3) took 0.11602 milliseconds
right-associated flatMap 1 (100) took 0.686782 milliseconds
right-associated flatMap 1 (200) took 1.217502 milliseconds
right-associated flatMap 1 (400) took 2.112652 milliseconds
right-associated flatMap 1 (800) took 4.086316 milliseconds
right-associated flatMap 1 (1600) took 4.951248 milliseconds
right-associated flatMap 1 (3200) took 12.645076 milliseconds
right-associated flatMap 1 (6400) took 21.027974 milliseconds
right-associated flatMap 1 (12800) took 25.125583 milliseconds
right-associated flatMap 1 (25600) took 41.095732 milliseconds
right-associated flatMap 1 (51200) took 53.856476 milliseconds
right-associated flatMap 1 (102400) took 217.335097 milliseconds       186 ms slower
transduce (id) 2 took 54.639209 milliseconds
transduce (id) 3 took 1.76692 milliseconds
transduce (id) 100 took 17.195121 milliseconds
transduce (id) 200 took 14.447027 milliseconds
transduce (id) 400 took 28.27559 milliseconds
transduce (id) 800 took 28.794336 milliseconds
transduce (id) 1600 took 42.814671 milliseconds
transduce (id) 3200 took 61.5993 milliseconds
transduce (id) 6400 took 87.624483 milliseconds
transduce (id) 12800 took 139.892941 milliseconds
transduce (id) 25600 took 250.006592 milliseconds
transduce (id) 51200 took 515.916172 milliseconds
transduce (id) 102400 took 1069.387798 milliseconds                    890 ms slower
+ StreamPerformance.left-associated ++: OK, proved property.
+ StreamPerformance.right-associated ++: OK, proved property.
+ StreamPerformance.left-associated flatMap 1: OK, proved property.
+ StreamPerformance.right-associated flatMap 1: OK, proved property.
+ StreamPerformance.left-associated flatMap 2: OK, proved property.
+ StreamPerformance.right-associated flatMap 1: OK, proved property.
+ StreamPerformance.transduce (id): OK, proved property.
+ StreamPerformance.bracket + onError (1): OK, proved property.
[success] Total time: 23 s, completed Mar 31, 2016 10:32:42 PM
```

topic/redesign:

```

[info] Running fs2.StreamPerformanceSpec
left-associated ++ (2) took 57.549648 milliseconds
left-associated ++ (3) took 0.144661 milliseconds
left-associated ++ (100) took 2.810072 milliseconds
left-associated ++ (200) took 5.826788 milliseconds
left-associated ++ (400) took 11.765979 milliseconds
left-associated ++ (800) took 24.286471 milliseconds
left-associated ++ (1600) took 26.451776 milliseconds
left-associated ++ (3200) took 11.451164 milliseconds
left-associated ++ (6400) took 10.320535 milliseconds
left-associated ++ (12800) took 17.8335 milliseconds
left-associated ++ (25600) took 26.135562 milliseconds
left-associated ++ (51200) took 26.179397 milliseconds
left-associated ++ (102400) took 81.097143 milliseconds
+ StreamPerformance.left-associated ++: OK, proved property.
right-associated ++ (2) took 3.458613 milliseconds
right-associated ++ (3) took 0.109088 milliseconds
right-associated ++ (100) took 0.283202 milliseconds
right-associated ++ (200) took 0.517107 milliseconds
right-associated ++ (400) took 1.155252 milliseconds
right-associated ++ (800) took 1.602436 milliseconds
right-associated ++ (1600) took 3.085497 milliseconds
right-associated ++ (3200) took 3.258559 milliseconds
right-associated ++ (6400) took 5.089533 milliseconds
right-associated ++ (12800) took 6.294894 milliseconds
right-associated ++ (25600) took 11.236428 milliseconds
right-associated ++ (51200) took 25.596518 milliseconds
right-associated ++ (102400) took 103.769721 milliseconds
+ StreamPerformance.right-associated ++: OK, proved property.
left-associated flatMap 1 (2) took 9.01648 milliseconds
left-associated flatMap 1 (3) took 0.201544 milliseconds
left-associated flatMap 1 (100) took 1.193612 milliseconds
left-associated flatMap 1 (200) took 1.75893 milliseconds
left-associated flatMap 1 (400) took 3.853587 milliseconds
left-associated flatMap 1 (800) took 5.78921 milliseconds
left-associated flatMap 1 (1600) took 18.618429 milliseconds
left-associated flatMap 1 (3200) took 12.654902 milliseconds
left-associated flatMap 1 (6400) took 20.457701 milliseconds
left-associated flatMap 1 (12800) took 23.852696 milliseconds
left-associated flatMap 1 (25600) took 12.596262 milliseconds
left-associated flatMap 1 (51200) took 17.859964 milliseconds
left-associated flatMap 1 (102400) took 40.615767 milliseconds
+ StreamPerformance.left-associated flatMap 1: OK, proved property.
right-associated flatMap 1 (2) took 2.417695 milliseconds
right-associated flatMap 1 (3) took 0.215582 milliseconds
right-associated flatMap 1 (100) took 0.840524 milliseconds
right-associated flatMap 1 (200) took 0.837263 milliseconds
right-associated flatMap 1 (400) took 1.665505 milliseconds
right-associated flatMap 1 (800) took 2.708075 milliseconds
right-associated flatMap 1 (1600) took 2.038848 milliseconds
right-associated flatMap 1 (3200) took 3.681178 milliseconds
right-associated flatMap 1 (6400) took 8.55724 milliseconds
right-associated flatMap 1 (12800) took 17.42565 milliseconds
right-associated flatMap 1 (25600) took 26.89546 milliseconds
right-associated flatMap 1 (51200) took 27.477158 milliseconds
right-associated flatMap 1 (102400) took 37.771068 milliseconds
+ StreamPerformance.right-associated flatMap 1: OK, proved property.
left-associated flatMap 2 (2) took 7.742839 milliseconds
left-associated flatMap 2 (3) took 0.935616 milliseconds
left-associated flatMap 2 (100) took 2.027678 milliseconds
left-associated flatMap 2 (200) took 2.750512 milliseconds
left-associated flatMap 2 (400) took 5.022182 milliseconds
left-associated flatMap 2 (800) took 9.565474 milliseconds
left-associated flatMap 2 (1600) took 17.879403 milliseconds
left-associated flatMap 2 (3200) took 20.189781 milliseconds
left-associated flatMap 2 (6400) took 20.333757 milliseconds
left-associated flatMap 2 (12800) took 14.765879 milliseconds
left-associated flatMap 2 (25600) took 36.695323 milliseconds
left-associated flatMap 2 (51200) took 64.111832 milliseconds
left-associated flatMap 2 (102400) took 137.641774 milliseconds
+ StreamPerformance.left-associated flatMap 2: OK, proved property.
right-associated flatMap 1 (2) took 3.408105 milliseconds
right-associated flatMap 1 (3) took 0.141604 milliseconds
right-associated flatMap 1 (100) took 0.275727 milliseconds
right-associated flatMap 1 (200) took 0.422087 milliseconds
right-associated flatMap 1 (400) took 0.911046 milliseconds
right-associated flatMap 1 (800) took 0.945921 milliseconds
right-associated flatMap 1 (1600) took 2.378181 milliseconds
right-associated flatMap 1 (3200) took 3.24267 milliseconds
right-associated flatMap 1 (6400) took 4.855116 milliseconds
right-associated flatMap 1 (12800) took 11.506362 milliseconds
right-associated flatMap 1 (25600) took 9.158122 milliseconds
right-associated flatMap 1 (51200) took 19.70136 milliseconds
right-associated flatMap 1 (102400) took 31.348646 milliseconds
+ StreamPerformance.right-associated flatMap 1: OK, proved property.
transduce (id) 2 took 18.409037 milliseconds
transduce (id) 3 took 0.397354 milliseconds
transduce (id) 100 took 4.714803 milliseconds
transduce (id) 200 took 6.699114 milliseconds
transduce (id) 400 took 8.265708 milliseconds
transduce (id) 800 took 10.350013 milliseconds
transduce (id) 1600 took 13.155783 milliseconds
transduce (id) 3200 took 14.311075 milliseconds
transduce (id) 6400 took 26.587861 milliseconds
transduce (id) 12800 took 42.910626 milliseconds
transduce (id) 25600 took 40.197602 milliseconds
transduce (id) 51200 took 94.376733 milliseconds
transduce (id) 102400 took 179.126923 milliseconds
+ StreamPerformance.transduce (id): OK, proved property.
+ StreamPerformance.bracket + onError (1): OK, proved property.
[success] Total time: 8 s, completed Mar 31, 2016 10:34:22 PM
```
