### PR TITLE
Signal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -140,6 +140,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % "3.0-c54025b",
       "org.typelevel" %%% "cats-effect-laws" % "3.0-c54025b" % "test",
+      "org.typelevel" %%% "cats-effect-testkit" % "3.0-c54025b" % "test",
       "org.scodec" %%% "scodec-bits" % "1.1.20",
       "org.typelevel" %%% "scalacheck-effect-munit" % "0.2.0" % "test"
     )

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2221,7 +2221,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
      stream.interruptWhen(pauseSignal.discrete.map(_.isEmpty))
     }
 
-  /** Alias for `pauseWhen(pauseWhenTrue.discrete)`. */
+  /** Pause this stream when `pauseWhenTrue` is `true`, resume when it's `false`. */
   def pauseWhen[F2[x] >: F[x]: Concurrent](
       pauseWhenTrue: Signal[F2, Boolean]
   ): Stream[F2, O] = {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2210,7 +2210,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       def writer = pauseWhenTrue.evalMap(pauseSignal.set).drain
 
       pauseWhen(pauseSignal).mergeHaltBoth(writer)
-  }
+    }
 
   /** Pause this stream when `pauseWhenTrue` is `true`, resume when it's `false`. */
   def pauseWhen[F2[x] >: F[x]: Concurrent](

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -22,10 +22,6 @@
 package fs2
 package concurrent
 
-// TODO
-// change bound in Token.apply
-// change pauseWhen
-
 import cats.{Applicative, Functor, Invariant}
 import cats.data.OptionT
 import cats.effect.Concurrent

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -23,7 +23,6 @@ package fs2
 package concurrent
 
 // TODO
-// comment on access conflict with discrete
 // create implicits object to put instances in
 // change bound in Token.apply
 // change pauseWhen
@@ -155,7 +154,18 @@ private[concurrent] trait SignalLowPriorityImplicits {
     }
 }
 
