### PR TITLE
Fix for resource leak that occurs when parent scope is closed during resource acquisition

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -95,8 +95,12 @@ private[fs2] final class CompileScope[F[_]] private (
     * Registers supplied resource in this scope.
     * This is always invoked before state can be marked as closed.
     */
-  private def register(resource: ScopedResource[F]): F[Unit] =
-    state.update(s => s.copy(resources = resource +: s.resources))
+  private def register(resource: ScopedResource[F]): F[Boolean] =
+    state.modify { s =>
+      // println(s">> REGISTERING TO $id $s")
+      if (s.open) (s.copy(resources = resource +: s.resources), true)
+      else (s, false)
+    }
 
   /**
     * Opens a child scope.
@@ -127,6 +131,7 @@ private[fs2] final class CompileScope[F[_]] private (
      */
     val createCompileScope: F[CompileScope[F]] = {
       val newScopeId = new Token
+      // println(s">> CREATED NEW SCOPE $newScopeId")
       self.interruptible match {
         case None =>
           val iCtx = InterruptContext.unsafeFromInterruptible(interruptible, newScopeId)
@@ -180,10 +185,20 @@ private[fs2] final class CompileScope[F[_]] private (
     F.uncancelable {
       F.flatMap(F.attempt(fr)) {
         case Right(r) =>
+          // println(s">>>> $id ACQ COMPLETED")
           val finalizer = (ec: ExitCase[Throwable]) => F.suspend(release(r, ec))
           F.flatMap(resource.acquired(finalizer)) { result =>
-            if (result.exists(identity)) F.map(register(resource))(_ => Right(r))
-            else F.pure(Left(result.swap.getOrElse(AcquireAfterScopeClosed)))
+            if (result.exists(identity)) {
+              // println(s">>>> $id REG")
+              F.flatMap(register(resource)) {
+                case false =>
+                  finalizer(ExitCase.Canceled).as(Left(AcquireAfterScopeClosed))
+                case true => F.pure(Right(r))
+              }
+            } else {
+              // println(s">>> $id LATE")
+              finalizer(ExitCase.Canceled).as(Left(result.swap.getOrElse(AcquireAfterScopeClosed)))
+            }
           }
         case Left(err) => F.pure(Left(err))
       }
@@ -232,6 +247,7 @@ private[fs2] final class CompileScope[F[_]] private (
     */
   def close(ec: ExitCase[Throwable]): F[Either[Throwable, Unit]] =
     F.flatMap(state.modify(s => s.close -> s)) { previous =>
+      // println(s">>> CLOSED $id " + previous)
       F.flatMap(traverseError[CompileScope[F]](previous.children, _.close(ec))) { resultChildren =>
         F.flatMap(traverseError[ScopedResource[F]](previous.resources, _.release(ec))) {
           resultResources =>

--- a/core/shared/src/main/scala/fs2/internal/ScopedResource.scala
+++ b/core/shared/src/main/scala/fs2/internal/ScopedResource.scala
@@ -144,11 +144,9 @@ private[internal] object ScopedResource {
       def acquired(finalizer: ExitCase[Throwable] => F[Unit]): F[Either[Throwable, Boolean]] =
         F.flatten(state.modify { s =>
           if (s.isFinished) {
-            println("ACQ FINISHD ALREADY")
             // state is closed and there are no leases, finalizer has to be invoked right away
             s -> F.attempt(F.as(finalizer(ExitCase.Completed), false))
           } else {
-            println("REG FINAL")
             val attemptFinalizer = (ec: ExitCase[Throwable]) => F.attempt(finalizer(ec))
             // either state is open, or leases are present, either release or `Lease#cancel` will run the finalizer
             s.copy(finalizer = Some(attemptFinalizer)) -> F.pure(Right(true))

--- a/core/shared/src/main/scala/fs2/internal/ScopedResource.scala
+++ b/core/shared/src/main/scala/fs2/internal/ScopedResource.scala
@@ -143,10 +143,12 @@ private[internal] object ScopedResource {
 
       def acquired(finalizer: ExitCase[Throwable] => F[Unit]): F[Either[Throwable, Boolean]] =
         F.flatten(state.modify { s =>
-          if (s.isFinished)
+          if (s.isFinished) {
+            println("ACQ FINISHD ALREADY")
             // state is closed and there are no leases, finalizer has to be invoked right away
             s -> F.attempt(F.as(finalizer(ExitCase.Completed), false))
-          else {
+          } else {
+            println("REG FINAL")
             val attemptFinalizer = (ec: ExitCase[Throwable]) => F.attempt(finalizer(ec))
             // either state is open, or leases are present, either release or `Lease#cancel` will run the finalizer
             s.copy(finalizer = Some(attemptFinalizer)) -> F.pure(Right(true))


### PR DESCRIPTION
This needs a lot more work but committing what I've found so far. When the resource acquisition completed in `CompileScope#acquireResource`, the wrapper `ScopedResource` instance was getting registered on the containing scope, but the containing scope's state was already closed. Not sure why the test I added yesterday passed though.