### PR TITLE
Move file operations to a Files[F] tagless interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,28 +69,28 @@ There are [detailed migration guides](https://github.com/functional-streams-for-
 FS2 is a streaming I/O library. The design goals are compositionality, expressiveness, resource safety, and speed. Here's a simple example of its use:
 
 ```scala
-import cats.effect.{Blocker, ExitCode, IO, IOApp, Resource}
-import fs2.{io, text, Stream}
+import cats.effect.{IO, IOApp, Resource}
+import fs2.{text, Stream}
+import fs2.io.file.Files
 import java.nio.file.Paths
 
-object Converter extends IOApp {
+object Converter extends IOApp.Simple {
 
-  val converter: Stream[IO, Unit] = Stream.resource(Blocker[IO]).flatMap { blocker =>
+  val converter: Stream[IO, Unit] = {
     def fahrenheitToCelsius(f: Double): Double =
       (f - 32.0) * (5.0/9.0)
 
-    io.file.readAll[IO](Paths.get("testdata/fahrenheit.txt"), blocker, 4096)
+    Files[IO].readAll(Paths.get("testdata/fahrenheit.txt"), 4096)
       .through(text.utf8Decode)
       .through(text.lines)
       .filter(s => !s.trim.isEmpty && !s.startsWith("//"))
       .map(line => fahrenheitToCelsius(line.toDouble).toString)
       .intersperse("\n")
       .through(text.utf8Encode)
-      .through(io.file.writeAll(Paths.get("testdata/celsius.txt"), blocker))
+      .through(Files[IO].writeAll(Paths.get("testdata/celsius.txt")))
   }
 
-  def run(args: List[String]): IO[ExitCode] =
-    converter.compile.drain.as(ExitCode.Success)
+  def run: IO[Unit] = converter.compile.drain
 }
 ```
 

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -110,13 +110,13 @@ trait FileHandle[F[_]] {
 
 object FileHandle {
 
-  @deprecated("Use BaseFiles[F].open")
+  @deprecated("Use Files[F].open")
   def fromPath[F[_]: Sync](path: Path, flags: Seq[OpenOption]): Resource[F, FileHandle[F]] =
-    BaseFiles[F].open(path, flags)
+    SyncFiles[F].open(path, flags)
 
-  @deprecated("Use BaseFiles[F].openFileChannel")
+  @deprecated("Use Files[F].openFileChannel")
   def fromFileChannel[F[_]: Sync](channel: F[FileChannel]): Resource[F, FileHandle[F]] =
-    BaseFiles[F].openFileChannel(channel)
+    SyncFiles[F].openFileChannel(channel)
 
   /** Creates a `FileHandle[F]` from a `java.nio.channels.FileChannel`. */
   private[file] def make[F[_]](

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -110,20 +110,16 @@ trait FileHandle[F[_]] {
 
 object FileHandle {
 
-  /** Creates a `FileHandle` for the file at the supplied `Path`. */
-  def fromPath[F[_]](path: Path, flags: Seq[OpenOption])(implicit
-      F: Sync[F]
-  ): Resource[F, FileHandle[F]] =
-    fromFileChannel(F.blocking(FileChannel.open(path, flags: _*)))
+  @deprecated("Use BaseFiles[F].open")
+  def fromPath[F[_]: Sync](path: Path, flags: Seq[OpenOption]): Resource[F, FileHandle[F]] =
+    BaseFiles[F].open(path, flags)
 
-  /** Creates a `FileHandle` for the supplied `FileChannel`. */
-  def fromFileChannel[F[_]](channel: F[FileChannel])(implicit
-      F: Sync[F]
-  ): Resource[F, FileHandle[F]] =
-    Resource.make(channel)(ch => F.blocking(ch.close())).map(ch => mk(ch))
+  @deprecated("Use BaseFiles[F].openFileChannel")
+  def fromFileChannel[F[_]: Sync](channel: F[FileChannel]): Resource[F, FileHandle[F]] =
+    BaseFiles[F].openFileChannel(channel)
 
   /** Creates a `FileHandle[F]` from a `java.nio.channels.FileChannel`. */
-  private def mk[F[_]](
+  private[file] def make[F[_]](
       chan: FileChannel
   )(implicit F: Sync[F]): FileHandle[F] =
     new FileHandle[F] {

--- a/io/src/main/scala/fs2/io/file/Files.scala
+++ b/io/src/main/scala/fs2/io/file/Files.scala
@@ -437,9 +437,7 @@ object Files {
 
   implicit def forAync[F[_]: Async]: Files[F] = new AsyncBaseFiles[F]
 
-  private final class AsyncBaseFiles[F[_]: Async]
-      extends BaseFiles.SyncBaseFiles[F]
-      with Files[F] {
+  private final class AsyncBaseFiles[F[_]: Async] extends BaseFiles.SyncBaseFiles[F] with Files[F] {
 
     def tail(path: Path, chunkSize: Int, offset: Long, pollDelay: FiniteDuration): Stream[F, Byte] =
       Stream.resource(ReadCursor.fromPath(path)).flatMap { cursor =>

--- a/io/src/main/scala/fs2/io/file/Files.scala
+++ b/io/src/main/scala/fs2/io/file/Files.scala
@@ -36,7 +36,15 @@ import java.util.stream.{Stream => JStream}
 
 import fs2.io.CollectionCompat._
 
-trait SyncFiles[F[_]] {
+/**
+  * Provides basic capabilities related to working with files.
+  *
+  * Normally, the [[Files]] capability should be used instead, which extends this trait
+  * with a few additional operations. `SyncFiles[F]` provides operations that only
+  * require synchronous effects -- * e.g., `SyncFiles[SyncIO]` has an instance whereas
+  * `Files[SyncIO]` does not.
+  */
+sealed trait SyncFiles[F[_]] {
 
   /**
     * Copies a file from the source to the target path,
@@ -387,6 +395,11 @@ object SyncFiles {
   }
 }
 
+/**
+  * Provides operations related to working with files in the effect `F`.
+  *
+  * An instance is available for any effect `F` which has an `Async[F]` instance.
+  */
 trait Files[F[_]] extends SyncFiles[F] {
 
   /**

--- a/io/src/main/scala/fs2/io/file/Files.scala
+++ b/io/src/main/scala/fs2/io/file/Files.scala
@@ -1,0 +1,512 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package io
+package file
+
+import scala.concurrent.duration._
+
+import cats.effect.kernel.{Async, Resource, Sync, Temporal}
+import cats.syntax.all._
+
+import java.io.IOException
+import java.nio.channels.{FileChannel, FileLock}
+import java.nio.file.{Files => JFiles, _}
+import java.nio.file.attribute.{BasicFileAttributes, FileAttribute, PosixFilePermission}
+import java.util.stream.{Stream => JStream}
+
+import fs2.io.CollectionCompat._
+
+trait BaseFiles[F[_]] {
+
+  /**
+    * Copies a file from the source to the target path,
+    *
+    * By default, the copy fails if the target file already exists or is a symbolic link.
+    */
+  def copy(source: Path, target: Path, flags: Seq[CopyOption] = Seq.empty): F[Path]
+
+  /**
+    * Creates a new directory at the given path.
+    */
+  def createDirectory(path: Path, flags: Seq[FileAttribute[_]] = Seq.empty): F[Path]
+
+  /**
+    * Creates a new directory at the given path and creates all nonexistent parent directories beforehand.
+    */
+  def createDirectories(path: Path, flags: Seq[FileAttribute[_]] = Seq.empty): F[Path]
+
+  /**
+    * Deletes a file.
+    *
+    * If the file is a directory then the directory must be empty for this action to succeed.
+    * This action will fail if the path doesn't exist.
+    */
+  def delete(path: Path): F[Unit]
+
+  /**
+    * Like `delete`, but will not fail when the path doesn't exist.
+    */
+  def deleteIfExists(path: Path): F[Boolean]
+
+  /**
+    * Recursively delete a directory
+    */
+  def deleteDirectoryRecursively(path: Path, options: Set[FileVisitOption] = Set.empty): F[Unit]
+
+  /**
+    * Creates a stream of [[Path]]s inside a directory.
+    */
+  def directoryStream(path: Path): Stream[F, Path]
+
+  /**
+    * Creates a stream of [[Path]]s inside a directory, filtering the results by the given predicate.
+    */
+  def directoryStream(path: Path, filter: Path => Boolean): Stream[F, Path]
+
+  /**
+    * Creates a stream of [[Path]]s inside a directory which match the given glob.
+    */
+  def directoryStream(path: Path, glob: String): Stream[F, Path]
+
+  /**
+    * Checks if a file exists.
+    *
+    * Note that the result of this method is immediately outdated. If this
+    * method indicates the file exists then there is no guarantee that a
+    * subsequence access will succeed. Care should be taken when using this
+    * method in security sensitive applications.
+    */
+  def exists(path: Path, flags: Seq[LinkOption] = Seq.empty): F[Boolean]
+
+  /**
+    * Moves (or renames) a file from the source to the target path.
+    *
+    * By default, the move fails if the target file already exists or is a symbolic link.
+    */
+  def move(source: Path, target: Path, flags: Seq[CopyOption] = Seq.empty): F[Path]
+
+  /** Creates a `FileHandle` for the file at the supplied `Path`. */
+  def openPath(path: Path, flags: Seq[OpenOption]): Resource[F, FileHandle[F]]
+
+  /** Creates a `FileHandle` for the supplied `FileChannel`. */
+  def openFileChannel(channel: F[FileChannel]): Resource[F, FileHandle[F]]
+
+  /**
+    * Get file permissions as set of [[PosixFilePermission]].
+    *
+    * Note: this will only work for POSIX supporting file systems.
+    */
+  def permissions(path: Path, flags: Seq[LinkOption] = Seq.empty): F[Set[PosixFilePermission]]
+
+  /**
+    * Reads all data from the file at the specified `java.nio.file.Path`.
+    */
+  def readAll(path: Path, chunkSize: Int): Stream[F, Byte]
+
+  /**
+    * Reads a range of data synchronously from the file at the specified `java.nio.file.Path`.
+    * `start` is inclusive, `end` is exclusive, so when `start` is 0 and `end` is 2,
+    * two bytes are read.
+    */
+  def readRange(path: Path, chunkSize: Int, start: Long, end: Long): Stream[F, Byte]
+
+  /**
+    * Set file permissions from set of [[PosixFilePermission]].
+    *
+    * Note: this will only work for POSIX supporting file systems.
+    */
+  def setPermissions(path: Path, permissions: Set[PosixFilePermission]): F[Path]
+
+  /**
+    * Returns the size of a file (in bytes).
+    */
+  def size(path: Path): F[Long]
+
+  /**
+    * Creates a stream containing the path of a temporary file.
+    *
+    * The temporary file is removed when the stream completes.
+    */
+  def tempFileStream(
+      dir: Path,
+      prefix: String = "",
+      suffix: String = ".tmp",
+      attributes: Seq[FileAttribute[_]] = Seq.empty
+  ): Stream[F, Path]
+
+  /**
+    * Creates a resource containing the path of a temporary file.
+    *
+    * The temporary file is removed during the resource release.
+    */
+  def tempFileResource(
+      dir: Path,
+      prefix: String = "",
+      suffix: String = ".tmp",
+      attributes: Seq[FileAttribute[_]] = Seq.empty
+  ): Resource[F, Path]
+
+  /**
+    * Creates a stream containing the path of a temporary directory.
+    *
+    * The temporary directory is removed when the stream completes.
+    */
+  def tempDirectoryStream(
+      dir: Path,
+      prefix: String = "",
+      attributes: Seq[FileAttribute[_]] = Seq.empty
+  ): Stream[F, Path]
+
+  /**
+    * Creates a resource containing the path of a temporary directory.
+    *
+    * The temporary directory is removed during the resource release.
+    */
+  def tempDirectoryResource(
+      dir: Path,
+      prefix: String = "",
+      attributes: Seq[FileAttribute[_]] = Seq.empty
+  ): Resource[F, Path]
+
+  /**
+    * Creates a stream of [[Path]]s contained in a given file tree. Depth is unlimited.
+    */
+  def walk(start: Path): Stream[F, Path]
+
+  /**
+    * Creates a stream of [[Path]]s contained in a given file tree, respecting the supplied options. Depth is unlimited.
+    */
+  def walk(start: Path, options: Seq[FileVisitOption]): Stream[F, Path]
+
+  /**
+    * Creates a stream of [[Path]]s contained in a given file tree down to a given depth.
+    */
+  def walk(start: Path, maxDepth: Int, options: Seq[FileVisitOption] = Seq.empty): Stream[F, Path]
+
+  /**
+    * Writes all data to the file at the specified `java.nio.file.Path`.
+    *
+    * Adds the WRITE flag to any other `OpenOption` flags specified. By default, also adds the CREATE flag.
+    */
+  def writeAll(
+      path: Path,
+      flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
+  ): Pipe[F, Byte, INothing]
+}
+
+object BaseFiles {
+  def apply[F[_]](implicit F: BaseFiles[F]): F.type = F
+
+  implicit def forSync[F[_]: Sync]: BaseFiles[F] = new SyncBaseFiles[F]
+
+  private[file] class SyncBaseFiles[F[_]: Sync] extends BaseFiles[F] {
+
+    def copy(source: Path, target: Path, flags: Seq[CopyOption]): F[Path] =
+      Sync[F].blocking(JFiles.copy(source, target, flags: _*))
+
+    def createDirectory(path: Path, flags: Seq[FileAttribute[_]]): F[Path] =
+      Sync[F].blocking(JFiles.createDirectory(path, flags: _*))
+
+    def createDirectories(path: Path, flags: Seq[FileAttribute[_]]): F[Path] =
+      Sync[F].blocking(JFiles.createDirectories(path, flags: _*))
+
+    def delete(path: Path): F[Unit] =
+      Sync[F].blocking(JFiles.delete(path))
+
+    def deleteIfExists(path: Path): F[Boolean] =
+      Sync[F].blocking(JFiles.deleteIfExists(path))
+
+    def deleteDirectoryRecursively(
+        path: Path,
+        options: Set[FileVisitOption]
+    ): F[Unit] =
+      Sync[F].blocking {
+        JFiles.walkFileTree(
+          path,
+          options.asJava,
+          Int.MaxValue,
+          new SimpleFileVisitor[Path] {
+            override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
+              JFiles.deleteIfExists(path)
+              FileVisitResult.CONTINUE
+            }
+            override def postVisitDirectory(path: Path, e: IOException): FileVisitResult = {
+              JFiles.deleteIfExists(path)
+              FileVisitResult.CONTINUE
+            }
+          }
+        )
+        ()
+      }
+
+    def directoryStream(path: Path): Stream[F, Path] =
+      _runJavaCollectionResource[DirectoryStream[Path]](
+        Sync[F].blocking(JFiles.newDirectoryStream(path)),
+        _.asScala.iterator
+      )
+
+    def directoryStream(path: Path, filter: Path => Boolean): Stream[F, Path] =
+      _runJavaCollectionResource[DirectoryStream[Path]](
+        Sync[F].blocking(JFiles.newDirectoryStream(path, (entry: Path) => filter(entry))),
+        _.asScala.iterator
+      )
+
+    def directoryStream(path: Path, glob: String): Stream[F, Path] =
+      _runJavaCollectionResource[DirectoryStream[Path]](
+        Sync[F].blocking(JFiles.newDirectoryStream(path, glob)),
+        _.asScala.iterator
+      )
+
+    private final val pathStreamChunkSize = 16
+    private def _runJavaCollectionResource[C <: AutoCloseable](
+        javaCollection: F[C],
+        collectionIterator: C => Iterator[Path]
+    ): Stream[F, Path] =
+      Stream
+        .resource(Resource.fromAutoCloseable(javaCollection))
+        .flatMap(ds => Stream.fromBlockingIterator[F](collectionIterator(ds), pathStreamChunkSize))
+
+    def exists(path: Path, flags: Seq[LinkOption]): F[Boolean] =
+      Sync[F].blocking(JFiles.exists(path, flags: _*))
+
+    def move(source: Path, target: Path, flags: Seq[CopyOption]): F[Path] =
+      Sync[F].blocking(JFiles.move(source, target, flags: _*))
+
+    def openPath(path: Path, flags: Seq[OpenOption]): Resource[F, FileHandle[F]] =
+      FileHandle.fromPath(path, flags)
+
+    def openFileChannel(channel: F[FileChannel]): Resource[F, FileHandle[F]] =
+      FileHandle.fromFileChannel(channel)
+
+    def permissions(path: Path, flags: Seq[LinkOption]): F[Set[PosixFilePermission]] =
+      Sync[F].blocking(JFiles.getPosixFilePermissions(path, flags: _*).asScala)
+
+    def readAll(path: Path, chunkSize: Int): Stream[F, Byte] =
+      Stream.resource(ReadCursor.fromPath(path)).flatMap { cursor =>
+        cursor.readAll(chunkSize).void.stream
+      }
+
+    def readRange(path: Path, chunkSize: Int, start: Long, end: Long): Stream[F, Byte] =
+      Stream.resource(ReadCursor.fromPath(path)).flatMap { cursor =>
+        cursor.seek(start).readUntil(chunkSize, end).void.stream
+      }
+
+    def setPermissions(path: Path, permissions: Set[PosixFilePermission]): F[Path] =
+      Sync[F].blocking(JFiles.setPosixFilePermissions(path, permissions.asJava))
+
+    def size(path: Path): F[Long] =
+      Sync[F].blocking(JFiles.size(path))
+
+    def tempFileStream(
+        dir: Path,
+        prefix: String,
+        suffix: String,
+        attributes: Seq[FileAttribute[_]]
+    ): Stream[F, Path] =
+      Stream.resource(tempFileResource(dir, prefix, suffix, attributes))
+
+    def tempFileResource(
+        dir: Path,
+        prefix: String,
+        suffix: String,
+        attributes: Seq[FileAttribute[_]]
+    ): Resource[F, Path] =
+      Resource.make {
+        Sync[F].blocking(JFiles.createTempFile(dir, prefix, suffix, attributes: _*))
+      }(deleteIfExists(_).void)
+
+    def tempDirectoryStream(
+        dir: Path,
+        prefix: String,
+        attributes: Seq[FileAttribute[_]]
+    ): Stream[F, Path] =
+      Stream.resource(tempDirectoryResource(dir, prefix, attributes))
+
+    def tempDirectoryResource(
+        dir: Path,
+        prefix: String,
+        attributes: Seq[FileAttribute[_]]
+    ): Resource[F, Path] =
+      Resource.make {
+        Sync[F].blocking(JFiles.createTempDirectory(dir, prefix, attributes: _*))
+      } { p =>
+        deleteDirectoryRecursively(p)
+          .recover { case _: NoSuchFileException => () }
+      }
+
+    def walk(start: Path): Stream[F, Path] =
+      walk(start, Seq.empty)
+
+    def walk(start: Path, options: Seq[FileVisitOption]): Stream[F, Path] =
+      walk(start, Int.MaxValue, options)
+
+    def walk(start: Path, maxDepth: Int, options: Seq[FileVisitOption]): Stream[F, Path] =
+      _runJavaCollectionResource[JStream[Path]](
+        Sync[F].blocking(JFiles.walk(start, maxDepth, options: _*)),
+        _.iterator.asScala
+      )
+
+    def writeAll(
+        path: Path,
+        flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
+    ): Pipe[F, Byte, INothing] =
+      in =>
+        Stream
+          .resource(WriteCursor.fromPath(path, flags))
+          .flatMap(_.writeAll(in).void.stream)
+
+  }
+}
+
+trait Files[F[_]] extends BaseFiles[F] {
+
+  /**
+    * Returns an infinite stream of data from the file at the specified path.
+    * Starts reading from the specified offset and upon reaching the end of the file,
+    * polls every `pollDuration` for additional updates to the file.
+    *
+    * Read operations are limited to emitting chunks of the specified chunk size
+    * but smaller chunks may occur.
+    *
+    * If an error occurs while reading from the file, the overall stream fails.
+    */
+  def tail(
+      path: Path,
+      chunkSize: Int,
+      offset: Long = 0L,
+      pollDelay: FiniteDuration = 1.second
+  ): Stream[F, Byte]
+
+  /**
+    * Creates a [[Watcher]] for the default file system.
+    *
+    * The watcher is returned as a resource. To use the watcher, lift the resource to a stream,
+    * watch or register 1 or more paths, and then return `watcher.events()`.
+    */
+  def watcher: Resource[F, Watcher[F]]
+
+  /**
+    * Watches a single path.
+    *
+    * Alias for creating a watcher and watching the supplied path, releasing the watcher when the resulting stream is finalized.
+    */
+  def watch(
+      path: Path,
+      types: Seq[Watcher.EventType] = Nil,
+      modifiers: Seq[WatchEvent.Modifier] = Nil,
+      pollTimeout: FiniteDuration = 1.second
+  ): Stream[F, Watcher.Event]
+
+  /**
+    * Writes all data to a sequence of files, each limited in size to `limit`.
+    *
+    * The `computePath` operation is used to compute the path of the first file
+    * and every subsequent file. Typically, the next file should be determined
+    * by analyzing the current state of the filesystem -- e.g., by looking at all
+    * files in a directory and generating a unique name.
+    */
+  def writeRotate(
+      computePath: F[Path],
+      limit: Long,
+      flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
+  ): Pipe[F, Byte, INothing]
+}
+
+object Files {
+  def apply[F[_]](implicit F: Files[F]): F.type = F
+
+  implicit def forAync[F[_]: Async]: Files[F] = new AsyncBaseFiles[F]
+
+  private final class AsyncBaseFiles[F[_]: Async]
+      extends BaseFiles.SyncBaseFiles[F]
+      with Files[F] {
+
+    def tail(path: Path, chunkSize: Int, offset: Long, pollDelay: FiniteDuration): Stream[F, Byte] =
+      Stream.resource(ReadCursor.fromPath(path)).flatMap { cursor =>
+        cursor.seek(offset).tail(chunkSize, pollDelay).void.stream
+      }
+
+    def watcher: Resource[F, Watcher[F]] = Watcher.default
+
+    def watch(
+        path: Path,
+        types: Seq[Watcher.EventType],
+        modifiers: Seq[WatchEvent.Modifier],
+        pollTimeout: FiniteDuration
+    ): Stream[F, Watcher.Event] =
+      Stream
+        .resource(Watcher.default)
+        .evalTap(_.watch(path, types, modifiers))
+        .flatMap(_.events(pollTimeout))
+
+    def writeRotate(
+        computePath: F[Path],
+        limit: Long,
+        flags: Seq[StandardOpenOption]
+    ): Pipe[F, Byte, INothing] = {
+      def openNewFile: Resource[F, FileHandle[F]] =
+        Resource
+          .liftF(computePath)
+          .flatMap(p => FileHandle.fromPath(p, StandardOpenOption.WRITE :: flags.toList))
+
+      def newCursor(file: FileHandle[F]): F[WriteCursor[F]] =
+        WriteCursor.fromFileHandle[F](file, flags.contains(StandardOpenOption.APPEND))
+
+      def go(
+          fileHotswap: Hotswap[F, FileHandle[F]],
+          cursor: WriteCursor[F],
+          acc: Long,
+          s: Stream[F, Byte]
+      ): Pull[F, Unit, Unit] = {
+        val toWrite = (limit - acc).min(Int.MaxValue.toLong).toInt
+        s.pull.unconsLimit(toWrite).flatMap {
+          case Some((hd, tl)) =>
+            val newAcc = acc + hd.size
+            cursor.writePull(hd).flatMap { nc =>
+              if (newAcc >= limit)
+                Pull
+                  .eval {
+                    fileHotswap
+                      .swap(openNewFile)
+                      .flatMap(newCursor)
+                  }
+                  .flatMap(nc => go(fileHotswap, nc, 0L, tl))
+              else
+                go(fileHotswap, nc, newAcc, tl)
+            }
+          case None => Pull.done
+        }
+      }
+
+      in =>
+        Stream
+          .resource(Hotswap(openNewFile))
+          .flatMap { case (fileHotswap, fileHandle) =>
+            Stream.eval(newCursor(fileHandle)).flatMap { cursor =>
+              go(fileHotswap, cursor, 0L, in).stream.drain
+            }
+          }
+    }
+  }
+
+}

--- a/io/src/main/scala/fs2/io/file/ReadCursor.scala
+++ b/io/src/main/scala/fs2/io/file/ReadCursor.scala
@@ -109,10 +109,10 @@ final case class ReadCursor[F[_]](file: FileHandle[F], offset: Long) {
 
 object ReadCursor {
 
-  @deprecated("Use BaseFiles[F].readCursor")
+  @deprecated("Use Files[F].readCursor")
   def fromPath[F[_]: Sync](
       path: Path,
       flags: Seq[OpenOption] = Nil
   ): Resource[F, ReadCursor[F]] =
-    BaseFiles[F].readCursor(path, flags)
+    SyncFiles[F].readCursor(path, flags)
 }

--- a/io/src/main/scala/fs2/io/file/ReadCursor.scala
+++ b/io/src/main/scala/fs2/io/file/ReadCursor.scala
@@ -109,14 +109,10 @@ final case class ReadCursor[F[_]](file: FileHandle[F], offset: Long) {
 
 object ReadCursor {
 
-  /**
-    * Returns a `ReadCursor` for the specified path. The `READ` option is added to the supplied flags.
-    */
+  @deprecated("Use BaseFiles[F].readCursor")
   def fromPath[F[_]: Sync](
       path: Path,
       flags: Seq[OpenOption] = Nil
   ): Resource[F, ReadCursor[F]] =
-    FileHandle.fromPath(path, StandardOpenOption.READ :: flags.toList).map { fileHandle =>
-      ReadCursor(fileHandle, 0L)
-    }
+    BaseFiles[F].readCursor(path, flags)
 }

--- a/io/src/main/scala/fs2/io/file/WriteCursor.scala
+++ b/io/src/main/scala/fs2/io/file/WriteCursor.scala
@@ -74,17 +74,17 @@ final case class WriteCursor[F[_]](file: FileHandle[F], offset: Long) {
 
 object WriteCursor {
 
-  @deprecated("Use BaseFiles[F].writeCursor")
+  @deprecated("Use Files[F].writeCursor")
   def fromPath[F[_]: Sync](
       path: Path,
       flags: Seq[OpenOption] = List(StandardOpenOption.CREATE)
   ): Resource[F, WriteCursor[F]] =
-    BaseFiles[F].writeCursor(path, flags)
+    SyncFiles[F].writeCursor(path, flags)
 
-  @deprecated("Use BaseFiles[F].writeCursorFromFileHandle")
+  @deprecated("Use Files[F].writeCursorFromFileHandle")
   def fromFileHandle[F[_]: Sync](
       file: FileHandle[F],
       append: Boolean
   ): F[WriteCursor[F]] =
-    BaseFiles[F].writeCursorFromFileHandle(file, append)
+    SyncFiles[F].writeCursorFromFileHandle(file, append)
 }

--- a/io/src/main/scala/fs2/io/file/WriteCursor.scala
+++ b/io/src/main/scala/fs2/io/file/WriteCursor.scala
@@ -74,30 +74,17 @@ final case class WriteCursor[F[_]](file: FileHandle[F], offset: Long) {
 
 object WriteCursor {
 
-  /**
-    * Returns a `WriteCursor` for the specified path.
-    *
-    * The `WRITE` option is added to the supplied flags. If the `APPEND` option is present in `flags`,
-    * the offset is initialized to the current size of the file.
-    */
+  @deprecated("Use BaseFiles[F].writeCursor")
   def fromPath[F[_]: Sync](
       path: Path,
       flags: Seq[OpenOption] = List(StandardOpenOption.CREATE)
   ): Resource[F, WriteCursor[F]] =
-    FileHandle.fromPath(path, StandardOpenOption.WRITE :: flags.toList).flatMap { fileHandle =>
-      val size = if (flags.contains(StandardOpenOption.APPEND)) fileHandle.size else 0L.pure[F]
-      val cursor = size.map(s => WriteCursor(fileHandle, s))
-      Resource.liftF(cursor)
-    }
+    BaseFiles[F].writeCursor(path, flags)
 
-  /**
-    * Returns a `WriteCursor` for the specified file handle.
-    *
-    * If `append` is true, the offset is initialized to the current size of the file.
-    */
+  @deprecated("Use BaseFiles[F].writeCursorFromFileHandle")
   def fromFileHandle[F[_]: Sync](
       file: FileHandle[F],
       append: Boolean
   ): F[WriteCursor[F]] =
-    if (append) file.size.map(s => WriteCursor(file, s)) else WriteCursor(file, 0L).pure[F]
+    BaseFiles[F].writeCursorFromFileHandle(file, append)
 }

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -37,24 +37,24 @@ import scala.concurrent.duration._
 /** Provides support for working with files. */
 package object file {
 
-  @deprecated("Use BaseFiles[F].readAll")
+  @deprecated("Use Files[F].readAll")
   def readAll[F[_]: Sync](
       path: Path,
       chunkSize: Int
-  ): Stream[F, Byte] = BaseFiles[F].readAll(path, chunkSize)
+  ): Stream[F, Byte] = SyncFiles[F].readAll(path, chunkSize)
 
   /**
     * Reads a range of data synchronously from the file at the specified `java.nio.file.Path`.
     * `start` is inclusive, `end` is exclusive, so when `start` is 0 and `end` is 2,
     * two bytes are read.
     */
-  @deprecated("Use BaseFiles[F].readRange")
+  @deprecated("Use Files[F].readRange")
   def readRange[F[_]: Sync](
       path: Path,
       chunkSize: Int,
       start: Long,
       end: Long
-  ): Stream[F, Byte] = BaseFiles[F].readRange(path, chunkSize, start, end)
+  ): Stream[F, Byte] = SyncFiles[F].readRange(path, chunkSize, start, end)
 
   /**
     * Returns an infinite stream of data from the file at the specified path.
@@ -79,11 +79,11 @@ package object file {
     *
     * Adds the WRITE flag to any other `OpenOption` flags specified. By default, also adds the CREATE flag.
     */
-  @deprecated("Use BaseFiles[F].writeAll")
+  @deprecated("Use Files[F].writeAll")
   def writeAll[F[_]: Sync](
       path: Path,
       flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
-  ): Pipe[F, Byte, INothing] = BaseFiles[F].writeAll(path, flags)
+  ): Pipe[F, Byte, INothing] = SyncFiles[F].writeAll(path, flags)
 
   /**
     * Writes all data to a sequence of files, each limited in size to `limit`.
@@ -133,49 +133,49 @@ package object file {
     * subsequence access will succeed. Care should be taken when using this
     * method in security sensitive applications.
     */
-  @deprecated("Use BaseFiles[F].exists")
+  @deprecated("Use Files[F].exists")
   def exists[F[_]: Sync](
       path: Path,
       flags: Seq[LinkOption] = Seq.empty
   ): F[Boolean] =
-    BaseFiles[F].exists(path, flags)
+    SyncFiles[F].exists(path, flags)
 
   /**
     * Get file permissions as set of [[PosixFilePermission]]
     *
     * This will only work for POSIX supporting file systems
     */
-  @deprecated("Use BaseFiles[F].permissions")
+  @deprecated("Use Files[F].permissions")
   def permissions[F[_]: Sync](
       path: Path,
       flags: Seq[LinkOption] = Seq.empty
   ): F[Set[PosixFilePermission]] =
-    BaseFiles[F].permissions(path, flags)
+    SyncFiles[F].permissions(path, flags)
 
   /**
     * Set file permissions from set of [[PosixFilePermission]]
     *
     * This will only work for POSIX supporting file systems
     */
-  @deprecated("Use BaseFiles[F].setPermissions")
+  @deprecated("Use Files[F].setPermissions")
   def setPermissions[F[_]: Sync](
       path: Path,
       permissions: Set[PosixFilePermission]
   ): F[Path] =
-    BaseFiles[F].setPermissions(path, permissions)
+    SyncFiles[F].setPermissions(path, permissions)
 
   /**
     * Copies a file from the source to the target path,
     *
     * By default, the copy fails if the target file already exists or is a symbolic link.
     */
-  @deprecated("Use BaseFiles[F].copy")
+  @deprecated("Use Files[F].copy")
   def copy[F[_]: Sync](
       source: Path,
       target: Path,
       flags: Seq[CopyOption] = Seq.empty
   ): F[Path] =
-    BaseFiles[F].copy(source, target, flags)
+    SyncFiles[F].copy(source, target, flags)
 
   /**
     * Deletes a file.
@@ -183,173 +183,173 @@ package object file {
     * If the file is a directory then the directory must be empty for this action to succeed.
     * This action will fail if the path doesn't exist.
     */
-  @deprecated("Use BaseFiles[F].delete")
+  @deprecated("Use Files[F].delete")
   def delete[F[_]: Sync](path: Path): F[Unit] =
-    BaseFiles[F].delete(path)
+    SyncFiles[F].delete(path)
 
   /**
     * Like `delete`, but will not fail when the path doesn't exist.
     */
-  @deprecated("Use BaseFiles[F].deleteIfExists")
+  @deprecated("Use Files[F].deleteIfExists")
   def deleteIfExists[F[_]: Sync](path: Path): F[Boolean] =
-    BaseFiles[F].deleteIfExists(path)
+    SyncFiles[F].deleteIfExists(path)
 
   /**
     * Recursively delete a directory
     */
-  @deprecated("Use BaseFiles[F].deleteDirectoryRecursively")
+  @deprecated("Use Files[F].deleteDirectoryRecursively")
   def deleteDirectoryRecursively[F[_]: Sync](
       path: Path,
       options: Set[FileVisitOption] = Set.empty
   ): F[Unit] =
-    BaseFiles[F].deleteDirectoryRecursively(path, options)
+    SyncFiles[F].deleteDirectoryRecursively(path, options)
 
   /**
     * Returns the size of a file (in bytes).
     */
-  @deprecated("Use BaseFiles[F].size")
+  @deprecated("Use Files[F].size")
   def size[F[_]: Sync](path: Path): F[Long] =
-    BaseFiles[F].size(path)
+    SyncFiles[F].size(path)
 
   /**
     * Moves (or renames) a file from the source to the target path.
     *
     * By default, the move fails if the target file already exists or is a symbolic link.
     */
-  @deprecated("Use BaseFiles[F].move")
+  @deprecated("Use Files[F].move")
   def move[F[_]: Sync](
       source: Path,
       target: Path,
       flags: Seq[CopyOption] = Seq.empty
   ): F[Path] =
-    BaseFiles[F].move(source, target, flags)
+    SyncFiles[F].move(source, target, flags)
 
   /**
     * Creates a stream containing the path of a temporary file.
     *
     * The temporary file is removed when the stream completes.
     */
-  @deprecated("Use Stream.resource(BaseFiles[F].tempFile(..))")
+  @deprecated("Use Stream.resource(Files[F].tempFile(..))")
   def tempFileStream[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       suffix: String = ".tmp",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Stream[F, Path] =
-    Stream.resource(BaseFiles[F].tempFile(dir, prefix, suffix, attributes))
+    Stream.resource(SyncFiles[F].tempFile(dir, prefix, suffix, attributes))
 
   /**
     * Creates a resource containing the path of a temporary file.
     *
     * The temporary file is removed during the resource release.
     */
-  @deprecated("Use BaseFiles[F].tempFile")
+  @deprecated("Use Files[F].tempFile")
   def tempFileResource[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       suffix: String = ".tmp",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, Path] =
-    BaseFiles[F].tempFile(dir, prefix, suffix, attributes)
+    SyncFiles[F].tempFile(dir, prefix, suffix, attributes)
 
   /**
     * Creates a stream containing the path of a temporary directory.
     *
     * The temporary directory is removed when the stream completes.
     */
-  @deprecated("Use Stream.resource(BaseFiles[F].tempDirectory(..))")
+  @deprecated("Use Stream.resource(SyncFiles[F].tempDirectory(..))")
   def tempDirectoryStream[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Stream[F, Path] =
-    Stream.resource(BaseFiles[F].tempDirectory(dir, prefix, attributes))
+    Stream.resource(SyncFiles[F].tempDirectory(dir, prefix, attributes))
 
   /**
     * Creates a resource containing the path of a temporary directory.
     *
     * The temporary directory is removed during the resource release.
     */
-  @deprecated("Use BaseFiles[F].tempDirectory")
+  @deprecated("Use Files[F].tempDirectory")
   def tempDirectoryResource[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, Path] =
-    BaseFiles[F].tempDirectory(dir, prefix, attributes)
+    SyncFiles[F].tempDirectory(dir, prefix, attributes)
 
   /**
     * Creates a new directory at the given path
     */
-  @deprecated("Use BaseFiles[F].createDirectory")
+  @deprecated("Use Files[F].createDirectory")
   def createDirectory[F[_]: Sync](
       path: Path,
       flags: Seq[FileAttribute[_]] = Seq.empty
   ): F[Path] =
-    BaseFiles[F].createDirectory(path, flags)
+    SyncFiles[F].createDirectory(path, flags)
 
   /**
     * Creates a new directory at the given path and creates all nonexistent parent directories beforehand.
     */
-  @deprecated("Use BaseFiles[F].createDirectories")
+  @deprecated("Use Files[F].createDirectories")
   def createDirectories[F[_]: Sync](
       path: Path,
       flags: Seq[FileAttribute[_]] = Seq.empty
   ): F[Path] =
-    BaseFiles[F].createDirectories(path, flags)
+    SyncFiles[F].createDirectories(path, flags)
 
   /**
     * Creates a stream of [[Path]]s inside a directory.
     */
-  @deprecated("Use BaseFiles[F].directoryStream")
+  @deprecated("Use Files[F].directoryStream")
   def directoryStream[F[_]: Sync](path: Path): Stream[F, Path] =
-    BaseFiles[F].directoryStream(path)
+    SyncFiles[F].directoryStream(path)
 
   /**
     * Creates a stream of [[Path]]s inside a directory, filtering the results by the given predicate.
     */
-  @deprecated("Use BaseFiles[F].directoryStream")
+  @deprecated("Use Files[F].directoryStream")
   def directoryStream[F[_]: Sync](
       path: Path,
       filter: Path => Boolean
   ): Stream[F, Path] =
-    BaseFiles[F].directoryStream(path, filter)
+    SyncFiles[F].directoryStream(path, filter)
 
   /**
     * Creates a stream of [[Path]]s inside a directory which match the given glob.
     */
-  @deprecated("Use BaseFiles[F].directoryStream")
+  @deprecated("Use Files[F].directoryStream")
   def directoryStream[F[_]: Sync](
       path: Path,
       glob: String
   ): Stream[F, Path] =
-    BaseFiles[F].directoryStream(path, glob)
+    SyncFiles[F].directoryStream(path, glob)
 
   /**
     * Creates a stream of [[Path]]s contained in a given file tree. Depth is unlimited.
     */
-  @deprecated("Use BaseFiles[F].walk")
+  @deprecated("Use Files[F].walk")
   def walk[F[_]: Sync](start: Path): Stream[F, Path] =
-    BaseFiles[F].walk(start)
+    SyncFiles[F].walk(start)
 
   /**
     * Creates a stream of [[Path]]s contained in a given file tree, respecting the supplied options. Depth is unlimited.
     */
-  @deprecated("Use BaseFiles[F].walk")
+  @deprecated("Use Files[F].walk")
   def walk[F[_]: Sync](
       start: Path,
       options: Seq[FileVisitOption]
   ): Stream[F, Path] =
-    BaseFiles[F].walk(start, options)
+    SyncFiles[F].walk(start, options)
 
   /**
     * Creates a stream of [[Path]]s contained in a given file tree down to a given depth.
     */
-  @deprecated("Use BaseFiles[F].walk")
+  @deprecated("Use Files[F].walk")
   def walk[F[_]: Sync](
       start: Path,
       maxDepth: Int,
       options: Seq[FileVisitOption] = Seq.empty
   ): Stream[F, Path] =
-    BaseFiles[F].walk(start, maxDepth, options)
+    SyncFiles[F].walk(start, maxDepth, options)
 }

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -23,7 +23,7 @@ package fs2
 package io
 
 import java.io.IOException
-import java.nio.file._
+import java.nio.file.{Files => _, _}
 import java.nio.file.attribute.{BasicFileAttributes, FileAttribute, PosixFilePermission}
 import java.util.stream.{Stream => JStream}
 
@@ -37,31 +37,24 @@ import scala.concurrent.duration._
 /** Provides support for working with files. */
 package object file {
 
-  /**
-    * Reads all data synchronously from the file at the specified `java.nio.file.Path`.
-    */
+  @deprecated("Use BaseFiles[F].readAll")
   def readAll[F[_]: Sync](
       path: Path,
       chunkSize: Int
-  ): Stream[F, Byte] =
-    Stream.resource(ReadCursor.fromPath(path)).flatMap { cursor =>
-      cursor.readAll(chunkSize).void.stream
-    }
+  ): Stream[F, Byte] = BaseFiles[F].readAll(path, chunkSize)
 
   /**
     * Reads a range of data synchronously from the file at the specified `java.nio.file.Path`.
     * `start` is inclusive, `end` is exclusive, so when `start` is 0 and `end` is 2,
     * two bytes are read.
     */
+  @deprecated("Use BaseFiles[F].readRange")
   def readRange[F[_]: Sync](
       path: Path,
       chunkSize: Int,
       start: Long,
       end: Long
-  ): Stream[F, Byte] =
-    Stream.resource(ReadCursor.fromPath(path)).flatMap { cursor =>
-      cursor.seek(start).readUntil(chunkSize, end).void.stream
-    }
+  ): Stream[F, Byte] = BaseFiles[F].readRange(path, chunkSize, start, end)
 
   /**
     * Returns an infinite stream of data from the file at the specified path.
@@ -73,29 +66,24 @@ package object file {
     *
     * If an error occurs while reading from the file, the overall stream fails.
     */
-  def tail[F[_]: Sync: Temporal](
+  @deprecated("Use Files[F].tail")
+  def tail[F[_]: Async](
       path: Path,
       chunkSize: Int,
       offset: Long = 0L,
       pollDelay: FiniteDuration = 1.second
-  ): Stream[F, Byte] =
-    Stream.resource(ReadCursor.fromPath(path)).flatMap { cursor =>
-      cursor.seek(offset).tail(chunkSize, pollDelay).void.stream
-    }
+  ): Stream[F, Byte] = Files[F].tail(path, chunkSize, offset, pollDelay)
 
   /**
     * Writes all data to the file at the specified `java.nio.file.Path`.
     *
     * Adds the WRITE flag to any other `OpenOption` flags specified. By default, also adds the CREATE flag.
     */
+  @deprecated("Use BaseFiles[F].writeAll")
   def writeAll[F[_]: Sync](
       path: Path,
       flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
-  ): Pipe[F, Byte, INothing] =
-    in =>
-      Stream
-        .resource(WriteCursor.fromPath(path, flags))
-        .flatMap(_.writeAll(in).void.stream)
+  ): Pipe[F, Byte, INothing] = BaseFiles[F].writeAll(path, flags)
 
   /**
     * Writes all data to a sequence of files, each limited in size to `limit`.
@@ -105,54 +93,13 @@ package object file {
     * by analyzing the current state of the filesystem -- e.g., by looking at all
     * files in a directory and generating a unique name.
     */
+  @deprecated("Use Files[F].writeRotate")
   def writeRotate[F[_]](
       computePath: F[Path],
       limit: Long,
       flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
-  )(implicit F: Async[F]): Pipe[F, Byte, INothing] = {
-    def openNewFile: Resource[F, FileHandle[F]] =
-      Resource
-        .liftF(computePath)
-        .flatMap(p => FileHandle.fromPath(p, StandardOpenOption.WRITE :: flags.toList))
-
-    def newCursor(file: FileHandle[F]): F[WriteCursor[F]] =
-      WriteCursor.fromFileHandle[F](file, flags.contains(StandardOpenOption.APPEND))
-
-    def go(
-        fileHotswap: Hotswap[F, FileHandle[F]],
-        cursor: WriteCursor[F],
-        acc: Long,
-        s: Stream[F, Byte]
-    ): Pull[F, Unit, Unit] = {
-      val toWrite = (limit - acc).min(Int.MaxValue.toLong).toInt
-      s.pull.unconsLimit(toWrite).flatMap {
-        case Some((hd, tl)) =>
-          val newAcc = acc + hd.size
-          cursor.writePull(hd).flatMap { nc =>
-            if (newAcc >= limit)
-              Pull
-                .eval {
-                  fileHotswap
-                    .swap(openNewFile)
-                    .flatMap(newCursor)
-                }
-                .flatMap(nc => go(fileHotswap, nc, 0L, tl))
-            else
-              go(fileHotswap, nc, newAcc, tl)
-          }
-        case None => Pull.done
-      }
-    }
-
-    in =>
-      Stream
-        .resource(Hotswap(openNewFile))
-        .flatMap { case (fileHotswap, fileHandle) =>
-          Stream.eval(newCursor(fileHandle)).flatMap { cursor =>
-            go(fileHotswap, cursor, 0L, in).stream.drain
-          }
-        }
-  }
+  )(implicit F: Async[F]): Pipe[F, Byte, INothing] =
+    Files[F].writeRotate(computePath, limit, flags)
 
   /**
     * Creates a [[Watcher]] for the default file system.
@@ -160,24 +107,23 @@ package object file {
     * The watcher is returned as a resource. To use the watcher, lift the resource to a stream,
     * watch or register 1 or more paths, and then return `watcher.events()`.
     */
+  @deprecated("Use Files[F].watcher")
   def watcher[F[_]](implicit F: Async[F]): Resource[F, Watcher[F]] =
-    Watcher.default
+    Files[F].watcher
 
   /**
     * Watches a single path.
     *
     * Alias for creating a watcher and watching the supplied path, releasing the watcher when the resulting stream is finalized.
     */
+  @deprecated("Use Files[F].watch")
   def watch[F[_]](
       path: Path,
       types: Seq[Watcher.EventType] = Nil,
       modifiers: Seq[WatchEvent.Modifier] = Nil,
       pollTimeout: FiniteDuration = 1.second
   )(implicit F: Async[F]): Stream[F, Watcher.Event] =
-    Stream
-      .resource(Watcher.default)
-      .evalTap(_.watch(path, types, modifiers))
-      .flatMap(_.events(pollTimeout))
+    Files[F].watch(path, types, modifiers, pollTimeout)
 
   /**
     * Checks if a file exists
@@ -187,45 +133,49 @@ package object file {
     * subsequence access will succeed. Care should be taken when using this
     * method in security sensitive applications.
     */
+  @deprecated("Use BaseFiles[F].exists")
   def exists[F[_]: Sync](
       path: Path,
       flags: Seq[LinkOption] = Seq.empty
   ): F[Boolean] =
-    Sync[F].blocking(Files.exists(path, flags: _*))
+    BaseFiles[F].exists(path, flags)
 
   /**
     * Get file permissions as set of [[PosixFilePermission]]
     *
     * This will only work for POSIX supporting file systems
     */
+  @deprecated("Use BaseFiles[F].permissions")
   def permissions[F[_]: Sync](
       path: Path,
       flags: Seq[LinkOption] = Seq.empty
   ): F[Set[PosixFilePermission]] =
-    Sync[F].blocking(Files.getPosixFilePermissions(path, flags: _*).asScala)
+    BaseFiles[F].permissions(path, flags)
 
   /**
     * Set file permissions from set of [[PosixFilePermission]]
     *
     * This will only work for POSIX supporting file systems
     */
+  @deprecated("Use BaseFiles[F].setPermissions")
   def setPermissions[F[_]: Sync](
       path: Path,
       permissions: Set[PosixFilePermission]
   ): F[Path] =
-    Sync[F].blocking(Files.setPosixFilePermissions(path, permissions.asJava))
+    BaseFiles[F].setPermissions(path, permissions)
 
   /**
     * Copies a file from the source to the target path,
     *
     * By default, the copy fails if the target file already exists or is a symbolic link.
     */
+  @deprecated("Use BaseFiles[F].copy")
   def copy[F[_]: Sync](
       source: Path,
       target: Path,
       flags: Seq[CopyOption] = Seq.empty
   ): F[Path] =
-    Sync[F].blocking(Files.copy(source, target, flags: _*))
+    BaseFiles[F].copy(source, target, flags)
 
   /**
     * Deletes a file.
@@ -233,202 +183,173 @@ package object file {
     * If the file is a directory then the directory must be empty for this action to succeed.
     * This action will fail if the path doesn't exist.
     */
+  @deprecated("Use BaseFiles[F].delete")
   def delete[F[_]: Sync](path: Path): F[Unit] =
-    Sync[F].blocking(Files.delete(path))
+    BaseFiles[F].delete(path)
 
   /**
     * Like `delete`, but will not fail when the path doesn't exist.
     */
+  @deprecated("Use BaseFiles[F].deleteIfExists")
   def deleteIfExists[F[_]: Sync](path: Path): F[Boolean] =
-    Sync[F].blocking(Files.deleteIfExists(path))
+    BaseFiles[F].deleteIfExists(path)
 
   /**
     * Recursively delete a directory
     */
+  @deprecated("Use BaseFiles[F].deleteDirectoryRecursively")
   def deleteDirectoryRecursively[F[_]: Sync](
       path: Path,
       options: Set[FileVisitOption] = Set.empty
   ): F[Unit] =
-    Sync[F].blocking {
-      Files.walkFileTree(
-        path,
-        options.asJava,
-        Int.MaxValue,
-        new SimpleFileVisitor[Path] {
-          override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
-            Files.deleteIfExists(path)
-            FileVisitResult.CONTINUE
-          }
-          override def postVisitDirectory(path: Path, e: IOException): FileVisitResult = {
-            Files.deleteIfExists(path)
-            FileVisitResult.CONTINUE
-          }
-        }
-      )
-      ()
-    }
+    BaseFiles[F].deleteDirectoryRecursively(path, options)
 
   /**
     * Returns the size of a file (in bytes).
     */
+  @deprecated("Use BaseFiles[F].size")
   def size[F[_]: Sync](path: Path): F[Long] =
-    Sync[F].blocking(Files.size(path))
+    BaseFiles[F].size(path)
 
   /**
     * Moves (or renames) a file from the source to the target path.
     *
     * By default, the move fails if the target file already exists or is a symbolic link.
     */
+  @deprecated("Use BaseFiles[F].move")
   def move[F[_]: Sync](
       source: Path,
       target: Path,
       flags: Seq[CopyOption] = Seq.empty
   ): F[Path] =
-    Sync[F].blocking(Files.move(source, target, flags: _*))
+    BaseFiles[F].move(source, target, flags)
 
   /**
     * Creates a stream containing the path of a temporary file.
     *
     * The temporary file is removed when the stream completes.
     */
+  @deprecated("Use BaseFiles[F].tempFileStream")
   def tempFileStream[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       suffix: String = ".tmp",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Stream[F, Path] =
-    Stream.resource(tempFileResource[F](dir, prefix, suffix, attributes))
+    BaseFiles[F].tempFileStream(dir, prefix, suffix, attributes)
 
   /**
     * Creates a resource containing the path of a temporary file.
     *
     * The temporary file is removed during the resource release.
     */
+  @deprecated("Use BaseFiles[F].tempFileResource")
   def tempFileResource[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       suffix: String = ".tmp",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, Path] =
-    Resource.make {
-      Sync[F].blocking(Files.createTempFile(dir, prefix, suffix, attributes: _*))
-    }(deleteIfExists[F](_).void)
+    BaseFiles[F].tempFileResource(dir, prefix, suffix, attributes)
 
   /**
     * Creates a stream containing the path of a temporary directory.
     *
     * The temporary directory is removed when the stream completes.
     */
+  @deprecated("Use BaseFiles[F].tempDirectoryStream")
   def tempDirectoryStream[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Stream[F, Path] =
-    Stream.resource(tempDirectoryResource[F](dir, prefix, attributes))
+    BaseFiles[F].tempDirectoryStream(dir, prefix, attributes)
 
   /**
     * Creates a resource containing the path of a temporary directory.
     *
     * The temporary directory is removed during the resource release.
     */
+  @deprecated("Use BaseFiles[F].tempDirectoryResource")
   def tempDirectoryResource[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, Path] =
-    Resource.make {
-      Sync[F].blocking(Files.createTempDirectory(dir, prefix, attributes: _*))
-    } { p =>
-      deleteDirectoryRecursively[F](p)
-        .recover { case _: NoSuchFileException => () }
-    }
+    BaseFiles[F].tempDirectoryResource(dir, prefix, attributes)
 
   /**
     * Creates a new directory at the given path
     */
+  @deprecated("Use BaseFiles[F].createDirectory")
   def createDirectory[F[_]: Sync](
       path: Path,
       flags: Seq[FileAttribute[_]] = Seq.empty
   ): F[Path] =
-    Sync[F].blocking(Files.createDirectory(path, flags: _*))
+    BaseFiles[F].createDirectory(path, flags)
 
   /**
     * Creates a new directory at the given path and creates all nonexistent parent directories beforehand.
     */
+  @deprecated("Use BaseFiles[F].createDirectories")
   def createDirectories[F[_]: Sync](
       path: Path,
       flags: Seq[FileAttribute[_]] = Seq.empty
   ): F[Path] =
-    Sync[F].blocking(Files.createDirectories(path, flags: _*))
+    BaseFiles[F].createDirectories(path, flags)
 
   /**
     * Creates a stream of [[Path]]s inside a directory.
     */
+  @deprecated("Use BaseFiles[F].directoryStream")
   def directoryStream[F[_]: Sync](path: Path): Stream[F, Path] =
-    _runJavaCollectionResource[F, DirectoryStream[Path]](
-      Sync[F].blocking(Files.newDirectoryStream(path)),
-      _.asScala.iterator
-    )
+    BaseFiles[F].directoryStream(path)
 
   /**
     * Creates a stream of [[Path]]s inside a directory, filtering the results by the given predicate.
     */
+  @deprecated("Use BaseFiles[F].directoryStream")
   def directoryStream[F[_]: Sync](
       path: Path,
       filter: Path => Boolean
   ): Stream[F, Path] =
-    _runJavaCollectionResource[F, DirectoryStream[Path]](
-      Sync[F].blocking(Files.newDirectoryStream(path, (entry: Path) => filter(entry))),
-      _.asScala.iterator
-    )
+    BaseFiles[F].directoryStream(path, filter)
 
   /**
     * Creates a stream of [[Path]]s inside a directory which match the given glob.
     */
+  @deprecated("Use BaseFiles[F].directoryStream")
   def directoryStream[F[_]: Sync](
       path: Path,
       glob: String
   ): Stream[F, Path] =
-    _runJavaCollectionResource[F, DirectoryStream[Path]](
-      Sync[F].blocking(Files.newDirectoryStream(path, glob)),
-      _.asScala.iterator
-    )
+    BaseFiles[F].directoryStream(path, glob)
 
   /**
     * Creates a stream of [[Path]]s contained in a given file tree. Depth is unlimited.
     */
+  @deprecated("Use BaseFiles[F].walk")
   def walk[F[_]: Sync](start: Path): Stream[F, Path] =
-    walk[F](start, Seq.empty)
+    BaseFiles[F].walk(start)
 
   /**
     * Creates a stream of [[Path]]s contained in a given file tree, respecting the supplied options. Depth is unlimited.
     */
+  @deprecated("Use BaseFiles[F].walk")
   def walk[F[_]: Sync](
       start: Path,
       options: Seq[FileVisitOption]
   ): Stream[F, Path] =
-    walk[F](start, Int.MaxValue, options)
+    BaseFiles[F].walk(start, options)
 
   /**
     * Creates a stream of [[Path]]s contained in a given file tree down to a given depth.
     */
+  @deprecated("Use BaseFiles[F].walk")
   def walk[F[_]: Sync](
       start: Path,
       maxDepth: Int,
       options: Seq[FileVisitOption] = Seq.empty
   ): Stream[F, Path] =
-    _runJavaCollectionResource[F, JStream[Path]](
-      Sync[F].blocking(Files.walk(start, maxDepth, options: _*)),
-      _.iterator.asScala
-    )
-
-  private val pathStreamChunkSize = 16
-
-  private def _runJavaCollectionResource[F[_]: Sync, C <: AutoCloseable](
-      javaCollection: F[C],
-      collectionIterator: C => Iterator[Path]
-  ): Stream[F, Path] =
-    Stream
-      .resource(Resource.fromAutoCloseable(javaCollection))
-      .flatMap(ds => Stream.fromBlockingIterator[F](collectionIterator(ds), pathStreamChunkSize))
+    BaseFiles[F].walk(start, maxDepth, options)
 }

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -229,54 +229,54 @@ package object file {
     *
     * The temporary file is removed when the stream completes.
     */
-  @deprecated("Use BaseFiles[F].tempFileStream")
+  @deprecated("Use Stream.resource(BaseFiles[F].tempFile(..))")
   def tempFileStream[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       suffix: String = ".tmp",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Stream[F, Path] =
-    BaseFiles[F].tempFileStream(dir, prefix, suffix, attributes)
+    Stream.resource(BaseFiles[F].tempFile(dir, prefix, suffix, attributes))
 
   /**
     * Creates a resource containing the path of a temporary file.
     *
     * The temporary file is removed during the resource release.
     */
-  @deprecated("Use BaseFiles[F].tempFileResource")
+  @deprecated("Use BaseFiles[F].tempFile")
   def tempFileResource[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       suffix: String = ".tmp",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, Path] =
-    BaseFiles[F].tempFileResource(dir, prefix, suffix, attributes)
+    BaseFiles[F].tempFile(dir, prefix, suffix, attributes)
 
   /**
     * Creates a stream containing the path of a temporary directory.
     *
     * The temporary directory is removed when the stream completes.
     */
-  @deprecated("Use BaseFiles[F].tempDirectoryStream")
+  @deprecated("Use Stream.resource(BaseFiles[F].tempDirectory(..))")
   def tempDirectoryStream[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Stream[F, Path] =
-    BaseFiles[F].tempDirectoryStream(dir, prefix, attributes)
+    Stream.resource(BaseFiles[F].tempDirectory(dir, prefix, attributes))
 
   /**
     * Creates a resource containing the path of a temporary directory.
     *
     * The temporary directory is removed during the resource release.
     */
-  @deprecated("Use BaseFiles[F].tempDirectoryResource")
+  @deprecated("Use BaseFiles[F].tempDirectory")
   def tempDirectoryResource[F[_]: Sync](
       dir: Path,
       prefix: String = "",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, Path] =
-    BaseFiles[F].tempDirectoryResource(dir, prefix, attributes)
+    BaseFiles[F].tempDirectory(dir, prefix, attributes)
 
   /**
     * Creates a new directory at the given path

--- a/io/src/test/scala/fs2/io/file/FileSuite.scala
+++ b/io/src/test/scala/fs2/io/file/FileSuite.scala
@@ -40,7 +40,7 @@ class FileSuite extends BaseFileSuite {
       assert(
         tempFile
           .flatTap(modify)
-          .flatMap(path => file.readAll[IO](path, 4096))
+          .flatMap(path => Files[IO].readAll(path, 4096))
           .compile
           .toList
           .map(_.size)
@@ -54,7 +54,7 @@ class FileSuite extends BaseFileSuite {
       assert(
         tempFile
           .flatTap(modify)
-          .flatMap(path => file.readRange[IO](path, 4096, 0, 2))
+          .flatMap(path => Files[IO].readRange(path, 4096, 0, 2))
           .compile
           .toList
           .map(_.size)
@@ -66,7 +66,7 @@ class FileSuite extends BaseFileSuite {
       assert(
         tempFile
           .flatTap(modify)
-          .flatMap(path => file.readRange[IO](path, 4096, 0, 100))
+          .flatMap(path => Files[IO].readRange(path, 4096, 0, 100))
           .compile
           .toList
           .map(_.size)
@@ -83,8 +83,8 @@ class FileSuite extends BaseFileSuite {
             Stream("Hello", " world!")
               .covary[IO]
               .through(text.utf8Encode)
-              .through(file.writeAll[IO](path)) ++ file
-              .readAll[IO](path, 4096)
+              .through(Files[IO].writeAll(path)) ++ Files[IO]
+              .readAll(path, 4096)
               .through(text.utf8Decode)
           )
           .compile
@@ -98,9 +98,9 @@ class FileSuite extends BaseFileSuite {
         tempFile
           .flatMap { path =>
             val src = Stream("Hello", " world!").covary[IO].through(text.utf8Encode)
-            src.through(file.writeAll[IO](path)) ++
-              src.through(file.writeAll[IO](path, List(StandardOpenOption.APPEND))) ++ file
-                .readAll[IO](path, 4096)
+            src.through(Files[IO].writeAll(path)) ++
+              src.through(Files[IO].writeAll(path, List(StandardOpenOption.APPEND))) ++ Files[IO]
+                .readAll(path, 4096)
                 .through(text.utf8Decode)
           }
           .compile
@@ -115,8 +115,8 @@ class FileSuite extends BaseFileSuite {
       assert(
         tempFile
           .flatMap { path =>
-            file
-              .tail[IO](path, 4096, pollDelay = 25.millis)
+            Files[IO]
+              .tail(path, 4096, pollDelay = 25.millis)
               .concurrently(modifyLater(path))
           }
           .take(4)
@@ -130,12 +130,12 @@ class FileSuite extends BaseFileSuite {
 
   group("exists") {
     test("returns false on a non existent file") {
-      assert(file.exists[IO](Paths.get("nothing")).unsafeRunSync() == false)
+      assert(Files[IO].exists(Paths.get("nothing")).unsafeRunSync() == false)
     }
     test("returns true on an existing file") {
       assert(
         tempFile
-          .evalMap(file.exists[IO](_))
+          .evalMap(Files[IO].exists(_))
           .compile
           .fold(true)(_ && _)
           .unsafeRunSync() == true
@@ -146,8 +146,8 @@ class FileSuite extends BaseFileSuite {
   group("permissions") {
     test("should fail for a non existent file") {
       assert(
-        file
-          .permissions[IO](Paths.get("nothing"))
+        Files[IO]
+          .permissions(Paths.get("nothing"))
           .attempt
           .unsafeRunSync()
           .isLeft == true
@@ -156,7 +156,7 @@ class FileSuite extends BaseFileSuite {
     test("should return permissions for existing file") {
       val permissions = PosixFilePermissions.fromString("rwxrwxr-x").asScala
       tempFile
-        .evalMap(p => file.setPermissions[IO](p, permissions) >> file.permissions[IO](p))
+        .evalMap(p => Files[IO].setPermissions(p, permissions) >> Files[IO].permissions(p))
         .compile
         .lastOrError
         .map(it => assert(it == permissions))
@@ -166,8 +166,8 @@ class FileSuite extends BaseFileSuite {
   group("setPermissions") {
     test("should fail for a non existent file") {
       assert(
-        file
-          .setPermissions[IO](Paths.get("nothing"), Set.empty)
+        Files[IO]
+          .setPermissions(Paths.get("nothing"), Set.empty)
           .attempt
           .unsafeRunSync()
           .isLeft == true
@@ -179,9 +179,9 @@ class FileSuite extends BaseFileSuite {
         tempFile
           .evalMap { p =>
             for {
-              initialPermissions <- file.permissions[IO](p)
-              _ <- file.setPermissions[IO](p, permissions)
-              updatedPermissions <- file.permissions[IO](p)
+              initialPermissions <- Files[IO].permissions(p)
+              _ <- Files[IO].setPermissions(p, permissions)
+              updatedPermissions <- Files[IO].permissions(p)
             } yield (initialPermissions -> updatedPermissions)
           }
           .compile
@@ -199,8 +199,8 @@ class FileSuite extends BaseFileSuite {
         (for {
           filePath <- tempFile
           tempDir <- tempDirectory
-          result <- Stream.eval(file.copy[IO](filePath, tempDir.resolve("newfile")))
-          exists <- Stream.eval(file.exists[IO](result))
+          result <- Stream.eval(Files[IO].copy(filePath, tempDir.resolve("newfile")))
+          exists <- Stream.eval(Files[IO].exists(result))
         } yield exists).compile.fold(true)(_ && _).unsafeRunSync() == true
       )
     }
@@ -210,7 +210,7 @@ class FileSuite extends BaseFileSuite {
     test("should result in non existent file") {
       assert(
         tempFile
-          .flatMap(path => Stream.eval(file.delete[IO](path) *> file.exists[IO](path)))
+          .flatMap(path => Stream.eval(Files[IO].delete(path) *> Files[IO].exists(path)))
           .compile
           .fold(false)(_ || _)
           .unsafeRunSync() == false
@@ -221,8 +221,8 @@ class FileSuite extends BaseFileSuite {
   group("delete") {
     test("should fail on a non existent file") {
       assert(
-        file
-          .delete[IO](Paths.get("nothing"))
+        Files[IO]
+          .delete(Paths.get("nothing"))
           .attempt
           .unsafeRunSync()
           .isLeft == true
@@ -235,9 +235,9 @@ class FileSuite extends BaseFileSuite {
       val testPath = Paths.get("a")
       Stream
         .eval(
-          file.createDirectories[IO](testPath.resolve("b/c")) >>
-            file.deleteDirectoryRecursively[IO](testPath) >>
-            file.exists[IO](testPath)
+          Files[IO].createDirectories(testPath.resolve("b/c")) >>
+            Files[IO].deleteDirectoryRecursively(testPath) >>
+            Files[IO].exists(testPath)
         )
         .compile
         .lastOrError
@@ -251,8 +251,8 @@ class FileSuite extends BaseFileSuite {
         (for {
           filePath <- tempFile
           tempDir <- tempDirectory
-          _ <- Stream.eval(file.move[IO](filePath, tempDir.resolve("newfile")))
-          exists <- Stream.eval(file.exists[IO](filePath))
+          _ <- Stream.eval(Files[IO].move(filePath, tempDir.resolve("newfile")))
+          exists <- Stream.eval(Files[IO].exists(filePath))
         } yield exists).compile.fold(false)(_ || _).unsafeRunSync() == false
       )
     }
@@ -263,7 +263,7 @@ class FileSuite extends BaseFileSuite {
       assert(
         tempFile
           .flatTap(modify)
-          .flatMap(path => Stream.eval(file.size[IO](path)))
+          .flatMap(path => Stream.eval(Files[IO].size(path)))
           .compile
           .lastOrError
           .unsafeRunSync() == 4L
@@ -273,21 +273,21 @@ class FileSuite extends BaseFileSuite {
 
   group("tempFileStream") {
     test("should remove the file following stream closure") {
-      file
-        .tempFileStream[IO](Paths.get(""))
-        .evalMap(path => file.exists[IO](path).map(_ -> path))
+      Files[IO]
+        .tempFileStream(Paths.get(""))
+        .evalMap(path => Files[IO].exists(path).map(_ -> path))
         .compile
         .lastOrError
         .flatMap { case (existsBefore, path) =>
-          file.exists[IO](path).map(existsBefore -> _)
+          Files[IO].exists(path).map(existsBefore -> _)
         }
         .map(it => assert(it == true -> false))
     }
 
     test("should not fail if the file is deleted before the stream completes") {
-      file
-        .tempFileStream[IO](Paths.get(""))
-        .evalMap(path => file.delete[IO](path))
+      Files[IO]
+        .tempFileStream(Paths.get(""))
+        .evalMap(path => Files[IO].delete(path))
         .compile
         .lastOrError
         .attempt
@@ -297,21 +297,21 @@ class FileSuite extends BaseFileSuite {
 
   group("tempDirectoryStream") {
     test("should remove the directory following stream closure") {
-      file
-        .tempDirectoryStream[IO](Paths.get(""))
-        .evalMap(path => file.exists[IO](path).map(_ -> path))
+      Files[IO]
+        .tempDirectoryStream(Paths.get(""))
+        .evalMap(path => Files[IO].exists(path).map(_ -> path))
         .compile
         .lastOrError
         .flatMap { case (existsBefore, path) =>
-          file.exists[IO](path).map(existsBefore -> _)
+          Files[IO].exists(path).map(existsBefore -> _)
         }
         .map(it => assert(it == true -> false))
     }
 
     test("should not fail if the directory is deleted before the stream completes") {
-      file
-        .tempDirectoryStream[IO](Paths.get(""))
-        .evalMap(path => file.delete[IO](path))
+      Files[IO]
+        .tempDirectoryStream(Paths.get(""))
+        .evalMap(path => Files[IO].delete(path))
         .compile
         .lastOrError
         .attempt
@@ -324,9 +324,9 @@ class FileSuite extends BaseFileSuite {
       assert(
         tempDirectory
           .evalMap(path =>
-            file
-              .createDirectory[IO](path.resolve("temp"))
-              .bracket(file.exists[IO](_))(file.deleteIfExists[IO](_).void)
+            Files[IO]
+              .createDirectory(path.resolve("temp"))
+              .bracket(Files[IO].exists(_))(Files[IO].deleteIfExists(_).void)
           )
           .compile
           .fold(true)(_ && _)
@@ -340,9 +340,9 @@ class FileSuite extends BaseFileSuite {
       assert(
         tempDirectory
           .evalMap(path =>
-            file
-              .createDirectories[IO](path.resolve("temp/inner"))
-              .bracket(file.exists[IO](_))(file.deleteIfExists[IO](_).void)
+            Files[IO]
+              .createDirectories(path.resolve("temp/inner"))
+              .bracket(Files[IO].exists(_))(Files[IO].deleteIfExists(_).void)
           )
           .compile
           .fold(true)(_ && _)
@@ -355,7 +355,7 @@ class FileSuite extends BaseFileSuite {
     test("returns an empty Stream on an empty directory") {
       assert(
         tempDirectory
-          .flatMap(path => file.directoryStream[IO](path))
+          .flatMap(path => Files[IO].directoryStream(path))
           .compile
           .toList
           .unsafeRunSync()
@@ -368,7 +368,7 @@ class FileSuite extends BaseFileSuite {
         tempFiles(10)
           .flatMap { paths =>
             val parent = paths.head.getParent
-            file.directoryStream[IO](parent).tupleRight(paths)
+            Files[IO].directoryStream(parent).tupleRight(paths)
           }
           .map { case (path, paths) => paths.exists(_.normalize == path.normalize) }
           .compile
@@ -383,7 +383,7 @@ class FileSuite extends BaseFileSuite {
       assert(
         tempFile
           .flatMap { path =>
-            file.walk[IO](path.getParent).map(_.normalize == path.normalize)
+            Files[IO].walk(path.getParent).map(_.normalize == path.normalize)
           }
           .compile
           .toList
@@ -397,7 +397,7 @@ class FileSuite extends BaseFileSuite {
         tempFiles(10)
           .flatMap { paths =>
             val parent = paths.head.getParent
-            file.walk[IO](parent).tupleRight(parent :: paths)
+            Files[IO].walk(parent).tupleRight(parent :: paths)
           }
           .map { case (path, paths) => paths.exists(_.normalize == path.normalize) }
           .compile
@@ -409,7 +409,7 @@ class FileSuite extends BaseFileSuite {
     test("returns all files in a nested tree correctly") {
       assert(
         tempFilesHierarchy
-          .flatMap(topDir => file.walk[IO](topDir))
+          .flatMap(topDir => Files[IO].walk(topDir))
           .compile
           .toList
           .unsafeRunSync()
@@ -429,17 +429,17 @@ class FileSuite extends BaseFileSuite {
           val write = Stream(0x42.toByte).repeat
             .buffer(bufferSize)
             .take(totalBytes.toLong)
-            .through(file.writeRotate[IO](path, rotateLimit.toLong))
+            .through(Files[IO].writeRotate(path, rotateLimit.toLong))
             .compile
             .drain
-          val verify = file
-            .directoryStream[IO](dir)
+          val verify = Files[IO]
+            .directoryStream(dir)
             .compile
             .toList
             .flatMap { paths =>
               paths
                 .sortBy(_.toString)
-                .traverse(p => file.size[IO](p))
+                .traverse(p => Files[IO].size(p))
             }
             .map { sizes =>
               assert(sizes.size == ((totalBytes + rotateLimit - 1) / rotateLimit))

--- a/io/src/test/scala/fs2/io/file/FileSuite.scala
+++ b/io/src/test/scala/fs2/io/file/FileSuite.scala
@@ -271,10 +271,10 @@ class FileSuite extends BaseFileSuite {
     }
   }
 
-  group("tempFileStream") {
+  group("tempFile") {
     test("should remove the file following stream closure") {
-      Files[IO]
-        .tempFileStream(Paths.get(""))
+      Stream.resource(Files[IO]
+        .tempFile(Paths.get("")))
         .evalMap(path => Files[IO].exists(path).map(_ -> path))
         .compile
         .lastOrError
@@ -285,8 +285,8 @@ class FileSuite extends BaseFileSuite {
     }
 
     test("should not fail if the file is deleted before the stream completes") {
-      Files[IO]
-        .tempFileStream(Paths.get(""))
+      Stream.resource(Files[IO]
+        .tempFile(Paths.get("")))
         .evalMap(path => Files[IO].delete(path))
         .compile
         .lastOrError
@@ -297,8 +297,8 @@ class FileSuite extends BaseFileSuite {
 
   group("tempDirectoryStream") {
     test("should remove the directory following stream closure") {
-      Files[IO]
-        .tempDirectoryStream(Paths.get(""))
+      Stream.resource(Files[IO]
+        .tempDirectory(Paths.get("")))
         .evalMap(path => Files[IO].exists(path).map(_ -> path))
         .compile
         .lastOrError
@@ -309,8 +309,8 @@ class FileSuite extends BaseFileSuite {
     }
 
     test("should not fail if the directory is deleted before the stream completes") {
-      Files[IO]
-        .tempDirectoryStream(Paths.get(""))
+      Stream.resource(Files[IO]
+        .tempDirectory(Paths.get("")))
         .evalMap(path => Files[IO].delete(path))
         .compile
         .lastOrError

--- a/io/src/test/scala/fs2/io/file/FileSuite.scala
+++ b/io/src/test/scala/fs2/io/file/FileSuite.scala
@@ -273,8 +273,11 @@ class FileSuite extends BaseFileSuite {
 
   group("tempFile") {
     test("should remove the file following stream closure") {
-      Stream.resource(Files[IO]
-        .tempFile(Paths.get("")))
+      Stream
+        .resource(
+          Files[IO]
+            .tempFile(Paths.get(""))
+        )
         .evalMap(path => Files[IO].exists(path).map(_ -> path))
         .compile
         .lastOrError
@@ -285,8 +288,11 @@ class FileSuite extends BaseFileSuite {
     }
 
     test("should not fail if the file is deleted before the stream completes") {
-      Stream.resource(Files[IO]
-        .tempFile(Paths.get("")))
+      Stream
+        .resource(
+          Files[IO]
+            .tempFile(Paths.get(""))
+        )
         .evalMap(path => Files[IO].delete(path))
         .compile
         .lastOrError
@@ -297,8 +303,11 @@ class FileSuite extends BaseFileSuite {
 
   group("tempDirectoryStream") {
     test("should remove the directory following stream closure") {
-      Stream.resource(Files[IO]
-        .tempDirectory(Paths.get("")))
+      Stream
+        .resource(
+          Files[IO]
+            .tempDirectory(Paths.get(""))
+        )
         .evalMap(path => Files[IO].exists(path).map(_ -> path))
         .compile
         .lastOrError
@@ -309,8 +318,11 @@ class FileSuite extends BaseFileSuite {
     }
 
     test("should not fail if the directory is deleted before the stream completes") {
-      Stream.resource(Files[IO]
-        .tempDirectory(Paths.get("")))
+      Stream
+        .resource(
+          Files[IO]
+            .tempDirectory(Paths.get(""))
+        )
         .evalMap(path => Files[IO].delete(path))
         .compile
         .lastOrError


### PR DESCRIPTION
Stuff to address:
- ~`FileHandle` currently can be constructed via `Files[F].open*` or directly via `FileHandle.from*`. Should the `from` constructors be made private or otherwise removed?~
- ~`ReadCursor` and `WriteCursor` have convenience constructors in their companions. Should those be removed or moved to `Files`?~
- ~Is there a better name for `BaseFiles`?~ Renamed to `SyncFiles`
- Docs