### PR TITLE
Fix microsite CI build

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,18 +1,5 @@
-jobs:
-  publish:
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: "actions/checkout@v2.1.0"
-      - uses: "cachix/install-nix-action@v9"
-      - uses: "cachix/cachix-action@v6"
-        with:
-          name: fs2-site
-          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
-      - name: "Building microsite 🚧"
-        run: "nix-shell --run \"sbt ;++2.13.3;microsite/publishMicrosite\""
 name: Microsite
+
 on:
   push:
     branches:
@@ -20,3 +7,26 @@ on:
     paths:
       - "site/**"
       - "**/README.md"
+
+jobs:
+  publish:
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2.1.0
+
+      - name: "Install Nix ❄️"
+        uses: nixbuild/nix-quick-install-action@v2
+
+      - name: "Install Cachix ❄️"
+        uses: cachix/cachix-action@v6
+        with:
+          name: fs2-site
+          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
+
+      - name: "I WILL DELETE THIS IN THE NEXT COMMIT"
+        run: echo "${{ secrets.CACHIX_SIGNING_KEY }}"
+
+      - name: "Building microsite 🚧"
+        run: nix-shell --run "sbt '++2.13.3;microsite/publishMicrosite'"

--- a/.github/workflows/update-nix-cache.yml
+++ b/.github/workflows/update-nix-cache.yml
@@ -1,23 +1,26 @@
-name: Microsite
+name: Cachix
 
 on:
   push:
     branches:
       - main
     paths:
-      - "site/**"
-      - "**/README.md"
+      - "nix/**"
+      - "shell.nix"
 
 jobs:
-  publish:
+  update-nix-cache:
     env:
+      CACHIX_SIGNING_KEY: "${{ secrets.CACHIX_SIGNING_KEY }}"
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2.1.0
 
       - name: "Install Nix ❄️"
-        uses: nixbuild/nix-quick-install-action@v2
+        uses: cachix/install-nix-action@v11
+        with:
+          skip_adding_nixpkgs_channel: true
 
       - name: "Install Cachix ❄️"
         uses: cachix/cachix-action@v6
@@ -25,5 +28,5 @@ jobs:
           name: fs2-site
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
-      - name: "Building microsite 🚧"
-        run: nix-shell --run "sbt '++2.13.3;microsite/publishMicrosite'"
+      - name: "Update Nix cache"
+        run: nix-store -qR --include-outputs $(nix-instantiate shell.nix) | cachix push fs2-site

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,0 +1,20 @@
+{ java }:
+
+let
+  nixpkgs = fetchTarball {
+    name   = "nixos-unstable-2020-09-25";
+    url    = "https://github.com/NixOS/nixpkgs-channels/archive/72b9660dc18b.tar.gz";
+    sha256 = "1cqgpw263bz261bgz34j6hiawi4hi6smwp6981yz375fx0g6kmss";
+  };
+
+  config = {
+    packageOverrides = p: {
+      sbt = p.sbt.override {
+        jre = p.${java};
+      };
+    };
+  };
+
+  pkgs = import nixpkgs { inherit config; };
+in
+  pkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,30 +1,26 @@
-let
-  # Override the java version of sbt package
-  config = {
-    packageOverrides = pkgs: rec {
-      sbt = pkgs.sbt.overrideAttrs (
-        old: rec {
-          version = "1.3.13";
+{ java ? "openjdk11" }:
 
-          patchPhase = ''
-            echo -java-home ${pkgs.openjdk11} >> conf/sbtopts
-          '';
-        }
-      );
+let
+  nixpkgs = fetchTarball {
+    name   = "nixos-unstable-2020-09-25";
+    url    = "https://github.com/NixOS/nixpkgs-channels/archive/72b9660dc18b.tar.gz";
+    sha256 = "1cqgpw263bz261bgz34j6hiawi4hi6smwp6981yz375fx0g6kmss";
+  };
+
+  config = {
+    packageOverrides = p: {
+      sbt = p.sbt.override {
+        jre = p.${java};
+      };
     };
   };
 
-  nixpkgs = fetchTarball {
-    name   = "NixOS-unstable-08-06-2020";
-    url    = "https://github.com/NixOS/nixpkgs-channels/archive/dcb64ea42e6.tar.gz";
-    sha256 = "0i77sgs0gic6pwbkvk9lbpfshgizdrqyh18law2ji1409azc09w0";
-  };
   pkgs = import nixpkgs { inherit config; };
 in
   pkgs.mkShell {
-    buildInputs = with pkgs; [
-      jekyll # 4.1.0
-      openjdk11 # 11.0.6-internal
-      sbt # 1.3.13
+    buildInputs = [
+      pkgs.jekyll
+      pkgs.${java}
+      pkgs.sbt
     ];
   }

--- a/shell.nix
+++ b/shell.nix
@@ -1,21 +1,7 @@
 { java ? "openjdk11" }:
 
 let
-  nixpkgs = fetchTarball {
-    name   = "nixos-unstable-2020-09-25";
-    url    = "https://github.com/NixOS/nixpkgs-channels/archive/72b9660dc18b.tar.gz";
-    sha256 = "1cqgpw263bz261bgz34j6hiawi4hi6smwp6981yz375fx0g6kmss";
-  };
-
-  config = {
-    packageOverrides = p: {
-      sbt = p.sbt.override {
-        jre = p.${java};
-      };
-    };
-  };
-
-  pkgs = import nixpkgs { inherit config; };
+  pkgs = import nix/pkgs.nix { inherit java; };
 in
   pkgs.mkShell {
     buildInputs = [


### PR DESCRIPTION
In addition to fixing the command to build the microsite, I made some other small changes:

- Add `nix/pkgs.nix` to pin to a specific version of Nixpkgs for reproducibility.
- Add new CI job to update the binary cache when any of the Nix files change.
- Modify `shell.nix` to import packages from `nix/pkgs.nix`.