### PR TITLE
Create chunks in Stream.fromIterator (#2010)

### DIFF
--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -651,29 +651,53 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
   }
 
-  test("fromIterator") {
-    forAllF { (x: List[Int], cs: Int) =>
-      val chunkSize = (cs % 4096).abs + 1
-      Stream
-        .fromIterator[IO](x.iterator, chunkSize)
-        .compile
-        .toList
-        .map(it => assert(it == x))
+  group("fromIterator") {
+    test("single") {
+      forAllF { (x: List[Int]) =>
+        Stream
+          .fromIterator[IO](x.iterator)
+          .compile
+          .toList
+          .map(it => assert(it == x))
+      }
+    }
+
+    test("chunked") {
+      forAllF { (x: List[Int], cs: Int) =>
+        val chunkSize = (cs % 4096).abs + 1
+        Stream
+          .fromIterator[IO](x.iterator, chunkSize)
+          .compile
+          .toList
+          .map(it => assert(it == x))
+      }
     }
   }
 
-  test("fromBlockingIterator") {
-    forAllF { (x: List[Int], cs: Int) =>
-      val chunkSize = (cs % 4096).abs + 1
-      Stream
-        .fromBlockingIterator[IO](
-          Blocker.liftExecutionContext(munitExecutionContext),
-          x.iterator,
-          chunkSize
-        )
-        .compile
-        .toList
-        .map(it => assert(it == x))
+  group("fromBlockingIterator") {
+    test("single") {
+      forAllF { (x: List[Int]) =>
+        Stream
+          .fromBlockingIterator[IO](Blocker.liftExecutionContext(munitExecutionContext), x.iterator)
+          .compile
+          .toList
+          .map(it => assert(it == x))
+      }
+    }
+
+    test("chunked") {
+      forAllF { (x: List[Int], cs: Int) =>
+        val chunkSize = (cs % 4096).abs + 1
+        Stream
+          .fromBlockingIterator[IO](
+            Blocker.liftExecutionContext(munitExecutionContext),
+            x.iterator,
+            chunkSize
+          )
+          .compile
+          .toList
+          .map(it => assert(it == x))
+      }
     }
   }
 

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -652,9 +652,10 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   test("fromIterator") {
-    forAllF { (x: List[Int]) =>
+    forAllF { (x: List[Int], cs: Int) =>
+      val chunkSize = (cs % 4096).abs + 1
       Stream
-        .fromIterator[IO](x.iterator)
+        .fromIterator[IO](x.iterator, chunkSize)
         .compile
         .toList
         .map(it => assert(it == x))
@@ -662,9 +663,14 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   test("fromBlockingIterator") {
-    forAllF { (x: List[Int]) =>
+    forAllF { (x: List[Int], cs: Int) =>
+      val chunkSize = (cs % 4096).abs + 1
       Stream
-        .fromBlockingIterator[IO](Blocker.liftExecutionContext(munitExecutionContext), x.iterator)
+        .fromBlockingIterator[IO](
+          Blocker.liftExecutionContext(munitExecutionContext),
+          x.iterator,
+          chunkSize
+        )
         .compile
         .toList
         .map(it => assert(it == x))


### PR DESCRIPTION
Improves performance of `Stream.fromIterator` and `Stream.fromBlockingIterator` by creating chunks of requested size, as described in #2010.