### PR TITLE
Create chunks in Stream.fromIterator and Stream.fromBlockingIterator

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3364,15 +3364,19 @@ object Stream extends StreamLowPriority {
     new PartiallyAppliedFromEither(dummy = true)
 
   private[fs2] final class PartiallyAppliedFromIterator[F[_]](
-      private val dummy: Boolean
+      private val blocking: Boolean
   ) extends AnyVal {
-    def apply[A](iterator: Iterator[A])(implicit F: Sync[F]): Stream[F, A] = {
-      def getNext(i: Iterator[A]): F[Option[(A, Iterator[A])]] =
-        F.delay(i.hasNext).flatMap { b =>
-          if (b) F.delay(i.next()).map(a => (a, i).some) else F.pure(None)
+    def apply[A](iterator: Iterator[A], chunkSize: Int)(implicit F: Sync[F]): Stream[F, A] = {
+      def eff[B](thunk: => B) = if (blocking) F.blocking(thunk) else F.delay(thunk)
+
+      def getNextChunk(i: Iterator[A]): F[Option[(Chunk[A], Iterator[A])]] =
+        eff {
+          for (_ <- 1 to chunkSize if i.hasNext) yield i.next()
+        }.map { s =>
+          if (s.isEmpty) None else Some((Chunk.seq(s), i))
         }
 
-      Stream.unfoldEval(iterator)(getNext)
+      Stream.unfoldChunkEval(iterator)(getNextChunk)
     }
   }
 
@@ -3380,28 +3384,13 @@ object Stream extends StreamLowPriority {
     * Lifts an iterator into a Stream.
     */
   def fromIterator[F[_]]: PartiallyAppliedFromIterator[F] =
-    new PartiallyAppliedFromIterator(dummy = true)
-
-  private[fs2] final class PartiallyAppliedFromBlockingIterator[F[_]](
-      private val dummy: Boolean
-  ) extends AnyVal {
-    def apply[A](
-        iterator: Iterator[A]
-    )(implicit F: Sync[F]): Stream[F, A] = {
-      def getNext(i: Iterator[A]): F[Option[(A, Iterator[A])]] =
-        F.blocking(i.hasNext).flatMap { b =>
-          if (b) F.blocking(i.next()).map(a => (a, i).some) else F.pure(None)
-        }
-
-      Stream.unfoldEval(iterator)(getNext)
-    }
-  }
+    new PartiallyAppliedFromIterator(blocking = false)
 
   /**
     * Lifts an iterator into a Stream, shifting any interaction with the iterator to the blocking pool.
     */
-  def fromBlockingIterator[F[_]]: PartiallyAppliedFromBlockingIterator[F] =
-    new PartiallyAppliedFromBlockingIterator(dummy = true)
+  def fromBlockingIterator[F[_]]: PartiallyAppliedFromIterator[F] =
+    new PartiallyAppliedFromIterator(blocking = true)
 
   /**
     * Like `emits`, but works for any G that has a `Foldable` instance.

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -652,9 +652,10 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   test("fromIterator") {
-    forAllF { (x: List[Int]) =>
+    forAllF { (x: List[Int], cs: Int) =>
+      val chunkSize = (cs % 4096).abs + 1
       Stream
-        .fromIterator[IO](x.iterator)
+        .fromIterator[IO](x.iterator, chunkSize)
         .compile
         .toList
         .map(it => assert(it == x))
@@ -662,9 +663,10 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   test("fromBlockingIterator") {
-    forAllF { (x: List[Int]) =>
+    forAllF { (x: List[Int], cs: Int) =>
+      val chunkSize = (cs % 4096).abs + 1
       Stream
-        .fromBlockingIterator[IO](x.iterator)
+        .fromBlockingIterator[IO](x.iterator, chunkSize)
         .compile
         .toList
         .map(it => assert(it == x))

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -421,11 +421,13 @@ package object file {
       _.iterator.asScala
     )
 
+  private val pathStreamChunkSize = 16
+
   private def _runJavaCollectionResource[F[_]: Sync, C <: AutoCloseable](
       javaCollection: F[C],
       collectionIterator: C => Iterator[Path]
   ): Stream[F, Path] =
     Stream
       .resource(Resource.fromAutoCloseable(javaCollection))
-      .flatMap(ds => Stream.fromBlockingIterator[F](collectionIterator(ds)))
+      .flatMap(ds => Stream.fromBlockingIterator[F](collectionIterator(ds), pathStreamChunkSize))
 }


### PR DESCRIPTION
I think that in reference to #2010 we can make `fromIterator` in the 3.x series chunk-aware from beginning and similar to most other methods which create chunks, do not provide any default value. Because the code for blocking and non-blocking `PartiallyAppliedFromIterator` is nearly identical, I would suggest to merge it into single class.