### PR TITLE
fs2.Stream convenient fromOption method

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3273,6 +3273,26 @@ object Stream extends StreamLowPriority {
     now.flatMap(go)
   }
 
+  private[fs2] final class PartiallyAppliedFromOption[F[_]](
+      private val dummy: Boolean
+  ) extends AnyVal {
+    def apply[A](option: Option[A]): Stream[F, A] =
+      option.map(Stream.emit).getOrElse(Stream.empty)
+  }
+
+  /** Lifts an Option[A] to an effectful Stream.
+    *
+    * @example {{{
+    * scala> import cats.effect.SyncIO
+    * scala> Stream.fromOption[SyncIO](Some(42)).compile.toList.unsafeRunSync()
+    * res0: List[Int] = List(42)
+    * scala> Stream.fromOption[SyncIO](None).compile.toList.unsafeRunSync()
+    * res1: List[Int] = List()
+    * }}}
+    */
+  def fromOption[F[_]]: PartiallyAppliedFromOption[F] =
+    new PartiallyAppliedFromOption(dummy = true)
+
   private[fs2] final class PartiallyAppliedFromEither[F[_]](
       private val dummy: Boolean
   ) extends AnyVal {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3287,7 +3287,7 @@ object Stream extends StreamLowPriority {
     * scala> Stream.fromOption[SyncIO](Some(42)).compile.toList.unsafeRunSync()
     * res0: List[Int] = List(42)
     * scala> Stream.fromOption[SyncIO](None).compile.toList.unsafeRunSync()
-    * res1: List[Int] = List()
+    * res1: List[Nothing] = List()
     * }}}
     */
   def fromOption[F[_]]: PartiallyAppliedFromOption[F] =

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -649,6 +649,16 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
   }
 
+  property("fromOption") {
+    forAll { (option: Option[Int]) =>
+      val stream: Stream[Pure, Int] = Stream.fromOption[Pure](option)
+      option match {
+        case None    => assert(stream.toList == List.empty)
+        case Some(i) => assert(stream.toList == List(i))
+      }
+    }
+  }
+
   test("fromIterator") {
     forAllF { (x: List[Int], cs: Int) =>
       val chunkSize = (cs % 4096).abs + 1


### PR DESCRIPTION
Consider this synthetic example:
```
  import fs2.Stream

  def getFraction(n: Int): Option[Float] = if(n == 0) None else Some(1.toFloat / n)

  val stream =
    for {
      i <- fs2.Stream.repeatEval(IO.delay(Random.nextInt))
      fractionOpt = getFraction(i)

      fraction1 = Stream.emits(fractionOpt.toList)
      fraction2 = Stream.fromIterator(fractionOpt.iterator)
      fraction3 = Stream.fromOption(fractionOpt)

      fraction <- fraction1
    } yield fraction
```

I want to transform the result of the stream with use of `getFraction` method. I've found 2 method to accomplish it: emits, fromIterator. But the most accurate method is fromOption, which seems to be absent from Stream companion object. This PR adds fromOption.