-/** Pure holder of a single value of type `A` that can be both read and updated in the effect `F`. */
+/**
+  * Pure holder of a single value of type `A` that can be both read
+  * and updated in the effect `F`.
+  *
+  * The update methods have the same semantics as Ref, as well as
+  * propagating changes to `discrete` (with a last-update-wins policy
+  * in case of very fast updates).
+  *
+  * The `access` method differs slightly from `Ref` in that the update
+  * function, in the presence of `discrete`, can return `false` and
+  * need looping even without any other writers.
+  */
 abstract class SignallingRef[F[_], A] extends Ref[F, A] with Signal[F, A]
 
 object SignallingRef {

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -205,11 +205,7 @@ object SignallingRef {
 
     override def access: F[(A, A => F[Boolean])] =
       state.access.map { case (snapshot, set) =>
-        val setter = { (a: A) =>
-          if (a == snapshot._1) set((a, snapshot._2, snapshot._3))
-          else F.pure(false)
-        }
-
+        val setter = { (a: A) => set((a, snapshot._2, snapshot._3)) }
         (snapshot._1, setter)
       }
 

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -73,13 +73,12 @@ object Signal extends SignalInstances {
       def get: F[B] = Functor[F].map(fa.get)(f)
     }
 
-  // TODO do we need this?
   implicit class SignalOps[F[_], A](val self: Signal[F, A]) extends AnyVal {
     /**
       * Converts this signal to signal of `B` by applying `f`.
       */
     def map[B](f: A => B)(implicit F: Functor[F]): Signal[F, B] =
-      self.map(f)
+      Signal.mapped(self)(f)
   }
 
   implicit class BooleanSignalOps[F[_]](val self: Signal[F, Boolean]) extends AnyVal {

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -164,7 +164,7 @@ object SignallingRef {
 
           def set(a: A): F[Unit] = update(_ => a)
 
-          def update(f: A => A): F[Unit] = modify(a => f(a) -> ())
+          def update(f: A => A): F[Unit] = modify(a => (f(a), ()))
 
           def modify[B](f: A => (A, B)): F[B] =
             state.modify(updateAndNotify(_, f)).flatten
@@ -173,7 +173,7 @@ object SignallingRef {
             state.tryModify(updateAndNotify(_, f)).flatMap(_.sequence)
 
           def tryUpdate(f: A => A): F[Boolean] =
-            tryModify(a => f(a) -> ()).map(_.isDefined)
+            tryModify(a => (f(a), ())).map(_.isDefined)
 
           def access: F[(A, A => F[Boolean])] =
             state.access.map { case (state, set) =>

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -172,7 +172,7 @@ object SignallingRef {
   )(implicit F: Concurrent[F])
       extends SignallingRef[F, A] {
 
-    override def get: F[A] = state.get.map(_._1)
+    override def get: F[A] = state.get.map(_.value)
 
     override def continuous: Stream[F, A] =
       Stream.repeatEval(get)

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -23,7 +23,6 @@ package fs2
 package concurrent
 
 // TODO
-// create implicits object to put instances in
 // change bound in Token.apply
 // change pauseWhen
 

--- a/core/shared/src/main/scala/fs2/internal/Token.scala
+++ b/core/shared/src/main/scala/fs2/internal/Token.scala
@@ -31,6 +31,7 @@ final class Token private () extends Serializable {
 }
 
 object Token {
+
   /**
     * Token provides uniqueness by relying on object equality,
     * which means that `new Token` is actually a side-effect

--- a/core/shared/src/main/scala/fs2/internal/Token.scala
+++ b/core/shared/src/main/scala/fs2/internal/Token.scala
@@ -49,7 +49,7 @@ object Token {
     * - it's infallible
     * - it's not created in contexts that affect stack safety such as iteration
     *
-    * Given all these reasons, we suspend it via `flatMap` of
+    * Given all these reasons, we suspend it via `flatMap` instead of
     * using `Sync[F].delay`. Do not try this at home.
     *
     * Note: The `Compiler.Target` bound only resolves if `F` has an

--- a/core/shared/src/main/scala/fs2/internal/Token.scala
+++ b/core/shared/src/main/scala/fs2/internal/Token.scala
@@ -23,6 +23,7 @@ package fs2.internal
 
 import cats.Monad
 import cats.syntax.all._
+import fs2.Compiler
 
 /** Represents a unique identifier (using object equality). */
 final class Token private () extends Serializable {
@@ -30,7 +31,6 @@ final class Token private () extends Serializable {
 }
 
 object Token {
-
   /**
     * Token provides uniqueness by relying on object equality,
     * which means that `new Token` is actually a side-effect
@@ -48,9 +48,13 @@ object Token {
     * - it's infallible
     * - it's not created in contexts that affect stack safety such as iteration
     *
-    * Given all these reasons, we suspend it via `Monad` instead of
-    * using `Sync.` Do not try this at home.
+    * Given all these reasons, we suspend it via `flatMap` of
+    * using `Sync[F].delay`. Do not try this at home.
+    *
+    * Note: The `Compiler.Target` bound only resolves if `F` has an
+    * instance of `Sync` or `Concurrent`, meaning that `flatMap` is
+    * guaranteed to suspend.
     */
-  def apply[F[_]: Monad]: F[Token] =
+  def apply[F[_]: Compiler.Target]: F[Token] =
     ().pure[F].map(_ => new Token)
 }

--- a/core/shared/src/test/scala/fs2/Fs2Suite.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Suite.scala
@@ -72,8 +72,8 @@ abstract class Fs2Suite extends ScalaCheckEffectSuite with TestPlatform with Gen
       }
   }
 
-
   implicit class Deterministically[F[_], A](private val self: IO[A]) {
+
     /**
       * Allows to run an IO deterministically through TextContext.
       * Assumes you want to run the IO to completion, if you need to step through execution,
@@ -103,7 +103,6 @@ abstract class Fs2Suite extends ScalaCheckEffectSuite with TestPlatform with Gen
     (ctx, runtime)
   }
 
-
   /** Returns a stream that has a 10% chance of failing with an error on each output value. */
   protected def spuriousFail[F[_]: RaiseThrowable, O](s: Stream[F, O]): Stream[F, O] =
     Stream.suspend {
@@ -130,7 +129,11 @@ abstract class Fs2Suite extends ScalaCheckEffectSuite with TestPlatform with Gen
       property(s"${name}.${id}")(prop)
 
   override def munitValueTransforms: List[ValueTransform] =
-    super.munitValueTransforms ++ List(munitIOTransform, munitSyncIOTransform, munitDeterministicIOTransform)
+    super.munitValueTransforms ++ List(
+      munitIOTransform,
+      munitSyncIOTransform,
+      munitDeterministicIOTransform
+    )
 
   private val munitIOTransform: ValueTransform =
     new ValueTransform("IO", { case e: IO[_] => e.unsafeToFuture() })

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -905,7 +905,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   group("pauseWhen") {
-    test("pause and resume".only) {
+    test("pause and resume") {
       SignallingRef[IO, Boolean](false)
         .product(Ref[IO].of(0))
         .flatMap { case (pause, counter) =>

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -945,7 +945,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
         }
     }
 
-    test("starts in paused state".only) {
+    test("starts in paused state") {
       (SignallingRef[IO, Boolean](true) product Ref[IO].of(false))
         .flatMap { case (pause, written) =>
           Stream

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -906,7 +906,8 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
   group("pauseWhen") {
     test("pause and resume") {
-      (SignallingRef[IO, Boolean](false) product Ref[IO].of(0))
+      SignallingRef[IO, Boolean](false)
+        .product(Ref[IO].of(0))
         .flatMap { case (pause, counter) =>
           def counterChangesFrom(i: Int): IO[Unit] =
             counter.get.flatMap { v =>
@@ -937,7 +938,6 @@ class StreamCombinatorsSuite extends Fs2Suite {
             _ <- counterChangesFrom(v)
           } yield ()
 
-
           for {
             fiber <- stream.compile.drain.start
             _ <- behaviour.timeout(5.seconds).guarantee(fiber.cancel)
@@ -946,13 +946,16 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
 
     test("starts in paused state") {
-      (SignallingRef[IO, Boolean](true) product Ref[IO].of(false))
+      SignallingRef[IO, Boolean](true)
+        .product(Ref[IO].of(false))
         .flatMap { case (pause, written) =>
           Stream
             .eval(written.set(true))
             .pauseWhen(pause)
             .timeout(200.millis)
-            .compile.drain.attempt >> written.get.map(assertEquals(_, false))
+            .compile
+            .drain
+            .attempt >> written.get.map(assertEquals(_, false))
         }
     }
   }

--- a/core/shared/src/test/scala/fs2/StreamZipSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamZipSuite.scala
@@ -21,7 +21,6 @@
 
 package fs2
 
-
 import cats.effect.{IO, SyncIO}
 import cats.syntax.all._
 
@@ -214,49 +213,49 @@ class StreamZipSuite extends Fs2Suite {
       }
     }
 
-      test("parZip evaluates effects with bounded concurrency") {
-        val (env, runtime) = createDeterministicRuntime
+    test("parZip evaluates effects with bounded concurrency") {
+      val (env, runtime) = createDeterministicRuntime
 
-        // track progress of the computation
-        @volatile var lhs: Int = 0
-        @volatile var rhs: Int = 0
-        @volatile var output: Vector[(String, Int)] = Vector()
+      // track progress of the computation
+      @volatile var lhs: Int = 0
+      @volatile var rhs: Int = 0
+      @volatile var output: Vector[(String, Int)] = Vector()
 
-        // synchronises lhs and rhs to test both sides of the race in parZip
-        def parZipRace[A, B](lhs: Stream[IO, A], rhs: Stream[IO, B]) = {
-          val rate = Stream(1, 2).repeat
-          val skewedRate = Stream(2, 1).repeat
-          def sync[C]: Pipe2[IO, C, Int, C] =
-            (in, rate) => rate.evalMap(n => IO.sleep(n.seconds)).zipRight(in)
+      // synchronises lhs and rhs to test both sides of the race in parZip
+      def parZipRace[A, B](lhs: Stream[IO, A], rhs: Stream[IO, B]) = {
+        val rate = Stream(1, 2).repeat
+        val skewedRate = Stream(2, 1).repeat
+        def sync[C]: Pipe2[IO, C, Int, C] =
+          (in, rate) => rate.evalMap(n => IO.sleep(n.seconds)).zipRight(in)
 
-          lhs.through2(rate)(sync).parZip(rhs.through2(skewedRate)(sync))
-        }
-
-        val stream = parZipRace(
-          Stream("a", "b", "c").evalTap(_ => IO { lhs = lhs + 1 }),
-          Stream(1, 2, 3).evalTap(_ => IO { rhs = rhs + 1 })
-        ).evalTap(x => IO { output = output :+ x })
-
-        val result = stream.compile.toVector.unsafeToFuture()(runtime)
-
-        // lhsAt, rhsAt and output at time T = [1s, 2s, ..]
-        val snapshots = Vector(
-          (1, 0, Vector()),
-          (1, 1, Vector("a" -> 1)),
-          (1, 2, Vector("a" -> 1)),
-          (2, 2, Vector("a" -> 1, "b" -> 2)),
-          (3, 2, Vector("a" -> 1, "b" -> 2)),
-          (3, 3, Vector("a" -> 1, "b" -> 2, "c" -> 3))
-        )
-
-        snapshots.foreach { snapshot =>
-          env.tick(1.second)
-          assertEquals((lhs, rhs, output), snapshot)
-        }
-
-        env.tick(1.second)
-        result.map(r => assertEquals(r, snapshots.last._3))(munitExecutionContext)
+        lhs.through2(rate)(sync).parZip(rhs.through2(skewedRate)(sync))
       }
+
+      val stream = parZipRace(
+        Stream("a", "b", "c").evalTap(_ => IO { lhs = lhs + 1 }),
+        Stream(1, 2, 3).evalTap(_ => IO { rhs = rhs + 1 })
+      ).evalTap(x => IO { output = output :+ x })
+
+      val result = stream.compile.toVector.unsafeToFuture()(runtime)
+
+      // lhsAt, rhsAt and output at time T = [1s, 2s, ..]
+      val snapshots = Vector(
+        (1, 0, Vector()),
+        (1, 1, Vector("a" -> 1)),
+        (1, 2, Vector("a" -> 1)),
+        (2, 2, Vector("a" -> 1, "b" -> 2)),
+        (3, 2, Vector("a" -> 1, "b" -> 2)),
+        (3, 3, Vector("a" -> 1, "b" -> 2, "c" -> 3))
+      )
+
+      snapshots.foreach { snapshot =>
+        env.tick(1.second)
+        assertEquals((lhs, rhs, output), snapshot)
+      }
+
+      env.tick(1.second)
+      result.map(r => assertEquals(r, snapshots.last._3))(munitExecutionContext)
+    }
   }
 
   property("zipWithIndex") {

--- a/core/shared/src/test/scala/fs2/StreamZipSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamZipSuite.scala
@@ -251,11 +251,11 @@ class StreamZipSuite extends Fs2Suite {
 
         snapshots.foreach { snapshot =>
           env.tick(1.second)
-          assert((lhs, rhs, output) == snapshot)
+          assertEquals((lhs, rhs, output), snapshot)
         }
 
         env.tick(1.second)
-        result.map(r => assert(r == snapshots.last._3))(munitExecutionContext)
+        result.map(r => assertEquals(r, snapshots.last._3))(munitExecutionContext)
       }
   }
 

--- a/core/shared/src/test/scala/fs2/StreamZipSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamZipSuite.scala
@@ -215,7 +215,7 @@ class StreamZipSuite extends Fs2Suite {
     }
 
       test("parZip evaluates effects with bounded concurrency") {
-        val (env, runtime) = createTestRuntime
+        val (env, runtime) = createDeterministicRuntime
 
         // track progress of the computation
         @volatile var lhs: Int = 0

--- a/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
@@ -96,7 +96,7 @@ class SignalSuite extends Fs2Suite {
     }
   }
 
-  test("access updates discrete") {
+  test("access updates discrete".ignore) {
     SignallingRef[IO, Int](0).flatMap { s =>
       def cas: IO[Unit] =
         s.access.flatMap { case (v, set) =>

--- a/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
@@ -96,7 +96,7 @@ class SignalSuite extends Fs2Suite {
     }
   }
 
-  test("access updates discrete".ignore) {
+  test("access updates discrete") {
     SignallingRef[IO, Int](0).flatMap { s =>
       def cas: IO[Unit] =
         s.access.flatMap { case (v, set) =>

--- a/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
@@ -84,11 +84,15 @@ class SignalSuite extends Fs2Suite {
       s <- SignallingRef[IO, Long](0L)
       access <- s.access
       (v, set) = access
-      r1 <- set(v)
-      r2 <- set(v)
+      v1 = v + 1
+      v2 = v1 + 1
+      r1 <- set(v1)
+      r2 <- set(v2)
+      r3 <- s.get
     } yield {
       assert(r1 == true)
       assert(r2 == false)
+      assert(r3 == v1)
     }
   }
 

--- a/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
@@ -106,7 +106,6 @@ class SignalSuite extends Fs2Suite {
       def updates =
         s.discrete.takeWhile(_ != 1).compile.drain
 
-
       updates.start.flatMap { fiber =>
         cas >> fiber.join.timeout(5.seconds)
       }


### PR DESCRIPTION
This PR has become a bit sprawling, I'm hoping in some leniency 😄 . The general thread is `Signal`.

- Fix the hilarious bug in #2018 where `access` would never succeed.
- Fix a more subtle bug in `access`, which failed to update `discrete`.
- Document a general limitation of `access` (there is contention with `discrete`)
- General cleanup of `Signal`, no more tuples etc.
- Strengthen bound on `Token.apply` to make our usage completely airtight (one liner)
- Added some TestContext infra (which proved to be a non strictly necessary yak to shave, but it's one off the todo list)
- Add more effective tests for `pauseWhen`, the existing test tested nothing
- Change behaviour of `pauseWhen` to not evaluate anything when started in paused state
- Significantly less convoluted implementation of the two `pauseWhen` overloads
