### PR TITLE
Backport: rewrite merge for readability.

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1921,63 +1921,54 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
       resultQ <- Queue.unbounded[F2, Option[Stream[F2, O2]]]
     } yield {
 
-      def go(
-          s: Stream[F2, O2],
-          guard: Semaphore[F2],
-          queue: Queue[F2, Option[Stream[F2, O2]]]
-      ): Pull[F2, O2, Unit] =
+      def watchInterrupted(str: Stream[F2, O2]): Stream[F2, O2] =
+        str.interruptWhen(interrupt.get.attempt)
+
+      // action to signal that one stream is finished, and if it is te last one
+      // then close te queue (by putting a None in it)
+      val doneAndClose: F2[Unit] = otherSideDone.modify(prev => (true, prev)).flatMap {
+        // complete only if other side is done too.
+        case true  => resultQ.enqueue1(None)
+        case false => F2.unit
+      }
+
+      // stream that is generated from pumping out the elements of the queue.
+      val pumpFromQueue: Stream[F2, O2] = resultQ.dequeue.unNoneTerminate.flatten
+
+      // action to interrupt the processing of both streams by completing interrupt
+      // We need to use `attempt` because `interruption` may already be completed.
+      val signalInterruption: F2[Unit] = interrupt.complete(()).attempt.void
+
+      def go(s: Stream[F2, O2], guard: Semaphore[F2]): Pull[F2, O2, Unit] =
         Pull.eval(guard.acquire) >> s.pull.uncons.flatMap {
           case Some((hd, tl)) =>
-            Pull
-              .eval(resultQ.enqueue1(Some(Stream.chunk(hd).onFinalize(guard.release)))) >>
-              go(tl, guard, queue)
+            val enq = resultQ.enqueue1(Some(Stream.chunk(hd).onFinalize(guard.release)))
+            Pull.eval(enq) >> go(tl, guard)
           case None => Pull.done
         }
+
       def runStream(s: Stream[F2, O2], whenDone: Deferred[F2, Either[Throwable, Unit]]): F2[Unit] =
         // guarantee we process only single chunk at any given time from any given side.
         Semaphore(1).flatMap { guard =>
-          go(s, guard, resultQ).stream
-            .interruptWhen(interrupt.get.attempt)
-            .compile
-            .drain
-            .attempt
-            .flatMap { r =>
-              whenDone.complete(r) >> { // signal completion of our side before we will signal interruption, to make sure our result is always available to others
-                if (r.isLeft)
-                  interrupt
-                    .complete(())
-                    .attempt
-                    .void // we need to attempt interruption in case the interrupt was already completed.
-                else
-                  otherSideDone
-                    .modify(prev => (true, prev))
-                    .flatMap { otherDone =>
-                      if (otherDone)
-                        resultQ
-                          .enqueue1(None) // complete only if other side is done too.
-                      else F2.unit
-                    }
-              }
-            }
+          val str = watchInterrupted(go(s, guard).stream)
+          str.compile.drain.attempt.flatMap {
+            // signal completion of our side before we will signal interruption,
+            // to make sure our result is always available to others
+            case r @ Left(_)  => whenDone.complete(r) >> signalInterruption
+            case r @ Right(_) => whenDone.complete(r) >> doneAndClose
+          }
         }
 
-      def resultStream: Stream[F2, O2] =
-        resultQ.dequeue.unNoneTerminate.flatten
-          .interruptWhen(interrupt.get.attempt)
+      val atRunEnd: F2[Unit] = for {
+        _ <- signalInterruption // interrupt so the upstreams have chance to complete
+        left <- resultL.get
+        right <- resultR.get
+        r <- F2.fromEither(CompositeFailure.fromResults(left, right))
+      } yield r
 
-      Stream.bracket(
-        F2.start(runStream(this, resultL)) >>
-          F2.start(runStream(that, resultR))
-      ) { _ =>
-        interrupt
-          .complete(())
-          .attempt >> // interrupt so the upstreams have chance to complete
-          resultL.get.flatMap { left =>
-            resultR.get.flatMap { right =>
-              F2.fromEither(CompositeFailure.fromResults(left, right))
-            }
-          }
-      } >> resultStream
+      val runStreams = F2.start(runStream(this, resultL)) >> F2.start(runStream(that, resultR))
+
+      Stream.bracket(runStreams)(_ => atRunEnd) >> watchInterrupted(pumpFromQueue)
     }
     Stream.eval(fstream).flatten
   }


### PR DESCRIPTION
Backports changes in https://github.com/typelevel/fs2/pull/1997 from the `develop` branch to the `main` branch

In the `Stream.merge` method, port some changes from the `develop` branch to the `main` branch, to reduce `diff` distance between those branches, and to merge https://github.com/typelevel/fs2/pull/1832 into the `main` first and then `develop` branches.