### PR TITLE
RFC: scalafmt configuration: add fewer lines in parameters

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -12,6 +12,11 @@ rewrite.rules = [
   PreferCurlyFors
 ]
 
+optIn.configStyleArguments = false
+runner.optimizer.forceConfigStyleMinArgCount = 3
+
+newlines.implicitParamListModifierPrefer = before
+
 rewrite.neverInfix.excludeFilters = [until
   to
   by

--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,7 @@ ThisBuild / startYear := Some(2013)
 
 ThisBuild / crossScalaVersions := Seq("2.13.3", "2.12.10", "0.27.0-RC1")
 
-ThisBuild / versionIntroduced := Map(
-  "0.27.0-RC1" -> "3.0.0"
-)
+ThisBuild / versionIntroduced := Map("0.27.0-RC1" -> "3.0.0")
 
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.11")
 
@@ -113,9 +111,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
   .in(file("core"))
   .configs(IntegrationTest)
   .settings(Defaults.itSettings: _*)
-  .settings(
-    inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings)
-  )
+  .settings(inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings))
   .settings(
     name := "fs2-core",
     Compile / scalafmt / unmanagedSources := (Compile / scalafmt / unmanagedSources).value

--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -34,15 +34,13 @@ class MemoryLeakSpec extends FunSuite {
       total - free
     }
 
-  protected def leakTest[O](
-      name: TestOptions,
-      params: LeakTestParams = LeakTestParams()
-  )(stream: => Stream[IO, O]): Unit = leakTestF(name, params)(stream.compile.drain)
+  protected def leakTest[O](name: TestOptions, params: LeakTestParams = LeakTestParams())(
+      stream: => Stream[IO, O]
+  ): Unit = leakTestF(name, params)(stream.compile.drain)
 
-  protected def leakTestF(
-      name: TestOptions,
-      params: LeakTestParams = LeakTestParams()
-  )(f: => IO[Unit]): Unit =
+  protected def leakTestF(name: TestOptions, params: LeakTestParams = LeakTestParams())(
+      f: => IO[Unit]
+  ): Unit =
     test(name) {
       println(s"Running leak test ${name.name}")
       IO.race(

--- a/core/jvm/src/test/scala/fs2/CompressionSuite.scala
+++ b/core/jvm/src/test/scala/fs2/CompressionSuite.scala
@@ -58,10 +58,7 @@ class CompressionSuite extends Fs2Suite {
   }
 
   implicit val zlibHeaders: Arbitrary[ZLibParams.Header] = Arbitrary(
-    Gen.oneOf(
-      ZLibParams.Header.ZLIB,
-      ZLibParams.Header.GZIP
-    )
+    Gen.oneOf(ZLibParams.Header.ZLIB, ZLibParams.Header.GZIP)
   )
 
   implicit val juzDeflaterLevels: Arbitrary[DeflateParams.Level] = Arbitrary(
@@ -177,13 +174,7 @@ class CompressionSuite extends Fs2Suite {
         )
       )
       .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
-      .through(
-        deflate(
-          DeflateParams(
-            header = ZLibParams.Header.ZLIB
-          )
-        )
-      )
+      .through(deflate(DeflateParams(header = ZLibParams.Header.ZLIB)))
       .compile
       .to(Array)
       .flatMap { deflated =>
@@ -302,9 +293,7 @@ class CompressionSuite extends Fs2Suite {
             )
           )
           .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
-          .through(
-            gunzip[IO](8192)
-          )
+          .through(gunzip[IO](8192))
           .flatMap { gunzipResult =>
             assert(gunzipResult.fileName == expectedFileName)
             assert(gunzipResult.comment == expectedComment)
@@ -347,9 +336,7 @@ class CompressionSuite extends Fs2Suite {
             )
           )
           .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
-          .through(
-            gunzip[IO](509)
-          )
+          .through(gunzip[IO](509))
           .flatMap { gunzipResult =>
             assert(gunzipResult.fileName == expectedFileName)
             assert(gunzipResult.comment == expectedComment)
@@ -392,9 +379,7 @@ class CompressionSuite extends Fs2Suite {
             )
           )
           .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
-          .through(
-            gunzip[IO](1031)
-          )
+          .through(gunzip[IO](1031))
           .flatMap { gunzipResult =>
             assert(gunzipResult.fileName == expectedFileName)
             assert(gunzipResult.comment == expectedComment)
@@ -470,9 +455,7 @@ class CompressionSuite extends Fs2Suite {
     val longString: String =
       Array
         .fill(1024 * 1024 + 1)("x")
-        .mkString(
-          ""
-        ) // max(classic.fileNameBytesSoftLimit, classic.fileCommentBytesSoftLimit) + 1
+        .mkString("") // max(classic.fileNameBytesSoftLimit, classic.fileCommentBytesSoftLimit) + 1
     val expectedFileName = Option(toEncodableFileName(longString))
     val expectedComment = Option(toEncodableComment(longString))
     Stream
@@ -510,9 +493,7 @@ class CompressionSuite extends Fs2Suite {
       0xe2, 0x02, 0x00, 0x57, 0xb3, 0x5e, 0x6d, 0x23, 0x00, 0x00, 0x00).map(_.toByte)
     Stream
       .chunk(Chunk.bytes(compressed))
-      .through(
-        gunzip[IO]()
-      )
+      .through(gunzip[IO]())
       .flatMap { gunzipResult =>
         assert(gunzipResult.fileName == expectedFileName)
         assert(gunzipResult.comment == expectedComment)

--- a/core/shared/src/main/scala-2.12/fs2/CollectorPlatform.scala
+++ b/core/shared/src/main/scala-2.12/fs2/CollectorPlatform.scala
@@ -32,24 +32,20 @@ import scala.collection.{MapLike, SetLike, Traversable}
 import fs2.internal._
 
 private[fs2] trait CollectorPlatform { self: Collector.type =>
-  implicit def supportsFactory[A, C[_], B](
-      f: Factory[A, C[B]]
-  ): Collector.Aux[A, C[B]] = make(Builder.fromFactory(f))
+  implicit def supportsFactory[A, C[_], B](f: Factory[A, C[B]]): Collector.Aux[A, C[B]] = make(
+    Builder.fromFactory(f)
+  )
 
   implicit def supportsTraversableFactory[A, C[x] <: Traversable[x] with GenericTraversableTemplate[
     x,
     C
-  ]](
-      f: TraversableFactory[C]
-  ): Collector.Aux[A, C[A]] = make(Builder.fromTraversableFactory(f))
+  ]](f: TraversableFactory[C]): Collector.Aux[A, C[A]] = make(Builder.fromTraversableFactory(f))
 
   implicit def supportsMapFactory[K, V, C[a, b] <: collection.Map[a, b] with MapLike[
     a,
     b,
     C[a, b]
-  ]](
-      f: MapFactory[C]
-  ): Collector.Aux[(K, V), C[K, V]] =
+  ]](f: MapFactory[C]): Collector.Aux[(K, V), C[K, V]] =
     make(Builder.fromMapFactory(f))
 
   implicit def supportsSetFactory[A, C[x] <: Set[x] with SetLike[x, C[x]]](

--- a/core/shared/src/main/scala-3/fs2/CollectorPlatform.scala
+++ b/core/shared/src/main/scala-3/fs2/CollectorPlatform.scala
@@ -26,9 +26,9 @@ import scala.collection.{Factory, IterableFactory, MapFactory}
 import scala.reflect.ClassTag
 
 private[fs2] trait CollectorPlatform { self: Collector.type =>
-  implicit def supportsFactory[A, C[_], B](
-      f: Factory[A, C[B]]
-  ): Collector.Aux[A, C[B]] = make(Builder.fromFactory(f))
+  implicit def supportsFactory[A, C[_], B](f: Factory[A, C[B]]): Collector.Aux[A, C[B]] = make(
+    Builder.fromFactory(f)
+  )
 
   implicit def supportsIterableFactory[A, C[_]](f: IterableFactory[C]): Collector.Aux[A, C[A]] =
     make(Builder.fromIterableFactory(f))

--- a/core/shared/src/main/scala/fs2/Compiler.scala
+++ b/core/shared/src/main/scala/fs2/Compiler.scala
@@ -35,9 +35,7 @@ import scala.annotation.implicitNotFound
 )
 sealed trait Compiler[F[_], G[_]] {
   private[fs2] val target: Monad[G]
-  private[fs2] def apply[O, B](stream: Pull[F, O, Unit], init: B)(
-      fold: (B, Chunk[O]) => B
-  ): G[B]
+  private[fs2] def apply[O, B](stream: Pull[F, O, Unit], init: B)(fold: (B, Chunk[O]) => B): G[B]
 }
 
 private[fs2] trait CompilerLowPriority2 {
@@ -45,10 +43,9 @@ private[fs2] trait CompilerLowPriority2 {
   implicit def resource[F[_]: Compiler.Target]: Compiler[F, Resource[F, *]] =
     new Compiler[F, Resource[F, *]] {
       val target: Monad[Resource[F, *]] = implicitly
-      def apply[O, B](
-          stream: Pull[F, O, Unit],
-          init: B
-      )(foldChunk: (B, Chunk[O]) => B): Resource[F, B] =
+      def apply[O, B](stream: Pull[F, O, Unit], init: B)(
+          foldChunk: (B, Chunk[O]) => B
+      ): Resource[F, B] =
         Resource
           .makeCase(CompileScope.newRoot[F])((scope, ec) => scope.close(ec).rethrow)
           .evalMap(scope => Pull.compile(stream, scope, true, init)(foldChunk))
@@ -59,10 +56,7 @@ private[fs2] trait CompilerLowPriority1 extends CompilerLowPriority2 {
   implicit def target[F[_]: Compiler.Target]: Compiler[F, F] =
     new Compiler[F, F] {
       val target: Monad[F] = implicitly
-      def apply[O, B](
-          stream: Pull[F, O, Unit],
-          init: B
-      )(foldChunk: (B, Chunk[O]) => B): F[B] =
+      def apply[O, B](stream: Pull[F, O, Unit], init: B)(foldChunk: (B, Chunk[O]) => B): F[B] =
         Resource
           .Bracket[F]
           .bracketCase(CompileScope.newRoot[F])(scope =>
@@ -74,10 +68,7 @@ private[fs2] trait CompilerLowPriority1 extends CompilerLowPriority2 {
 private[fs2] trait CompilerLowPriority0 extends CompilerLowPriority1 {
   implicit val idInstance: Compiler[Id, Id] = new Compiler[Id, Id] {
     val target: Monad[Id] = implicitly
-    def apply[O, B](
-        stream: Pull[Id, O, Unit],
-        init: B
-    )(foldChunk: (B, Chunk[O]) => B): B =
+    def apply[O, B](stream: Pull[Id, O, Unit], init: B)(foldChunk: (B, Chunk[O]) => B): B =
       Compiler
         .target[SyncIO]
         .apply(stream.covaryId[SyncIO], init)(foldChunk)
@@ -89,10 +80,9 @@ private[fs2] trait CompilerLowPriority extends CompilerLowPriority0 {
   implicit val fallibleInstance: Compiler[Fallible, Either[Throwable, *]] =
     new Compiler[Fallible, Either[Throwable, *]] {
       val target: Monad[Either[Throwable, *]] = implicitly
-      def apply[O, B](
-          stream: Pull[Fallible, O, Unit],
-          init: B
-      )(foldChunk: (B, Chunk[O]) => B): Either[Throwable, B] =
+      def apply[O, B](stream: Pull[Fallible, O, Unit], init: B)(
+          foldChunk: (B, Chunk[O]) => B
+      ): Either[Throwable, B] =
         Compiler
           .target[SyncIO]
           .apply(stream.asInstanceOf[Pull[SyncIO, O, Unit]], init)(foldChunk)
@@ -104,10 +94,7 @@ private[fs2] trait CompilerLowPriority extends CompilerLowPriority0 {
 object Compiler extends CompilerLowPriority {
   implicit val pureInstance: Compiler[Pure, Id] = new Compiler[Pure, Id] {
     val target: Monad[Id] = implicitly
-    def apply[O, B](
-        stream: Pull[Pure, O, Unit],
-        init: B
-    )(foldChunk: (B, Chunk[O]) => B): B =
+    def apply[O, B](stream: Pull[Pure, O, Unit], init: B)(foldChunk: (B, Chunk[O]) => B): B =
       Compiler
         .target[SyncIO]
         .apply(stream.covary[SyncIO], init)(foldChunk)
@@ -138,9 +125,8 @@ object Compiler extends CompilerLowPriority {
     implicit def forConcurrent[F[_]: Concurrent]: Target[F] =
       new ConcurrentTarget
 
-    private final class ConcurrentTarget[F[_]](
-        protected implicit val F: Concurrent[F]
-    ) extends Target[F]
+    private final class ConcurrentTarget[F[_]](protected implicit val F: Concurrent[F])
+        extends Target[F]
         with Resource.Bracket.MonadCancelBracket[F] {
       def ref[A](a: A): F[Ref[F, A]] = F.ref(a)
       def uncancelable[A](f: Poll[F] => F[A]): F[A] = F.uncancelable(f)

--- a/core/shared/src/main/scala/fs2/CompositeFailure.scala
+++ b/core/shared/src/main/scala/fs2/CompositeFailure.scala
@@ -24,10 +24,8 @@ package fs2
 import cats.data.NonEmptyList
 
 /** Represents multiple (>1) exceptions were thrown. */
-final class CompositeFailure(
-    val head: Throwable,
-    val tail: NonEmptyList[Throwable]
-) extends Throwable(
+final class CompositeFailure(val head: Throwable, val tail: NonEmptyList[Throwable])
+    extends Throwable(
       s"Multiple exceptions were thrown (${1 + tail.size}), first ${head.getClass.getName}: ${head.getMessage}",
       head
     ) {

--- a/core/shared/src/main/scala/fs2/Hotswap.scala
+++ b/core/shared/src/main/scala/fs2/Hotswap.scala
@@ -101,9 +101,7 @@ object Hotswap {
   /** Creates a new `Hotswap` initialized with the specified resource.
     * The `Hotswap` instance and the initial resource are returned.
     */
-  def apply[F[_]: Concurrent, R](
-      initial: Resource[F, R]
-  ): Resource[F, (Hotswap[F, R], R)] =
+  def apply[F[_]: Concurrent, R](initial: Resource[F, R]): Resource[F, (Hotswap[F, R], R)] =
     create[F, R].evalMap(p => p.swap(initial).map(r => (p, r)))
 
   /** Creates a new `Hotswap`, which represents a `Resource`

--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -29,8 +29,6 @@ object Pipe {
     * Input is fed to the first pipe until it terminates, at which point input is
     * fed to the second pipe, and so on.
     */
-  def join[F[_]: Concurrent, A, B](
-      pipes: Stream[F, Pipe[F, A, B]]
-  ): Pipe[F, A, B] =
+  def join[F[_]: Concurrent, A, B](pipes: Stream[F, Pipe[F, A, B]]): Pipe[F, A, B] =
     _.broadcast.zipWith(pipes)(_.through(_)).flatten
 }

--- a/core/shared/src/main/scala/fs2/RaiseThrowable.scala
+++ b/core/shared/src/main/scala/fs2/RaiseThrowable.scala
@@ -36,8 +36,8 @@ import scala.annotation.implicitNotFound
 trait RaiseThrowable[F[_]]
 
 object RaiseThrowable {
-  implicit def fromApplicativeError[F[_]](implicit
-      F: ApplicativeError[F, Throwable]
+  implicit def fromApplicativeError[F[_]](
+      implicit F: ApplicativeError[F, Throwable]
   ): RaiseThrowable[F] = {
     val _ = F
     new RaiseThrowable[F] {}

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -232,30 +232,26 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     *
     * @param pipes    Pipes that will concurrently process the work.
     */
-  def broadcastTo[F2[x] >: F[x]: Concurrent](
-      pipes: Pipe[F2, O, Nothing]*
-  ): Stream[F2, INothing] =
+  def broadcastTo[F2[x] >: F[x]: Concurrent](pipes: Pipe[F2, O, Nothing]*): Stream[F2, INothing] =
     this.through(Broadcast.through(pipes: _*))
 
   /** Variant of `broadcastTo` that broadcasts to `maxConcurrent` instances of a single pipe.
     */
-  def broadcastTo[F2[x] >: F[x]: Concurrent](
-      maxConcurrent: Int
-  )(pipe: Pipe[F2, O, Nothing]): Stream[F2, INothing] =
+  def broadcastTo[F2[x] >: F[x]: Concurrent](maxConcurrent: Int)(
+      pipe: Pipe[F2, O, Nothing]
+  ): Stream[F2, INothing] =
     this.broadcastTo[F2](List.fill(maxConcurrent)(pipe): _*)
 
   /** Alias for `through(Broadcast.through(pipes))`.
     */
-  def broadcastThrough[F2[x] >: F[x]: Concurrent, O2](
-      pipes: Pipe[F2, O, O2]*
-  ): Stream[F2, O2] =
+  def broadcastThrough[F2[x] >: F[x]: Concurrent, O2](pipes: Pipe[F2, O, O2]*): Stream[F2, O2] =
     through(Broadcast.through(pipes: _*))
 
   /** Variant of `broadcastTo` that broadcasts to `maxConcurrent` instances of the supplied pipe.
     */
-  def broadcastThrough[F2[x] >: F[x]: Concurrent, O2](
-      maxConcurrent: Int
-  )(pipe: Pipe[F2, O, O2]): Stream[F2, O2] =
+  def broadcastThrough[F2[x] >: F[x]: Concurrent, O2](maxConcurrent: Int)(
+      pipe: Pipe[F2, O, O2]
+  ): Stream[F2, O2] =
     this.broadcastThrough[F2, O2](List.fill(maxConcurrent)(pipe): _*)
 
   /** Behaves like the identity function, but requests `n` elements at a time from the input.
@@ -520,8 +516,8 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * res2: Vector[Int] = Vector(1, 2, 3, 4)
     * }}}
     */
-  def compile[F2[x] >: F[x], G[_], O2 >: O](implicit
-      compiler: Compiler[F2, G]
+  def compile[F2[x] >: F[x], G[_], O2 >: O](
+      implicit compiler: Compiler[F2, G]
   ): Stream.CompileOps[F2, G, O2] =
     new Stream.CompileOps[F2, G, O2](underlying)
 
@@ -564,9 +560,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
         }
 
       // stop background process but await for it to finalise with a result
-      val stopBack: F2[Unit] = interrupt.complete(()) >> doneR.get.flatMap(
-        F.fromEither
-      )
+      val stopBack: F2[Unit] = interrupt.complete(()) >> doneR.get.flatMap(F.fromEither)
 
       Stream.bracket(runR.start)(_ => stopBack) >>
         this.interruptWhen(interrupt.get.attempt)
@@ -642,9 +636,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * res0: Vector[Int] = Vector(3, 6)
     * }}}
     */
-  def debounce[F2[x] >: F[x]](
-      d: FiniteDuration
-  )(implicit F: Temporal[F2]): Stream[F2, O] =
+  def debounce[F2[x] >: F[x]](d: FiniteDuration)(implicit F: Temporal[F2]): Stream[F2, O] =
     Stream.eval(Queue.bounded[F2, Option[O]](1)).flatMap { queue =>
       Stream.eval(F.ref[Option[O]](None)).flatMap { ref =>
         val enqueueLatest: F2[Unit] =
@@ -775,9 +767,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     *
     * Alias for `through(Balance(chunkSize))`.
     */
-  def balance[F2[x] >: F[x]: Concurrent](
-      chunkSize: Int
-  ): Stream[F2, Stream[F2, O]] =
+  def balance[F2[x] >: F[x]: Concurrent](chunkSize: Int): Stream[F2, Stream[F2, O]] =
     through(Balance(chunkSize))
 
   /** Like [[balance]] but instead of providing a stream of sources, runs each pipe.
@@ -796,9 +786,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * @param chunkSize max size of chunks taken from the source stream
     * @param pipes pipes that will concurrently process the work
     */
-  def balanceTo[F2[x] >: F[x]: Concurrent](
-      chunkSize: Int
-  )(pipes: Pipe[F2, O, Nothing]*): Stream[F2, INothing] =
+  def balanceTo[F2[x] >: F[x]: Concurrent](chunkSize: Int)(
+      pipes: Pipe[F2, O, Nothing]*
+  ): Stream[F2, INothing] =
     balanceThrough[F2, INothing](chunkSize)(pipes: _*)
 
   /** Variant of `balanceTo` that broadcasts to `maxConcurrent` instances of a single pipe.
@@ -814,9 +804,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
 
   /** Alias for `through(Balance.through(chunkSize)(pipes)`.
     */
-  def balanceThrough[F2[x] >: F[x]: Concurrent, O2](
-      chunkSize: Int
-  )(pipes: Pipe[F2, O, O2]*): Stream[F2, O2] =
+  def balanceThrough[F2[x] >: F[x]: Concurrent, O2](chunkSize: Int)(
+      pipes: Pipe[F2, O, O2]*
+  ): Stream[F2, O2] =
     through(Balance.through[F2, O, O2](chunkSize)(pipes: _*))
 
   /** Variant of `balanceThrough` that takes number of concurrency required and single pipe.
@@ -825,10 +815,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * @param maxConcurrent maximum number of pipes to run concurrently
     * @param pipe pipe to use to process elements
     */
-  def balanceThrough[F2[x] >: F[x]: Concurrent, O2](
-      chunkSize: Int,
-      maxConcurrent: Int
-  )(
+  def balanceThrough[F2[x] >: F[x]: Concurrent, O2](chunkSize: Int, maxConcurrent: Int)(
       pipe: Pipe[F2, O, O2]
   ): Stream[F2, O2] =
     balanceThrough[F2, O2](chunkSize)((0 until maxConcurrent).map(_ => pipe): _*)
@@ -968,9 +955,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * res0: Vector[Either[Int,Int]] = Vector(Left(0), Right(0), Left(1), Right(1), Left(2), Right(2), Left(3), Right(3), Left(4), Right(4))
     * }}}
     */
-  def either[F2[x] >: F[x]: Concurrent, O2](
-      that: Stream[F2, O2]
-  ): Stream[F2, Either[O, O2]] =
+  def either[F2[x] >: F[x]: Concurrent, O2](that: Stream[F2, O2]): Stream[F2, Either[O, O2]] =
     map(Left(_)).merge(that.map(Right(_)))
 
   /** Alias for `flatMap(o => Stream.eval(f(o)))`.
@@ -1111,9 +1096,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   /** Like `filter`, but allows filtering based on an effect, with up to [[maxConcurrent]] concurrently running effects.
     * The ordering of emitted elements is unchanged.
     */
-  def evalFilterAsync[F2[x] >: F[
-    x
-  ]: Concurrent](
+  def evalFilterAsync[F2[x] >: F[x]: Concurrent](
       maxConcurrent: Int
   )(f: O => F2[Boolean]): Stream[F2, O] =
     parEvalMap[F2, Stream[F2, O]](maxConcurrent) { o =>
@@ -1131,9 +1114,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   /** Like `filterNot`, but allows filtering based on an effect, with up to [[maxConcurrent]] concurrently running effects.
     * The ordering of emitted elements is unchanged.
     */
-  def evalFilterNotAsync[F2[x] >: F[
-    x
-  ]: Concurrent](
+  def evalFilterNotAsync[F2[x] >: F[x]: Concurrent](
       maxConcurrent: Int
   )(f: O => F2[Boolean]): Stream[F2, O] =
     parEvalMap[F2, Stream[F2, O]](maxConcurrent) { o =>
@@ -1206,9 +1187,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   }
 
   /** Alias for `flatMap(_ => s2)`. */
-  def >>[F2[x] >: F[x], O2](
-      s2: => Stream[F2, O2]
-  )(implicit ev: Not[O <:< Nothing]): Stream[F2, O2] =
+  def >>[F2[x] >: F[x], O2](s2: => Stream[F2, O2])(
+      implicit ev: Not[O <:< Nothing]
+  ): Stream[F2, O2] =
     flatMap(_ => s2)
 
   /** Flattens a stream of streams in to a single stream by concatenating each stream.
@@ -1379,13 +1360,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
         // nonMatching is guaranteed to be non-empty here, because we know the last element of the chunk doesn't have
         // the same key as the first
         val k2 = f(nonMatching(0))
-        doChunk(
-          nonMatching,
-          s,
-          k2,
-          Chunk.Queue.empty,
-          newAcc
-        )
+        doChunk(nonMatching, s, k2, Chunk.Queue.empty, newAcc)
       }
     }
 
@@ -1399,10 +1374,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     *
     * Note: a time window starts each time downstream pulls.
     */
-  def groupWithin[F2[x] >: F[x]](
-      n: Int,
-      d: FiniteDuration
-  )(implicit F: Temporal[F2]): Stream[F2, Chunk[O]] =
+  def groupWithin[F2[x] >: F[x]](n: Int, d: FiniteDuration)(
+      implicit F: Temporal[F2]
+  ): Stream[F2, Chunk[O]] =
     Stream
       .eval {
         Queue
@@ -1515,9 +1489,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * produced by `source`. If the source stream is empty, the resulting signal
     * will always be `initial`.
     */
-  def hold[F2[x] >: F[x]: Concurrent, O2 >: O](
-      initial: O2
-  ): Stream[F2, Signal[F2, O2]] =
+  def hold[F2[x] >: F[x]: Concurrent, O2 >: O](initial: O2): Stream[F2, Signal[F2, O2]] =
     Stream.eval(SignallingRef.of[F2, O2](initial)).flatMap { sig =>
       Stream(sig).concurrently(evalMap(sig.set))
     }
@@ -1528,9 +1500,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
 
   /** Like [[hold]] but returns a `Resource` rather than a single element stream.
     */
-  def holdResource[F2[x] >: F[x]: Concurrent, O2 >: O](
-      initial: O2
-  ): Resource[F2, Signal[F2, O2]] =
+  def holdResource[F2[x] >: F[x]: Concurrent, O2 >: O](initial: O2): Resource[F2, Signal[F2, O2]] =
     Stream
       .eval(SignallingRef.of[F2, O2](initial))
       .flatMap(sig => Stream(sig).concurrently(evalMap(sig.set)))
@@ -1541,9 +1511,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   /**  Like [[holdResource]] but does not require an initial value,
     *  and hence all output elements are wrapped in `Some`.
     */
-  def holdOptionResource[F2[x] >: F[
-    x
-  ]: Concurrent, O2 >: O]: Resource[F2, Signal[F2, Option[O2]]] =
+  def holdOptionResource[F2[x] >: F[x]: Concurrent, O2 >: O]: Resource[F2, Signal[F2, Option[O2]]] =
     map(Some(_): Option[O2]).holdResource(None)
 
   /** Deterministically interleaves elements, starting on the left, terminating when the end of either branch is reached naturally.
@@ -1572,9 +1540,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
 
   /** Interrupts this stream after the specified duration has passed.
     */
-  def interruptAfter[F2[x] >: F[x]: Temporal](
-      duration: FiniteDuration
-  ): Stream[F2, O] =
+  def interruptAfter[F2[x] >: F[x]: Temporal](duration: FiniteDuration): Stream[F2, O] =
     interruptWhen[F2](Stream.sleep_[F2](duration) ++ Stream(true))
 
   /** Let through the `s2` branch as long as the `s1` branch is `false`,
@@ -1616,9 +1582,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     interruptWhen(haltWhenTrue.get)
 
   /** Alias for `interruptWhen(haltWhenTrue.discrete)`. */
-  def interruptWhen[F2[x] >: F[x]: Concurrent](
-      haltWhenTrue: Signal[F2, Boolean]
-  ): Stream[F2, O] =
+  def interruptWhen[F2[x] >: F[x]: Concurrent](haltWhenTrue: Signal[F2, Boolean]): Stream[F2, O] =
     interruptWhen(haltWhenTrue.discrete)
 
   /** Interrupts the stream, when `haltOnSignal` finishes its evaluation.
@@ -1729,20 +1693,14 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
 
   /** Alias for [[parEvalMap]].
     */
-  def mapAsync[F2[x] >: F[
-    x
-  ]: Concurrent, O2](
-      maxConcurrent: Int
-  )(f: O => F2[O2]): Stream[F2, O2] =
+  def mapAsync[F2[x] >: F[x]: Concurrent, O2](maxConcurrent: Int)(f: O => F2[O2]): Stream[F2, O2] =
     parEvalMap[F2, O2](maxConcurrent)(f)
 
   /** Alias for [[parEvalMapUnordered]].
     */
-  def mapAsyncUnordered[F2[x] >: F[
-    x
-  ]: Concurrent, O2](
-      maxConcurrent: Int
-  )(f: O => F2[O2]): Stream[F2, O2] =
+  def mapAsyncUnordered[F2[x] >: F[x]: Concurrent, O2](maxConcurrent: Int)(
+      f: O => F2[O2]
+  ): Stream[F2, O2] =
     map(o => Stream.eval(f(o))).parJoin(maxConcurrent)
 
   /** Applies the specified pure function to each chunk in this stream.
@@ -1785,9 +1743,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * When either the inner or outer stream fails, the entire stream fails and the finalizer of the
     * inner stream runs before the outer one.
     */
-  def switchMap[F2[x] >: F[x], O2](
-      f: O => Stream[F2, O2]
-  )(implicit F: Concurrent[F2]): Stream[F2, O2] =
+  def switchMap[F2[x] >: F[x], O2](f: O => Stream[F2, O2])(
+      implicit F: Concurrent[F2]
+  ): Stream[F2, O2] =
     Stream.force(Semaphore[F2](1).flatMap { guard =>
       F.ref[Option[Deferred[F2, Unit]]](None).map { haltRef =>
         def runInner(o: O, halt: Deferred[F2, Unit]): Stream[F2, O2] =
@@ -1905,27 +1863,21 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   }
 
   /** Like `merge`, but halts as soon as _either_ branch halts. */
-  def mergeHaltBoth[F2[x] >: F[x]: Concurrent, O2 >: O](
-      that: Stream[F2, O2]
-  ): Stream[F2, O2] =
+  def mergeHaltBoth[F2[x] >: F[x]: Concurrent, O2 >: O](that: Stream[F2, O2]): Stream[F2, O2] =
     noneTerminate.merge(that.noneTerminate).unNoneTerminate
 
   /** Like `merge`, but halts as soon as the `s1` branch halts.
     *
     * Note: it is *not* guaranteed that the last element of the stream will come from `s1`.
     */
-  def mergeHaltL[F2[x] >: F[x]: Concurrent, O2 >: O](
-      that: Stream[F2, O2]
-  ): Stream[F2, O2] =
+  def mergeHaltL[F2[x] >: F[x]: Concurrent, O2 >: O](that: Stream[F2, O2]): Stream[F2, O2] =
     noneTerminate.merge(that.map(Some(_))).unNoneTerminate
 
   /** Like `merge`, but halts as soon as the `s2` branch halts.
     *
     * Note: it is *not* guaranteed that the last element of the stream will come from `s2`.
     */
-  def mergeHaltR[F2[x] >: F[x]: Concurrent, O2 >: O](
-      that: Stream[F2, O2]
-  ): Stream[F2, O2] =
+  def mergeHaltR[F2[x] >: F[x]: Concurrent, O2 >: O](that: Stream[F2, O2]): Stream[F2, O2] =
     that.mergeHaltL(this)
 
   /** Emits each output wrapped in a `Some` and emits a `None` at the end of the stream.
@@ -1972,9 +1924,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
 
   /** Like [[onFinalize]] but provides the reason for finalization as an `ExitCase[Throwable]`.
     */
-  def onFinalizeCase[F2[x] >: F[x]](
-      f: Resource.ExitCase => F2[Unit]
-  )(implicit F2: Applicative[F2]): Stream[F2, O] =
+  def onFinalizeCase[F2[x] >: F[x]](f: Resource.ExitCase => F2[Unit])(
+      implicit F2: Applicative[F2]
+  ): Stream[F2, O] =
     Stream.bracketCase(F2.unit)((_, ec) => f(ec)) >> this
 
   /** Like [[onFinalizeCase]] but does not introduce a scope, allowing finalization to occur after
@@ -1984,9 +1936,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     *
     * See [[onFinalizeWeak]] for more details on semantics.
     */
-  def onFinalizeCaseWeak[F2[x] >: F[x]](
-      f: Resource.ExitCase => F2[Unit]
-  )(implicit F2: Applicative[F2]): Stream[F2, O] =
+  def onFinalizeCaseWeak[F2[x] >: F[x]](f: Resource.ExitCase => F2[Unit])(
+      implicit F2: Applicative[F2]
+  ): Stream[F2, O] =
     new Stream(Pull.acquire[F2, Unit](F2.unit, (_, ec) => f(ec)).flatMap(_ => underlying))
 
   /** Like [[Stream#evalMap]], but will evaluate effects in parallel, emitting the results
@@ -2049,11 +2001,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * res0: Unit = ()
     * }}}
     */
-  def parEvalMapUnordered[F2[x] >: F[
-    x
-  ]: Concurrent, O2](
-      maxConcurrent: Int
-  )(f: O => F2[O2]): Stream[F2, O2] =
+  def parEvalMapUnordered[F2[x] >: F[x]: Concurrent, O2](maxConcurrent: Int)(
+      f: O => F2[O2]
+  ): Stream[F2, O2] =
     map(o => Stream.eval(f(o))).parJoin(maxConcurrent)
 
   /** Concurrent zip.
@@ -2076,23 +2026,19 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * - The output of `parZip` is guaranteed to be the same as `zip`,
     *   although the order in which effects are executed differs.
     */
-  def parZip[F2[x] >: F[x]: Concurrent, O2](
-      that: Stream[F2, O2]
-  ): Stream[F2, (O, O2)] =
+  def parZip[F2[x] >: F[x]: Concurrent, O2](that: Stream[F2, O2]): Stream[F2, (O, O2)] =
     Stream.parZip(this, that)
 
   /** Like `parZip`, but combines elements pairwise with a function instead
     * of tupling them.
     */
-  def parZipWith[F2[x] >: F[x]: Concurrent, O2 >: O, O3, O4](
-      that: Stream[F2, O3]
-  )(f: (O2, O3) => O4): Stream[F2, O4] =
+  def parZipWith[F2[x] >: F[x]: Concurrent, O2 >: O, O3, O4](that: Stream[F2, O3])(
+      f: (O2, O3) => O4
+  ): Stream[F2, O4] =
     this.parZip(that).map(f.tupled)
 
   /** Pause this stream when `pauseWhenTrue` emits `true`, resuming when `false` is emitted. */
-  def pauseWhen[F2[x] >: F[x]: Concurrent](
-      pauseWhenTrue: Stream[F2, Boolean]
-  ): Stream[F2, O] =
+  def pauseWhen[F2[x] >: F[x]: Concurrent](pauseWhenTrue: Stream[F2, Boolean]): Stream[F2, O] =
     Stream.eval(SignallingRef[F2, Boolean](false)).flatMap { pauseSignal =>
       def writer = pauseWhenTrue.evalMap(pauseSignal.set).drain
 
@@ -2100,9 +2046,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     }
 
   /** Pause this stream when `pauseWhenTrue` is `true`, resume when it's `false`. */
-  def pauseWhen[F2[x] >: F[x]: Concurrent](
-      pauseWhenTrue: Signal[F2, Boolean]
-  ): Stream[F2, O] = {
+  def pauseWhen[F2[x] >: F[x]: Concurrent](pauseWhenTrue: Signal[F2, Boolean]): Stream[F2, O] = {
 
     def waitToResume =
       pauseWhenTrue.discrete.dropWhile(_ == true).take(1).compile.drain
@@ -2123,9 +2067,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   /** Behaves like `identity`, but starts fetches up to `n` chunks in parallel with downstream
     * consumption, enabling processing on either side of the `prefetchN` to run in parallel.
     */
-  def prefetchN[F2[x] >: F[x]: Concurrent](
-      n: Int
-  ): Stream[F2, O] =
+  def prefetchN[F2[x] >: F[x]: Concurrent](n: Int): Stream[F2, O] =
     Stream.eval(Queue.bounded[F2, Option[Chunk[O]]](n)).flatMap { queue =>
       queue.dequeue.unNoneTerminate
         .flatMap(Stream.chunk(_))
@@ -2256,8 +2198,8 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * res0: List[Int] = List(-1)
     * }}}
     */
-  def rethrow[F2[x] >: F[x], O2](implicit
-      ev: O <:< Either[Throwable, O2],
+  def rethrow[F2[x] >: F[x], O2](
+      implicit ev: O <:< Either[Throwable, O2],
       rt: RaiseThrowable[F2]
   ): Stream[F2, O2] = {
     val _ = ev // Convince scalac that ev is used
@@ -2328,9 +2270,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * res0: List[Int] = List(0, 1, 2, 3, 4)
     * }}}
     */
-  def scanChunksOpt[S, O2 >: O, O3](
-      init: S
-  )(f: S => Option[Chunk[O2] => (S, Chunk[O3])]): Stream[F, O3] =
+  def scanChunksOpt[S, O2 >: O, O3](init: S)(
+      f: S => Option[Chunk[O2] => (S, Chunk[O3])]
+  ): Stream[F, O3] =
     this.pull.scanChunksOpt(init)(f).void.stream
 
   /** Alias for `map(f).scanMonoid`.
@@ -2374,8 +2316,8 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   /** Writes this stream to standard out, converting each element to a `String` via `Show`,
     * emitting a unit for each line written.
     */
-  def showLinesStdOut[F2[x] >: F[x], O2 >: O](implicit
-      F: Sync[F2],
+  def showLinesStdOut[F2[x] >: F[x], O2 >: O](
+      implicit F: Sync[F2],
       showO: Show[O2]
   ): Stream[F2, INothing] =
     showLines[F2, O2](Console.out)
@@ -2508,15 +2450,13 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   def through[F2[x] >: F[x], O2](f: Stream[F, O] => Stream[F2, O2]): Stream[F2, O2] = f(this)
 
   /** Transforms this stream and `s2` using the given `Pipe2`. */
-  def through2[F2[x] >: F[x], O2, O3](
-      s2: Stream[F2, O2]
-  )(f: (Stream[F, O], Stream[F2, O2]) => Stream[F2, O3]): Stream[F2, O3] =
+  def through2[F2[x] >: F[x], O2, O3](s2: Stream[F2, O2])(
+      f: (Stream[F, O], Stream[F2, O2]) => Stream[F2, O3]
+  ): Stream[F2, O3] =
     f(this, s2)
 
   /** Fails this stream with a [[TimeoutException]] if it does not complete within given `timeout`. */
-  def timeout[F2[x] >: F[x]: Temporal](
-      timeout: FiniteDuration
-  ): Stream[F2, O] =
+  def timeout[F2[x] >: F[x]: Temporal](timeout: FiniteDuration): Stream[F2, O] =
     this.interruptWhen(
       Temporal[F2]
         .sleep(timeout)
@@ -2595,10 +2535,11 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   private type ZipWithCont[G[_], I, O2, R] =
     Either[(Chunk[I], Stream[G, I]), Stream[G, I]] => Pull[G, O2, Option[R]]
 
-  private def zipWith_[F2[x] >: F[x], O2 >: O, O3, O4](that: Stream[F2, O3])(
-      k1: ZipWithCont[F2, O2, O4, INothing],
-      k2: ZipWithCont[F2, O3, O4, INothing]
-  )(f: (O2, O3) => O4): Stream[F2, O4] = {
+  private def zipWith_[F2[x] >: F[x], O2 >: O, O3, O4](
+      that: Stream[F2, O3]
+  )(k1: ZipWithCont[F2, O2, O4, INothing], k2: ZipWithCont[F2, O3, O4, INothing])(
+      f: (O2, O3) => O4
+  ): Stream[F2, O4] = {
     def go(
         leg1: Stream.StepLeg[F2, O2],
         leg2: Stream.StepLeg[F2, O3]
@@ -2741,9 +2682,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * res0: List[Int] = List(5, 7, 9)
     * }}}
     */
-  def zipWith[F2[x] >: F[x], O2 >: O, O3, O4](
-      that: Stream[F2, O3]
-  )(f: (O2, O3) => O4): Stream[F2, O4] =
+  def zipWith[F2[x] >: F[x], O2 >: O, O3, O4](that: Stream[F2, O3])(
+      f: (O2, O3) => O4
+  ): Stream[F2, O4] =
     zipWith_[F2, O2, O3, O4](that)(_ => Pull.pure(None), _ => Pull.pure(None))(f)
 
   /** Zips the elements of the input stream with its indices, and returns the new stream.
@@ -2928,17 +2869,17 @@ object Stream extends StreamLowPriority {
     * `ExitCase.Canceled` is passed to the release action in the event of either stream interruption or
     * overall compiled effect cancelation.
     */
-  def bracketCase[F[x] >: Pure[x], R](
-      acquire: F[R]
-  )(release: (R, Resource.ExitCase) => F[Unit]): Stream[F, R] =
+  def bracketCase[F[x] >: Pure[x], R](acquire: F[R])(
+      release: (R, Resource.ExitCase) => F[Unit]
+  ): Stream[F, R] =
     bracketCaseWeak(acquire)(release).scope
 
   /** Like [[bracketCase]] but no scope is introduced, causing resource finalization to
     * occur at the end of the current scope at the time of acquisition.
     */
-  def bracketCaseWeak[F[x] >: Pure[x], R](
-      acquire: F[R]
-  )(release: (R, Resource.ExitCase) => F[Unit]): Stream[F, R] =
+  def bracketCaseWeak[F[x] >: Pure[x], R](acquire: F[R])(
+      release: (R, Resource.ExitCase) => F[Unit]
+  ): Stream[F, R] =
     new Stream(Pull.acquire[F, R](acquire, release).flatMap(Pull.output1(_)))
 
   /** Creates a pure stream that emits the elements of the supplied chunk.
@@ -3091,9 +3032,8 @@ object Stream extends StreamLowPriority {
     now.flatMap(go)
   }
 
-  private[fs2] final class PartiallyAppliedFromOption[F[_]](
-      private val dummy: Boolean
-  ) extends AnyVal {
+  private[fs2] final class PartiallyAppliedFromOption[F[_]](private val dummy: Boolean)
+      extends AnyVal {
     def apply[A](option: Option[A]): Stream[F, A] =
       option.map(Stream.emit).getOrElse(Stream.empty)
   }
@@ -3111,9 +3051,8 @@ object Stream extends StreamLowPriority {
   def fromOption[F[_]]: PartiallyAppliedFromOption[F] =
     new PartiallyAppliedFromOption(dummy = true)
 
-  private[fs2] final class PartiallyAppliedFromEither[F[_]](
-      private val dummy: Boolean
-  ) extends AnyVal {
+  private[fs2] final class PartiallyAppliedFromEither[F[_]](private val dummy: Boolean)
+      extends AnyVal {
     def apply[A](either: Either[Throwable, A])(implicit ev: RaiseThrowable[F]): Stream[F, A] =
       either.fold(Stream.raiseError[F], Stream.emit)
   }
@@ -3131,9 +3070,8 @@ object Stream extends StreamLowPriority {
   def fromEither[F[_]]: PartiallyAppliedFromEither[F] =
     new PartiallyAppliedFromEither(dummy = true)
 
-  private[fs2] final class PartiallyAppliedFromIterator[F[_]](
-      private val blocking: Boolean
-  ) extends AnyVal {
+  private[fs2] final class PartiallyAppliedFromIterator[F[_]](private val blocking: Boolean)
+      extends AnyVal {
     def apply[A](iterator: Iterator[A], chunkSize: Int)(implicit F: Sync[F]): Stream[F, A] = {
       def eff[B](thunk: => B) = if (blocking) F.blocking(thunk) else F.delay(thunk)
 
@@ -3366,9 +3304,7 @@ object Stream extends StreamLowPriority {
 
   /** Starts the supplied task and cancels it as finalization of the returned stream.
     */
-  def supervise[F[_], A](
-      fa: F[A]
-  )(implicit F: Concurrent[F]): Stream[F, Fiber[F, Throwable, A]] =
+  def supervise[F[_], A](fa: F[A])(implicit F: Concurrent[F]): Stream[F, Fiber[F, Throwable, A]] =
     bracket(F.start(fa))(_.cancel)
 
   /** Returns a stream that evaluates the supplied by-name each time the stream is used,
@@ -3558,9 +3494,7 @@ object Stream extends StreamLowPriority {
     /** Repeatedly invokes `using`, running the resultant `Pull` each time, halting when a pull
       * returns `None` instead of `Some(nextStream)`.
       */
-    def repeatPull[O2](
-        f: Stream.ToPull[F, O] => Pull[F, O2, Option[Stream[F, O]]]
-    ): Stream[F, O2] =
+    def repeatPull[O2](f: Stream.ToPull[F, O] => Pull[F, O2, Option[Stream[F, O]]]): Stream[F, O2] =
       Pull.loop(f.andThen(_.map(_.map(_.pull))))(pull).void.stream
   }
 
@@ -3598,9 +3532,7 @@ object Stream extends StreamLowPriority {
       *
       * @param maxOpen    Maximum number of open inner streams at any time. Must be > 0.
       */
-    def parJoin(
-        maxOpen: Int
-    )(implicit F: Concurrent[F]): Stream[F, O] = {
+    def parJoin(maxOpen: Int)(implicit F: Concurrent[F]): Stream[F, O] = {
       assert(maxOpen > 0, "maxOpen must be > 0, was: " + maxOpen)
       val fstream: F[Stream[F, O]] = for {
         done <- SignallingRef(None: Option[Option[Throwable]])
@@ -3742,9 +3674,7 @@ object Stream extends StreamLowPriority {
   }
 
   /** Projection of a `Stream` providing various ways to get a `Pull` from the `Stream`. */
-  final class ToPull[F[_], O] private[Stream] (
-      private val self: Stream[F, O]
-  ) extends AnyVal {
+  final class ToPull[F[_], O] private[Stream] (private val self: Stream[F, O]) extends AnyVal {
 
     /** Waits for a chunk of elements to be available in the source stream.
       * The chunk of elements along with a new stream are provided as the resource of the returned pull.
@@ -4071,9 +4001,9 @@ object Stream extends StreamLowPriority {
   }
 
   /** Projection of a `Stream` providing various ways to compile a `Stream[F,O]` to a `G[...]`. */
-  final class CompileOps[F[_], G[_], O] private[Stream] (
-      private val underlying: Pull[F, O, Unit]
-  )(implicit compiler: Compiler[F, G]) {
+  final class CompileOps[F[_], G[_], O] private[Stream] (private val underlying: Pull[F, O, Unit])(
+      implicit compiler: Compiler[F, G]
+  ) {
 
     /** Compiles this stream in to a value of the target effect type `F` and
       * discards any output values of the stream.
@@ -4244,8 +4174,8 @@ object Stream extends StreamLowPriority {
       * This works for every other `compile.` method, although it's a
       * very natural fit with `lastOrError`.
       */
-    def resource(implicit
-        compiler: Compiler[F, Resource[G, *]]
+    def resource(
+        implicit compiler: Compiler[F, Resource[G, *]]
     ): Stream.CompileOps[F, Resource[G, *], O] =
       new Stream.CompileOps[F, Resource[G, *], O](underlying)
 
@@ -4374,10 +4304,9 @@ object Stream extends StreamLowPriority {
     *  classes, so the presence of the `State` trait forces this
     *  method to be outside of the `Stream` class.
     */
-  private[fs2] def parZip[F[_], L, R](
-      left: Stream[F, L],
-      right: Stream[F, R]
-  )(implicit F: Concurrent[F]): Stream[F, (L, R)] = {
+  private[fs2] def parZip[F[_], L, R](left: Stream[F, L], right: Stream[F, R])(
+      implicit F: Concurrent[F]
+  ): Stream[F, (L, R)] = {
     sealed trait State
     case object Racing extends State
     case class LeftFirst(leftValue: L, waitOnRight: Deferred[F, Unit]) extends State
@@ -4460,8 +4389,8 @@ object Stream extends StreamLowPriority {
     * res0: List[(Int, Int)] = List((1,1), (-2,2), (3,3))
     * }}}
     */
-  implicit def monadErrorInstance[F[_]](implicit
-      ev: ApplicativeError[F, Throwable]
+  implicit def monadErrorInstance[F[_]](
+      implicit ev: ApplicativeError[F, Throwable]
   ): MonadError[Stream[F, *], Throwable] =
     new MonadError[Stream[F, *], Throwable] {
       def pure[A](a: A) = Stream(a)
@@ -4496,12 +4425,10 @@ object Stream extends StreamLowPriority {
       private type ZipWithCont[G[_], O2, L, R] =
         Either[(Chunk[O2], Stream[G, O2]), Stream[G, O2]] => Pull[G, Ior[L, R], Unit]
 
-      private def alignWith_[F2[x] >: F[x], O2, O3](
-          fa: Stream[F2, O2],
-          fb: Stream[F2, O3]
-      )(k1: ZipWithCont[F2, O2, O2, O3], k2: ZipWithCont[F2, O3, O2, O3])(
-          f: (O2, O3) => Ior[O2, O3]
-      ): Stream[F2, Ior[O2, O3]] = {
+      private def alignWith_[F2[x] >: F[x], O2, O3](fa: Stream[F2, O2], fb: Stream[F2, O3])(
+          k1: ZipWithCont[F2, O2, O2, O3],
+          k2: ZipWithCont[F2, O3, O2, O3]
+      )(f: (O2, O3) => Ior[O2, O3]): Stream[F2, Ior[O2, O3]] = {
         def go(
             leg1: Stream.StepLeg[F2, O2],
             leg2: Stream.StepLeg[F2, O3]

--- a/core/shared/src/main/scala/fs2/concurrent/Balance.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Balance.scala
@@ -99,9 +99,7 @@ object Balance {
     * @param pipes pipes to use to process work
     * @param chunkSize maximum chunk to present to each pipe, allowing fair distribution between pipes
     */
-  def through[F[_]: Concurrent, O, O2](
-      chunkSize: Int
-  )(pipes: Pipe[F, O, O2]*): Pipe[F, O, O2] =
+  def through[F[_]: Concurrent, O, O2](chunkSize: Int)(pipes: Pipe[F, O, O2]*): Pipe[F, O, O2] =
     _.balance(chunkSize)
       .take(pipes.size.toLong)
       .zipWithIndex

--- a/core/shared/src/main/scala/fs2/concurrent/PubSub.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/PubSub.scala
@@ -94,11 +94,7 @@ private[fs2] object PubSub {
       PubSubState(strategy.initial, ScalaQueue.empty, ScalaQueue.empty)
     ).map(state => new PubSubAsync(strategy, state))
 
-  private final case class Publisher[F[_], A](
-      token: Token,
-      i: A,
-      signal: Deferred[F, Unit]
-  ) {
+  private final case class Publisher[F[_], A](token: Token, i: A, signal: Deferred[F, Unit]) {
     def complete(implicit F: Functor[F]): F[Unit] =
       signal.complete(()).void
   }
@@ -616,10 +612,7 @@ private[fs2] object PubSub {
         * @param qs           State of the strategy to be inspected
         * @param inspected    List of subscribers that have seen the `qs` already
         */
-      final case class State[S](
-          qs: S,
-          inspected: Set[Token]
-      )
+      final case class State[S](qs: S, inspected: Set[Token])
 
       /** Allows to enhance the supplied strategy by ability to inspect the state.
         * If the `S` is same as previous state (by applying the supplied `Eq` then

--- a/core/shared/src/main/scala/fs2/concurrent/Queue.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Queue.scala
@@ -175,15 +175,11 @@ object Queue {
   def circularBufferNoneTerminated[F[_]: Concurrent, A](
       maxSize: Int
   ): F[NoneTerminatedQueue[F, A]] =
-    createNoneTerminated(
-      PubSub.Strategy.closeDrainFirst(Strategy.circularBuffer(maxSize))
-    )
+    createNoneTerminated(PubSub.Strategy.closeDrainFirst(Strategy.circularBuffer(maxSize)))
 
   /** Created a bounded queue that distributed always at max `fairSize` elements to any subscriber. */
   def fairBounded[F[_]: Concurrent, A](maxSize: Int, fairSize: Int): F[Queue[F, A]] =
-    create(
-      Strategy.boundedFifo(maxSize).transformSelector[Int]((sz, _) => sz.min(fairSize))
-    )
+    create(Strategy.boundedFifo(maxSize).transformSelector[Int]((sz, _) => sz.min(fairSize)))
 
   /** Created an unbounded queue terminated by enqueueing `None`. All elements before `None`. */
   def noneTerminated[F[_]: Concurrent, A]: F[NoneTerminatedQueue[F, A]] =
@@ -412,13 +408,9 @@ object InspectableQueue {
   def circularBuffer[F[_]: Concurrent, A](maxSize: Int): F[InspectableQueue[F, A]] =
     create(Queue.Strategy.circularBuffer[A](maxSize))(_.headOption)(_.size)
 
-  def create[F[_], S, A](
-      strategy: PubSub.Strategy[A, Chunk[A], S, Int]
-  )(
+  def create[F[_], S, A](strategy: PubSub.Strategy[A, Chunk[A], S, Int])(
       headOf: S => Option[A]
-  )(
-      sizeOf: S => Int
-  )(implicit F: Concurrent[F]): F[InspectableQueue[F, A]] = {
+  )(sizeOf: S => Int)(implicit F: Concurrent[F]): F[InspectableQueue[F, A]] = {
     implicit def eqInstance: Eq[S] = Eq.fromUniversalEquals[S]
     PubSub(PubSub.Strategy.Inspectable.strategy(strategy)).map { pubSub =>
       new InspectableQueue[F, A] {
@@ -466,11 +458,9 @@ object InspectableQueue {
         def dequeueBatch: Pipe[F, Int, A] =
           _.flatMap { sz =>
             Stream
-              .evalUnChunk(
-                pubSub.get(Right(sz)).map {
-                  _.getOrElse(Chunk.empty)
-                }
-              )
+              .evalUnChunk(pubSub.get(Right(sz)).map {
+                _.getOrElse(Chunk.empty)
+              })
           }
 
         def peek1: F[A] =

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -74,9 +74,7 @@ object Signal extends SignalInstances {
   }
 
   implicit class BooleanSignalOps[F[_]](val self: Signal[F, Boolean]) extends AnyVal {
-    def interrupt[A](
-        s: Stream[F, A]
-    )(implicit F: Concurrent[F]): Stream[F, A] =
+    def interrupt[A](s: Stream[F, A])(implicit F: Concurrent[F]): Stream[F, A] =
       s.interruptWhen(self)
   }
 }

--- a/core/shared/src/main/scala/fs2/concurrent/Topic.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Topic.scala
@@ -160,10 +160,7 @@ object Topic {
   }
 
   private[fs2] object Strategy {
-    final case class State[A](
-        last: A,
-        subscribers: Map[(Token, Int), SizedQueue[A]]
-    )
+    final case class State[A](last: A, subscribers: Map[(Token, Int), SizedQueue[A]])
 
     /** Strategy for topic, where every subscriber can specify max size of queued elements.
       * If that subscription is exceeded any other `publish` to the topic will hold,
@@ -181,10 +178,7 @@ object Topic {
           state.subscribers.forall { case ((_, max), q) => q.size < max }
 
         def publish(i: A, state: State[A]): State[A] =
-          State(
-            last = i,
-            subscribers = state.subscribers.map { case (k, v) => (k, v :+ i) }
-          )
+          State(last = i, subscribers = state.subscribers.map { case (k, v) => (k, v :+ i) })
 
         // Register empty queue
         def regEmpty(selector: (Token, Int), state: State[A]): State[A] =

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -249,10 +249,8 @@ private[fs2] final class CompileScope[F[_]] private (
           _ <- self.interruptible.map(_.cancelParent).getOrElse(F.unit)
           _ <- self.parent.fold(F.unit)(_.releaseChildScope(self.id))
         } yield {
-          val results = resultChildren.fold(List(_), _ => Nil) ++ resultResources.fold(
-            List(_),
-            _ => Nil
-          )
+          val results =
+            resultChildren.fold(List(_), _ => Nil) ++ resultResources.fold(List(_), _ => Nil)
           CompositeFailure.fromList(results.toList).toLeft(())
         }
       case _: CompileScope.State.Closed[F] => F.pure(Right(()))

--- a/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
+++ b/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
@@ -60,10 +60,7 @@ final private[fs2] case class InterruptContext[F[_]](
     * @param interruptible  Whether the child scope should be interruptible.
     * @param newScopeId     The id of the new scope.
     */
-  def childContext(
-      interruptible: Boolean,
-      newScopeId: Token
-  ): F[InterruptContext[F]] =
+  def childContext(interruptible: Boolean, newScopeId: Token): F[InterruptContext[F]] =
     if (interruptible) {
       self.deferred.get.start.flatMap { fiber =>
         InterruptContext(newScopeId, fiber.cancel).flatMap { context =>
@@ -93,10 +90,9 @@ private[fs2] object InterruptContext {
 
   type InterruptionOutcome = Outcome[Id, Throwable, Token]
 
-  def apply[F[_]](
-      newScopeId: Token,
-      cancelParent: F[Unit]
-  )(implicit F: Concurrent[F]): F[InterruptContext[F]] =
+  def apply[F[_]](newScopeId: Token, cancelParent: F[Unit])(
+      implicit F: Concurrent[F]
+  ): F[InterruptContext[F]] =
     for {
       ref <- F.ref[Option[InterruptionOutcome]](None)
       deferred <- F.deferred[InterruptionOutcome]

--- a/core/shared/src/main/scala/fs2/internal/ScopedResource.scala
+++ b/core/shared/src/main/scala/fs2/internal/ScopedResource.scala
@@ -149,10 +149,8 @@ private[internal] object ScopedResource {
           else {
             val attemptFinalizer = (ec: Resource.ExitCase) => finalizer(ec).attempt
             // either state is open, or leases are present, either release or `Lease#cancel` will run the finalizer
-            s.copy(finalizer = Some(attemptFinalizer)) -> (Right(true): Either[
-              Throwable,
-              Boolean
-            ]).pure[F]
+            s.copy(finalizer = Some(attemptFinalizer)) -> (Right(true): Either[Throwable, Boolean])
+              .pure[F]
           }
         }.flatten
 

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -365,12 +365,7 @@ object text {
               Right(Chunk((state.buffer >> 4).toByte))
             case 3 =>
               val buffer = state.buffer
-              Right(
-                Chunk(
-                  (buffer >> 10).toByte,
-                  (buffer >> 2).toByte
-                )
-              )
+              Right(Chunk((buffer >> 10).toByte, (buffer >> 2).toByte))
           }
 
       def go(state: State, s: Stream[F, String]): Pull[F, Byte, Unit] =
@@ -408,9 +403,8 @@ object text {
         var idx = 0
         val mod = bytes.length % 3
         while (idx < bytes.length - mod) {
-          var buffer = ((bytes(idx) & 0xff) << 16) | ((bytes(idx + 1) & 0xff) << 8) | (bytes(
-            idx + 2
-          ) & 0xff)
+          var buffer =
+            ((bytes(idx) & 0xff) << 16) | ((bytes(idx + 1) & 0xff) << 8) | (bytes(idx + 2) & 0xff)
           val fourth = buffer & 0x3f
           buffer = buffer >> 6
           val third = buffer & 0x3f

--- a/core/shared/src/test/scala/fs2/BracketSuite.scala
+++ b/core/shared/src/test/scala/fs2/BracketSuite.scala
@@ -63,10 +63,7 @@ class BracketSuite extends Fs2Suite {
   }
 
   group("bracket ++ bracket") {
-    def appendBracketTest[F[_]: Sync, A](
-        use1: Stream[F, A],
-        use2: Stream[F, A]
-    ): F[Unit] =
+    def appendBracketTest[F[_]: Sync, A](use1: Stream[F, A], use2: Stream[F, A]): F[Unit] =
       for {
         events <- Ref[F].of[Vector[BracketEvent]](Vector.empty)
         _ <-
@@ -150,13 +147,7 @@ class BracketSuite extends Fs2Suite {
         .toList
         .map { _ =>
           assert(
-            buffer.toList == List(
-              "Acquired",
-              "Used",
-              "FlatMapped",
-              "ReleaseInvoked",
-              "Released"
-            )
+            buffer.toList == List("Acquired", "Used", "FlatMapped", "ReleaseInvoked", "Released")
           )
         }
     }

--- a/core/shared/src/test/scala/fs2/ChunkGenerators.scala
+++ b/core/shared/src/test/scala/fs2/ChunkGenerators.scala
@@ -60,11 +60,7 @@ trait ChunkGeneratorsLowPriority1 extends MiscellaneousGenerators {
         .map(as => Chunk.chain(Chain.fromSeq(as))) // TODO Add variety in Chain
     )
 
-    Gen.frequency(
-      20 -> Gen.resize(20, gen),
-      5 -> gen,
-      2 -> Gen.resize(300, gen)
-    )
+    Gen.frequency(20 -> Gen.resize(20, gen), 5 -> gen, 2 -> Gen.resize(300, gen))
   }
 }
 
@@ -84,9 +80,9 @@ trait ChunkGeneratorsLowPriority extends ChunkGeneratorsLowPriority1 {
 }
 
 trait ChunkGenerators extends ChunkGeneratorsLowPriority {
-  private def arrayChunkGenerator[A](genA: Gen[A])(
-      build: (Array[A], Int, Int) => Chunk[A]
-  )(implicit ct: ClassTag[A]): Gen[Chunk[A]] =
+  private def arrayChunkGenerator[A](
+      genA: Gen[A]
+  )(build: (Array[A], Int, Int) => Chunk[A])(implicit ct: ClassTag[A]): Gen[Chunk[A]] =
     for {
       values <- Gen.listOf(genA).map(_.toArray)
       offset <- Gen.chooseNum(0, values.size)
@@ -247,10 +243,7 @@ trait ChunkGenerators extends ChunkGeneratorsLowPriority {
     )
 
   val charChunkGenerator: Gen[Chunk[Char]] =
-    Gen.frequency(
-      9 -> chunkGenerator(arbitrary[Char]),
-      1 -> charBufferChunkGenerator
-    )
+    Gen.frequency(9 -> chunkGenerator(arbitrary[Char]), 1 -> charBufferChunkGenerator)
   implicit val charChunkArbitrary: Arbitrary[Chunk[Char]] =
     Arbitrary(charChunkGenerator)
 

--- a/core/shared/src/test/scala/fs2/Fs2Suite.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Suite.scala
@@ -51,8 +51,8 @@ abstract class Fs2Suite extends ScalaCheckEffectSuite with TestPlatform with Gen
 
     /** Asserts that the `F[A]` fails with an exception of type `E`.
       */
-    def assertThrows[E <: Throwable](implicit
-        F: Sync[F],
+    def assertThrows[E <: Throwable](
+        implicit F: Sync[F],
         ct: reflect.ClassTag[E],
         loc: Location
     ): F[Unit] =

--- a/core/shared/src/test/scala/fs2/Generators.scala
+++ b/core/shared/src/test/scala/fs2/Generators.scala
@@ -40,8 +40,8 @@ trait Generators extends ChunkGenerators {
       )
     }
 
-  implicit def effectfulStreamGenerator[F[_], O](implicit
-      arbO: Arbitrary[O],
+  implicit def effectfulStreamGenerator[F[_], O](
+      implicit arbO: Arbitrary[O],
       arbFo: Arbitrary[F[O]],
       arbFu: Arbitrary[F[Unit]]
   ): Arbitrary[Stream[F, O]] =
@@ -58,8 +58,8 @@ trait Generators extends ChunkGenerators {
       )
     )
 
-  implicit def pullGenerator[F[_], O, R](implicit
-      arbR: Arbitrary[R],
+  implicit def pullGenerator[F[_], O, R](
+      implicit arbR: Arbitrary[R],
       arbFr: Arbitrary[F[R]],
       arbFo: Arbitrary[F[O]],
       arbO: Arbitrary[O],

--- a/core/shared/src/test/scala/fs2/HotswapSuite.scala
+++ b/core/shared/src/test/scala/fs2/HotswapSuite.scala
@@ -31,13 +31,7 @@ class HotswapSuite extends Fs2Suite {
         .flatMap(_ => logger.logInfo("using"))
         .compile
         .drain *> logger.get.map(it =>
-        assert(
-          it == List(
-            LogEvent.Acquired("a"),
-            LogEvent.Info("using"),
-            LogEvent.Released("a")
-          )
-        )
+        assert(it == List(LogEvent.Acquired("a"), LogEvent.Info("using"), LogEvent.Released("a")))
       )
     }
   }

--- a/core/shared/src/test/scala/fs2/StreamAlignSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamAlignSuite.scala
@@ -35,29 +35,22 @@ class StreamAlignSuite extends Fs2Suite {
   test("left side empty and right side populated") {
     val empty = Stream.empty
     val s = Stream("A", "B", "C")
-    assert(
-      empty.align(s).take(3).toList == List(Ior.Right("A"), Ior.Right("B"), Ior.Right("C"))
-    )
+    assert(empty.align(s).take(3).toList == List(Ior.Right("A"), Ior.Right("B"), Ior.Right("C")))
   }
 
   test("right side empty and left side populated") {
     val empty = Stream.empty
     val s = Stream("A", "B", "C")
-    assert(
-      s.align(empty).take(3).toList == List(Ior.Left("A"), Ior.Left("B"), Ior.Left("C"))
-    )
+    assert(s.align(empty).take(3).toList == List(Ior.Left("A"), Ior.Left("B"), Ior.Left("C")))
   }
 
   test("values in both sides") {
     val ones = Stream.constant("1")
     val s = Stream("A", "B", "C")
     assert(
-      s.align(ones).take(4).toList == List(
-        Ior.Both("A", "1"),
-        Ior.Both("B", "1"),
-        Ior.Both("C", "1"),
-        Ior.Right("1")
-      )
+      s.align(ones)
+        .take(4)
+        .toList == List(Ior.Both("A", "1"), Ior.Both("B", "1"), Ior.Both("C", "1"), Ior.Right("1"))
     )
   }
 

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -339,10 +339,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
             .covary[IO]
             .evalFilterAsync(n) { _ =>
               val ensureAcquired =
-                sem.tryAcquire.ifM(
-                  IO.unit,
-                  IO.raiseError(new Throwable("Couldn't acquire permit"))
-                )
+                sem.tryAcquire.ifM(IO.unit, IO.raiseError(new Throwable("Couldn't acquire permit")))
 
               ensureAcquired.bracket(_ =>
                 sig.update(_ + 1).bracket(_ => IO.sleep(10.millis))(_ => sig.update(_ - 1))
@@ -426,10 +423,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
             .covary[IO]
             .evalFilterNotAsync(n) { _ =>
               val ensureAcquired =
-                sem.tryAcquire.ifM(
-                  IO.unit,
-                  IO.raiseError(new Throwable("Couldn't acquire permit"))
-                )
+                sem.tryAcquire.ifM(IO.unit, IO.raiseError(new Throwable("Couldn't acquire permit")))
 
               ensureAcquired.bracket(_ =>
                 sig.update(_ + 1).bracket(_ => IO.sleep(10.millis))(_ => sig.update(_ - 1))
@@ -790,30 +784,10 @@ class StreamCombinatorsSuite extends Fs2Suite {
       val ones = Stream.constant("1")
       val s = Stream("A", "B", "C")
       assert(
-        ones.interleaveAll(s).take(9).toList == List(
-          "1",
-          "A",
-          "1",
-          "B",
-          "1",
-          "C",
-          "1",
-          "1",
-          "1"
-        )
+        ones.interleaveAll(s).take(9).toList == List("1", "A", "1", "B", "1", "C", "1", "1", "1")
       )
       assert(
-        s.interleaveAll(ones).take(9).toList == List(
-          "A",
-          "1",
-          "B",
-          "1",
-          "C",
-          "1",
-          "1",
-          "1",
-          "1"
-        )
+        s.interleaveAll(ones).take(9).toList == List("A", "1", "B", "1", "C", "1", "1", "1", "1")
       )
     }
 
@@ -1102,16 +1076,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
     def ones(s: String) = Chunk.vector(s.grouped(1).toVector)
     assert(input.take(2).repartition(ones).toVector == Vector("a", "b", "a", "b"))
     assert(
-      input.take(4).repartition(ones).toVector == Vector(
-        "a",
-        "b",
-        "a",
-        "b",
-        "a",
-        "b",
-        "a",
-        "b"
-      )
+      input.take(4).repartition(ones).toVector == Vector("a", "b", "a", "b", "a", "b", "a", "b")
     )
     assert(input.repartition(ones).take(2).toVector == Vector("a", "b"))
     assert(input.repartition(ones).take(4).toVector == Vector("a", "b", "a", "b"))
@@ -1122,9 +1087,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
         .toVector == Vector("a", "b", "a", "b", "a", "b", "a", "b")
     )
 
-    assert(
-      Stream(1, 2, 3, 4, 5).repartition(i => Chunk(i, i)).toList == List(1, 3, 6, 10, 15, 15)
-    )
+    assert(Stream(1, 2, 3, 4, 5).repartition(i => Chunk(i, i)).toList == List(1, 3, 6, 10, 15, 15))
 
     assert(
       Stream(1, 10, 100)
@@ -1222,12 +1185,10 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
     test("2") {
       assert(
-        Stream(1, 2, 0, 0, 3, 0, 4).split(_ == 0).toVector.map(_.toVector) == Vector(
-          Vector(1, 2),
-          Vector(),
-          Vector(3),
-          Vector(4)
-        )
+        Stream(1, 2, 0, 0, 3, 0, 4)
+          .split(_ == 0)
+          .toVector
+          .map(_.toVector) == Vector(Vector(1, 2), Vector(), Vector(3), Vector(4))
       )
       assert(
         Stream(1, 2, 0, 0, 3, 0).split(_ == 0).toVector.map(_.toVector) == Vector(
@@ -1237,12 +1198,10 @@ class StreamCombinatorsSuite extends Fs2Suite {
         )
       )
       assert(
-        Stream(1, 2, 0, 0, 3, 0, 0).split(_ == 0).toVector.map(_.toVector) == Vector(
-          Vector(1, 2),
-          Vector(),
-          Vector(3),
-          Vector()
-        )
+        Stream(1, 2, 0, 0, 3, 0, 0)
+          .split(_ == 0)
+          .toVector
+          .map(_.toVector) == Vector(Vector(1, 2), Vector(), Vector(3), Vector())
       )
     }
   }

--- a/core/shared/src/test/scala/fs2/StreamMergeSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamMergeSuite.scala
@@ -132,9 +132,7 @@ class StreamMergeSuite extends Fs2Suite {
                 finalizerRef.get.flatMap { finalizers =>
                   sideRunRef.get.flatMap { case (left, right) =>
                     if (left && right) IO {
-                      assert(
-                        List("Inner L", "Inner R", "Outer").forall(finalizers.contains)
-                      )
+                      assert(List("Inner L", "Inner R", "Outer").forall(finalizers.contains))
                       assert(finalizers.lastOption == Some("Outer"))
                       assert(r == Left(err))
                     }

--- a/core/shared/src/test/scala/fs2/StreamObserveSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamObserveSuite.scala
@@ -114,9 +114,7 @@ class StreamObserveSuite extends Fs2Suite {
   observationTests(
     "observe",
     new Observer {
-      def apply[F[_]: Async, O](
-          s: Stream[F, O]
-      )(observation: Pipe[F, O, INothing]): Stream[F, O] =
+      def apply[F[_]: Async, O](s: Stream[F, O])(observation: Pipe[F, O, INothing]): Stream[F, O] =
         s.observe(observation)
     }
   )
@@ -124,9 +122,7 @@ class StreamObserveSuite extends Fs2Suite {
   observationTests(
     "observeAsync",
     new Observer {
-      def apply[F[_]: Async, O](
-          s: Stream[F, O]
-      )(observation: Pipe[F, O, INothing]): Stream[F, O] =
+      def apply[F[_]: Async, O](s: Stream[F, O])(observation: Pipe[F, O, INothing]): Stream[F, O] =
         s.observeAsync(maxQueued = 10)(observation)
     }
   )

--- a/core/shared/src/test/scala/fs2/StreamSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamSuite.scala
@@ -388,9 +388,7 @@ class StreamSuite extends Fs2Suite {
     test("constant")(testCancelation(constantStream))
 
     test("bracketed stream") {
-      testCancelation(
-        Stream.bracket(IO.unit)(_ => IO.unit).flatMap(_ => constantStream)
-      )
+      testCancelation(Stream.bracket(IO.unit)(_ => IO.unit).flatMap(_ => constantStream))
     }
 
     test("concurrently") {
@@ -534,9 +532,7 @@ class StreamSuite extends Fs2Suite {
         // Bind
         val res2 = mkRes("21") *> mkRes("22")
         // Suspend
-        val res3 = Resource.suspend(
-          record("suspend").as(mkRes("3"))
-        )
+        val res3 = Resource.suspend(record("suspend").as(mkRes("3")))
 
         List(res1, res2, res3)
           .foldMap(Stream.resource(_))
@@ -582,9 +578,7 @@ class StreamSuite extends Fs2Suite {
         // Bind
         val res2 = mkRes("21") *> mkRes("22")
         // Suspend
-        val res3 = Resource.suspend(
-          record("suspend").as(mkRes("3"))
-        )
+        val res3 = Resource.suspend(record("suspend").as(mkRes("3")))
 
         List(res1, res2, res3)
           .foldMap(Stream.resourceWeak(_))
@@ -695,9 +689,8 @@ class StreamSuite extends Fs2Suite {
     test("4") {
       forAllF { (s: Stream[Pure, Int]) =>
         Counter[IO].flatMap { counter =>
-          val s2 = Stream.bracket(counter.increment)(_ => counter.decrement) >> spuriousFail(
-            s.covary[IO]
-          )
+          val s2 =
+            Stream.bracket(counter.increment)(_ => counter.decrement) >> spuriousFail(s.covary[IO])
           val one = s2.prefetch.attempt
           val two = s2.prefetch.prefetch.attempt
           val three = s2.prefetch.prefetch.prefetch.attempt
@@ -844,9 +837,8 @@ class StreamSuite extends Fs2Suite {
           Stream
             .eval(Deferred[IO, Unit].product(Deferred[IO, Unit]))
             .flatMap { case (startCondition, waitForStream) =>
-              val worker = Stream.eval(startCondition.get) ++ Stream.eval(
-                waitForStream.complete(())
-              )
+              val worker =
+                Stream.eval(startCondition.get) ++ Stream.eval(waitForStream.complete(()))
               val result = startCondition.complete(()) >> waitForStream.get
 
               Stream.emit(result).concurrently(worker)

--- a/core/shared/src/test/scala/fs2/StreamZipSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamZipSuite.scala
@@ -111,22 +111,15 @@ class StreamZipSuite extends Fs2Suite {
       val ones = Stream.constant("1")
       val s = Stream("A", "B", "C")
       assert(
-        ones.zipAll(s)("2", "Z").take(5).toList == List(
-          "1" -> "A",
-          "1" -> "B",
-          "1" -> "C",
-          "1" -> "Z",
-          "1" -> "Z"
-        )
+        ones
+          .zipAll(s)("2", "Z")
+          .take(5)
+          .toList == List("1" -> "A", "1" -> "B", "1" -> "C", "1" -> "Z", "1" -> "Z")
       )
       assert(
-        s.zipAll(ones)("Z", "2").take(5).toList == List(
-          "A" -> "1",
-          "B" -> "1",
-          "C" -> "1",
-          "Z" -> "1",
-          "Z" -> "1"
-        )
+        s.zipAll(ones)("Z", "2")
+          .take(5)
+          .toList == List("A" -> "1", "B" -> "1", "C" -> "1", "Z" -> "1", "Z" -> "1")
       )
     }
 
@@ -294,9 +287,7 @@ class StreamZipSuite extends Fs2Suite {
     test("2") {
       assert(Stream().zipWithPrevious.toList == Nil)
       assert(Stream(0).zipWithPrevious.toList == List((None, 0)))
-      assert(
-        Stream(0, 1, 2).zipWithPrevious.toList == List((None, 0), (Some(0), 1), (Some(1), 2))
-      )
+      assert(Stream(0, 1, 2).zipWithPrevious.toList == List((None, 0), (Some(0), 1), (Some(1), 2)))
     }
   }
 
@@ -347,9 +338,8 @@ class StreamZipSuite extends Fs2Suite {
 
   group("regressions") {
     test("#1089") {
-      (Stream.chunk(Chunk.bytes(Array.fill(2000)(1.toByte))) ++ Stream.eval(
-        IO.never[Byte]
-      )).take(2000).chunks.compile.toVector
+      (Stream.chunk(Chunk.bytes(Array.fill(2000)(1.toByte))) ++ Stream
+        .eval(IO.never[Byte])).take(2000).chunks.compile.toVector
     }
 
     test("#1107 - scope") {

--- a/core/shared/src/test/scala/fs2/concurrent/QueueSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/QueueSuite.scala
@@ -187,16 +187,14 @@ class QueueSuite extends Fs2Suite {
 
   test("peek1") {
     Stream
-      .eval(
-        for {
-          q <- InspectableQueue.unbounded[IO, Int]
-          f <- q.peek1.start
-          g <- q.peek1.start
-          _ <- q.enqueue1(42)
-          x <- f.joinAndEmbedNever
-          y <- g.joinAndEmbedNever
-        } yield List(x, y)
-      )
+      .eval(for {
+        q <- InspectableQueue.unbounded[IO, Int]
+        f <- q.peek1.start
+        g <- q.peek1.start
+        _ <- q.enqueue1(42)
+        x <- f.joinAndEmbedNever
+        y <- g.joinAndEmbedNever
+      } yield List(x, y))
       .compile
       .toList
       .map(it => assertEquals(it.flatten, List(42, 42)))
@@ -204,19 +202,17 @@ class QueueSuite extends Fs2Suite {
 
   test("peek1 with dequeue1") {
     Stream
-      .eval(
-        for {
-          q <- InspectableQueue.unbounded[IO, Int]
-          f <- q.peek1.product(q.dequeue1).start
-          _ <- q.enqueue1(42)
-          x <- f.joinAndEmbedNever
-          g <- q.peek1.product(q.dequeue1).product(q.peek1.product(q.dequeue1)).start
-          _ <- q.enqueue1(43)
-          _ <- q.enqueue1(44)
-          yz <- g.joinAndEmbedNever
-          (y, z) = yz
-        } yield List(x, y, z)
-      )
+      .eval(for {
+        q <- InspectableQueue.unbounded[IO, Int]
+        f <- q.peek1.product(q.dequeue1).start
+        _ <- q.enqueue1(42)
+        x <- f.joinAndEmbedNever
+        g <- q.peek1.product(q.dequeue1).product(q.peek1.product(q.dequeue1)).start
+        _ <- q.enqueue1(43)
+        _ <- q.enqueue1(44)
+        yz <- g.joinAndEmbedNever
+        (y, z) = yz
+      } yield List(x, y, z))
       .compile
       .toList
       .map(it => assertEquals(it.flatten, List((42, 42), (43, 43), (44, 44))))
@@ -224,18 +220,16 @@ class QueueSuite extends Fs2Suite {
 
   test("peek1 bounded queue") {
     Stream
-      .eval(
-        for {
-          q <- InspectableQueue.bounded[IO, Int](maxSize = 1)
-          f <- q.peek1.start
-          g <- q.peek1.start
-          _ <- q.enqueue1(42)
-          b <- q.offer1(43)
-          x <- f.joinAndEmbedNever
-          y <- g.joinAndEmbedNever
-          z <- q.dequeue1
-        } yield List(b, x, y, z)
-      )
+      .eval(for {
+        q <- InspectableQueue.bounded[IO, Int](maxSize = 1)
+        f <- q.peek1.start
+        g <- q.peek1.start
+        _ <- q.enqueue1(42)
+        b <- q.offer1(43)
+        x <- f.joinAndEmbedNever
+        y <- g.joinAndEmbedNever
+        z <- q.dequeue1
+      } yield List(b, x, y, z))
       .compile
       .toList
       .map(it => assertEquals(it.flatten, List[AnyVal](false, 42, 42, 42)))
@@ -243,18 +237,16 @@ class QueueSuite extends Fs2Suite {
 
   test("peek1 circular buffer") {
     Stream
-      .eval(
-        for {
-          q <- InspectableQueue.circularBuffer[IO, Int](maxSize = 1)
-          f <- q.peek1.start
-          g <- q.peek1.start
-          _ <- q.enqueue1(42)
-          x <- f.joinAndEmbedNever
-          y <- g.joinAndEmbedNever
-          b <- q.offer1(43)
-          z <- q.peek1
-        } yield List(b, x, y, z)
-      )
+      .eval(for {
+        q <- InspectableQueue.circularBuffer[IO, Int](maxSize = 1)
+        f <- q.peek1.start
+        g <- q.peek1.start
+        _ <- q.enqueue1(42)
+        x <- f.joinAndEmbedNever
+        y <- g.joinAndEmbedNever
+        b <- q.offer1(43)
+        z <- q.peek1
+      } yield List(b, x, y, z))
       .compile
       .toList
       .map(it => assertEquals(it.flatten, List[AnyVal](true, 42, 42, 43)))

--- a/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
+++ b/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
@@ -203,26 +203,24 @@ private[io] object JavaInputOutputStream {
         )
         .flatMap { case (queue, upState, dnState) =>
           val mkInputStream = processInput(source, queue, upState, dnState)
-            .as(
-              new InputStream {
-                override def close(): Unit =
-                  runner.unsafeRunAndForget(closeIs(upState, dnState))
+            .as(new InputStream {
+              override def close(): Unit =
+                runner.unsafeRunAndForget(closeIs(upState, dnState))
 
-                override def read(b: Array[Byte], off: Int, len: Int): Int =
-                  runner.unsafeRunSync(readOnce(b, off, len, queue, dnState))
+              override def read(b: Array[Byte], off: Int, len: Int): Int =
+                runner.unsafeRunSync(readOnce(b, off, len, queue, dnState))
 
-                def read(): Int = {
-                  def go(acc: Array[Byte]): F[Int] =
-                    readOnce(acc, 0, 1, queue, dnState).flatMap { read =>
-                      if (read < 0) F.pure(-1)
-                      else if (read == 0) go(acc)
-                      else F.pure(acc(0) & 0xff)
-                    }
+              def read(): Int = {
+                def go(acc: Array[Byte]): F[Int] =
+                  readOnce(acc, 0, 1, queue, dnState).flatMap { read =>
+                    if (read < 0) F.pure(-1)
+                    else if (read == 0) go(acc)
+                    else F.pure(acc(0) & 0xff)
+                  }
 
-                  runner.unsafeRunSync(go(new Array[Byte](1)))
-                }
+                runner.unsafeRunSync(go(new Array[Byte](1)))
               }
-            )
+            })
 
           Resource.make(mkInputStream)(_ => closeIs(upState, dnState))
         }

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -108,9 +108,7 @@ object FileHandle {
     SyncFiles[F].openFileChannel(channel)
 
   /** Creates a `FileHandle[F]` from a `java.nio.channels.FileChannel`. */
-  private[file] def make[F[_]](
-      chan: FileChannel
-  )(implicit F: Sync[F]): FileHandle[F] =
+  private[file] def make[F[_]](chan: FileChannel)(implicit F: Sync[F]): FileHandle[F] =
     new FileHandle[F] {
       type Lock = FileLock
 

--- a/io/src/main/scala/fs2/io/file/Files.scala
+++ b/io/src/main/scala/fs2/io/file/Files.scala
@@ -193,10 +193,7 @@ sealed trait SyncFiles[F[_]] {
     *
     * If `append` is true, the offset is initialized to the current size of the file.
     */
-  def writeCursorFromFileHandle(
-      file: FileHandle[F],
-      append: Boolean
-  ): F[WriteCursor[F]]
+  def writeCursorFromFileHandle(file: FileHandle[F], append: Boolean): F[WriteCursor[F]]
 }
 
 object SyncFiles {
@@ -221,10 +218,7 @@ object SyncFiles {
     def deleteIfExists(path: Path): F[Boolean] =
       Sync[F].blocking(JFiles.deleteIfExists(path))
 
-    def deleteDirectoryRecursively(
-        path: Path,
-        options: Set[FileVisitOption]
-    ): F[Unit] =
+    def deleteDirectoryRecursively(path: Path, options: Set[FileVisitOption]): F[Unit] =
       Sync[F].blocking {
         JFiles.walkFileTree(
           path,
@@ -360,10 +354,7 @@ object SyncFiles {
         Resource.liftF(cursor)
       }
 
-    def writeCursorFromFileHandle(
-        file: FileHandle[F],
-        append: Boolean
-    ): F[WriteCursor[F]] =
+    def writeCursorFromFileHandle(file: FileHandle[F], append: Boolean): F[WriteCursor[F]] =
       if (append) file.size.map(s => WriteCursor(file, s)) else WriteCursor(file, 0L).pure[F]
 
   }

--- a/io/src/main/scala/fs2/io/file/ReadCursor.scala
+++ b/io/src/main/scala/fs2/io/file/ReadCursor.scala
@@ -92,8 +92,8 @@ final case class ReadCursor[F[_]](file: FileHandle[F], offset: Long) {
     * @param pollDelay amount of time to wait upon reaching the end of the file before
     * polling for updates
     */
-  def tail(chunkSize: Int, pollDelay: FiniteDuration)(implicit
-      t: Temporal[F]
+  def tail(chunkSize: Int, pollDelay: FiniteDuration)(
+      implicit t: Temporal[F]
   ): Pull[F, Byte, ReadCursor[F]] =
     readPull(chunkSize).flatMap {
       case Some((next, chunk)) => Pull.output(chunk) >> next.tail(chunkSize, pollDelay)
@@ -104,9 +104,6 @@ final case class ReadCursor[F[_]](file: FileHandle[F], offset: Long) {
 object ReadCursor {
 
   @deprecated("Use Files[F].readCursor", "3.0.0")
-  def fromPath[F[_]: Sync](
-      path: Path,
-      flags: Seq[OpenOption] = Nil
-  ): Resource[F, ReadCursor[F]] =
+  def fromPath[F[_]: Sync](path: Path, flags: Seq[OpenOption] = Nil): Resource[F, ReadCursor[F]] =
     SyncFiles[F].readCursor(path, flags)
 }

--- a/io/src/main/scala/fs2/io/file/Watcher.scala
+++ b/io/src/main/scala/fs2/io/file/Watcher.scala
@@ -155,9 +155,7 @@ object Watcher {
       .flatMap(fromFileSystem(_))
 
   /** Creates a watcher for the supplied file system. */
-  def fromFileSystem[F[_]](
-      fs: FileSystem
-  )(implicit F: Async[F]): Resource[F, Watcher[F]] =
+  def fromFileSystem[F[_]](fs: FileSystem)(implicit F: Async[F]): Resource[F, Watcher[F]] =
     Resource(F.blocking(fs.newWatchService).flatMap { ws =>
       fromWatchService(ws).map(w => w -> F.blocking(ws.close))
     })
@@ -172,9 +170,7 @@ object Watcher {
   )
 
   /** Creates a watcher for the supplied NIO `WatchService`. */
-  def fromWatchService[F[_]](
-      ws: WatchService
-  )(implicit F: Async[F]): F[Watcher[F]] =
+  def fromWatchService[F[_]](ws: WatchService)(implicit F: Async[F]): F[Watcher[F]] =
     SignallingRef
       .of[F, Map[WatchKey, Registration[F]]](Map.empty)
       .map(new DefaultWatcher(ws, _))
@@ -182,9 +178,8 @@ object Watcher {
   private class DefaultWatcher[F[_]](
       ws: WatchService,
       registrations: SignallingRef[F, Map[WatchKey, Registration[F]]]
-  )(implicit
-      F: Async[F]
-  ) extends Watcher[F] {
+  )(implicit F: Async[F])
+      extends Watcher[F] {
     private def isDir(p: Path): F[Boolean] =
       F.blocking(Files.isDirectory(p))
 

--- a/io/src/main/scala/fs2/io/file/WriteCursor.scala
+++ b/io/src/main/scala/fs2/io/file/WriteCursor.scala
@@ -78,9 +78,6 @@ object WriteCursor {
     SyncFiles[F].writeCursor(path, flags)
 
   @deprecated("Use Files[F].writeCursorFromFileHandle", "3.0.0")
-  def fromFileHandle[F[_]: Sync](
-      file: FileHandle[F],
-      append: Boolean
-  ): F[WriteCursor[F]] =
+  def fromFileHandle[F[_]: Sync](file: FileHandle[F], append: Boolean): F[WriteCursor[F]] =
     SyncFiles[F].writeCursorFromFileHandle(file, append)
 }

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -34,22 +34,16 @@ import scala.concurrent.duration._
 package object file {
 
   @deprecated("Use Files[F].readAll", "3.0.0")
-  def readAll[F[_]: Sync](
-      path: Path,
-      chunkSize: Int
-  ): Stream[F, Byte] = SyncFiles[F].readAll(path, chunkSize)
+  def readAll[F[_]: Sync](path: Path, chunkSize: Int): Stream[F, Byte] =
+    SyncFiles[F].readAll(path, chunkSize)
 
   /** Reads a range of data synchronously from the file at the specified `java.nio.file.Path`.
     * `start` is inclusive, `end` is exclusive, so when `start` is 0 and `end` is 2,
     * two bytes are read.
     */
   @deprecated("Use Files[F].readRange", "3.0.0")
-  def readRange[F[_]: Sync](
-      path: Path,
-      chunkSize: Int,
-      start: Long,
-      end: Long
-  ): Stream[F, Byte] = SyncFiles[F].readRange(path, chunkSize, start, end)
+  def readRange[F[_]: Sync](path: Path, chunkSize: Int, start: Long, end: Long): Stream[F, Byte] =
+    SyncFiles[F].readRange(path, chunkSize, start, end)
 
   /** Returns an infinite stream of data from the file at the specified path.
     * Starts reading from the specified offset and upon reaching the end of the file,
@@ -123,10 +117,7 @@ package object file {
     * method in security sensitive applications.
     */
   @deprecated("Use Files[F].exists", "3.0.0")
-  def exists[F[_]: Sync](
-      path: Path,
-      flags: Seq[LinkOption] = Seq.empty
-  ): F[Boolean] =
+  def exists[F[_]: Sync](path: Path, flags: Seq[LinkOption] = Seq.empty): F[Boolean] =
     SyncFiles[F].exists(path, flags)
 
   /** Get file permissions as set of [[PosixFilePermission]]
@@ -145,10 +136,7 @@ package object file {
     * This will only work for POSIX supporting file systems
     */
   @deprecated("Use Files[F].setPermissions", "3.0.0")
-  def setPermissions[F[_]: Sync](
-      path: Path,
-      permissions: Set[PosixFilePermission]
-  ): F[Path] =
+  def setPermissions[F[_]: Sync](path: Path, permissions: Set[PosixFilePermission]): F[Path] =
     SyncFiles[F].setPermissions(path, permissions)
 
   /** Copies a file from the source to the target path,
@@ -156,11 +144,7 @@ package object file {
     * By default, the copy fails if the target file already exists or is a symbolic link.
     */
   @deprecated("Use Files[F].copy", "3.0.0")
-  def copy[F[_]: Sync](
-      source: Path,
-      target: Path,
-      flags: Seq[CopyOption] = Seq.empty
-  ): F[Path] =
+  def copy[F[_]: Sync](source: Path, target: Path, flags: Seq[CopyOption] = Seq.empty): F[Path] =
     SyncFiles[F].copy(source, target, flags)
 
   /** Deletes a file.
@@ -198,11 +182,7 @@ package object file {
     * By default, the move fails if the target file already exists or is a symbolic link.
     */
   @deprecated("Use Files[F].move", "3.0.0")
-  def move[F[_]: Sync](
-      source: Path,
-      target: Path,
-      flags: Seq[CopyOption] = Seq.empty
-  ): F[Path] =
+  def move[F[_]: Sync](source: Path, target: Path, flags: Seq[CopyOption] = Seq.empty): F[Path] =
     SyncFiles[F].move(source, target, flags)
 
   /** Creates a stream containing the path of a temporary file.
@@ -258,19 +238,13 @@ package object file {
   /** Creates a new directory at the given path
     */
   @deprecated("Use Files[F].createDirectory", "3.0.0")
-  def createDirectory[F[_]: Sync](
-      path: Path,
-      flags: Seq[FileAttribute[_]] = Seq.empty
-  ): F[Path] =
+  def createDirectory[F[_]: Sync](path: Path, flags: Seq[FileAttribute[_]] = Seq.empty): F[Path] =
     SyncFiles[F].createDirectory(path, flags)
 
   /** Creates a new directory at the given path and creates all nonexistent parent directories beforehand.
     */
   @deprecated("Use Files[F].createDirectories", "3.0.0")
-  def createDirectories[F[_]: Sync](
-      path: Path,
-      flags: Seq[FileAttribute[_]] = Seq.empty
-  ): F[Path] =
+  def createDirectories[F[_]: Sync](path: Path, flags: Seq[FileAttribute[_]] = Seq.empty): F[Path] =
     SyncFiles[F].createDirectories(path, flags)
 
   /** Creates a stream of [[Path]]s inside a directory.
@@ -282,19 +256,13 @@ package object file {
   /** Creates a stream of [[Path]]s inside a directory, filtering the results by the given predicate.
     */
   @deprecated("Use Files[F].directoryStream", "3.0.0")
-  def directoryStream[F[_]: Sync](
-      path: Path,
-      filter: Path => Boolean
-  ): Stream[F, Path] =
+  def directoryStream[F[_]: Sync](path: Path, filter: Path => Boolean): Stream[F, Path] =
     SyncFiles[F].directoryStream(path, filter)
 
   /** Creates a stream of [[Path]]s inside a directory which match the given glob.
     */
   @deprecated("Use Files[F].directoryStream", "3.0.0")
-  def directoryStream[F[_]: Sync](
-      path: Path,
-      glob: String
-  ): Stream[F, Path] =
+  def directoryStream[F[_]: Sync](path: Path, glob: String): Stream[F, Path] =
     SyncFiles[F].directoryStream(path, glob)
 
   /** Creates a stream of [[Path]]s contained in a given file tree. Depth is unlimited.
@@ -306,10 +274,7 @@ package object file {
   /** Creates a stream of [[Path]]s contained in a given file tree, respecting the supplied options. Depth is unlimited.
     */
   @deprecated("Use Files[F].walk", "3.0.0")
-  def walk[F[_]: Sync](
-      start: Path,
-      options: Seq[FileVisitOption]
-  ): Stream[F, Path] =
+  def walk[F[_]: Sync](start: Path, options: Seq[FileVisitOption]): Stream[F, Path] =
     SyncFiles[F].walk(start, options)
 
   /** Creates a stream of [[Path]]s contained in a given file tree down to a given depth.

--- a/io/src/main/scala/fs2/io/tcp/SocketGroup.scala
+++ b/io/src/main/scala/fs2/io/tcp/SocketGroup.scala
@@ -128,14 +128,7 @@ final class SocketGroup(channelGroup: AsynchronousChannelGroup) {
       additionalSocketOptions: List[SocketOptionMapping[_]] = List.empty
   )(implicit F: Network[F]): Stream[F, Resource[F, Socket[F]]] =
     Stream
-      .resource(
-        serverResource(
-          address,
-          reuseAddress,
-          receiveBufferSize,
-          additionalSocketOptions
-        )
-      )
+      .resource(serverResource(address, reuseAddress, receiveBufferSize, additionalSocketOptions))
       .flatMap { case (_, clients) => clients }
 
   /** Like [[server]] but provides the `InetSocketAddress` of the bound server socket before providing accepted sockets.

--- a/io/src/main/scala/fs2/io/tls/InputOutputBuffer.scala
+++ b/io/src/main/scala/fs2/io/tls/InputOutputBuffer.scala
@@ -81,9 +81,7 @@ private[tls] object InputOutputBuffer {
             }
           }
 
-      def perform[A](
-          f: (ByteBuffer, ByteBuffer) => A
-      ): F[A] =
+      def perform[A](f: (ByteBuffer, ByteBuffer) => A): F[A] =
         inBuff.get.flatMap { in =>
           outBuff.get.flatMap { out =>
             Sync[F].delay {

--- a/io/src/main/scala/fs2/io/tls/SSLEngineTaskRunner.scala
+++ b/io/src/main/scala/fs2/io/tls/SSLEngineTaskRunner.scala
@@ -34,9 +34,7 @@ private[tls] trait SSLEngineTaskRunner[F[_]] {
 }
 
 private[tls] object SSLEngineTaskRunner {
-  def apply[F[_]](
-      engine: SSLEngine
-  )(implicit F: Sync[F]): SSLEngineTaskRunner[F] =
+  def apply[F[_]](engine: SSLEngine)(implicit F: Sync[F]): SSLEngineTaskRunner[F] =
     new SSLEngineTaskRunner[F] {
       def runDelegatedTasks: F[Unit] =
         F.blocking(Option(engine.getDelegatedTask)).flatMap {

--- a/io/src/main/scala/fs2/io/tls/TLSContext.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSContext.scala
@@ -92,33 +92,17 @@ sealed trait TLSContext {
 object TLSContext {
 
   /** Creates a `TLSContext` from an `SSLContext`. */
-  def fromSSLContext(
-      ctx: SSLContext
-  ): TLSContext =
+  def fromSSLContext(ctx: SSLContext): TLSContext =
     new TLSContext {
-      def client[F[_]](
-          socket: Socket[F],
-          params: TLSParameters,
-          logger: Option[String => F[Unit]]
-      )(implicit F: Network[F]): Resource[F, TLSSocket[F]] =
-        mkSocket(
-          socket,
-          true,
-          params,
-          logger
-        )
+      def client[F[_]](socket: Socket[F], params: TLSParameters, logger: Option[String => F[Unit]])(
+          implicit F: Network[F]
+      ): Resource[F, TLSSocket[F]] =
+        mkSocket(socket, true, params, logger)
 
-      def server[F[_]](
-          socket: Socket[F],
-          params: TLSParameters,
-          logger: Option[String => F[Unit]]
-      )(implicit F: Network[F]): Resource[F, TLSSocket[F]] =
-        mkSocket(
-          socket,
-          false,
-          params,
-          logger
-        )
+      def server[F[_]](socket: Socket[F], params: TLSParameters, logger: Option[String => F[Unit]])(
+          implicit F: Network[F]
+      ): Resource[F, TLSSocket[F]] =
+        mkSocket(socket, false, params, logger)
 
       private def mkSocket[F[_]](
           socket: Socket[F],
@@ -150,13 +134,7 @@ object TLSContext {
           params: TLSParameters,
           logger: Option[String => F[Unit]]
       )(implicit F: Network[F]): Resource[F, DTLSSocket[F]] =
-        mkDtlsSocket(
-          socket,
-          remoteAddress,
-          true,
-          params,
-          logger
-        )
+        mkDtlsSocket(socket, remoteAddress, true, params, logger)
 
       def dtlsServer[F[_]](
           socket: udp.Socket[F],
@@ -164,13 +142,7 @@ object TLSContext {
           params: TLSParameters,
           logger: Option[String => F[Unit]]
       )(implicit F: Network[F]): Resource[F, DTLSSocket[F]] =
-        mkDtlsSocket(
-          socket,
-          remoteAddress,
-          false,
-          params,
-          logger
-        )
+        mkDtlsSocket(socket, remoteAddress, false, params, logger)
 
       private def mkDtlsSocket[F[_]](
           socket: udp.Socket[F],
@@ -249,11 +221,9 @@ object TLSContext {
   }
 
   /** Creates a `TLSContext` from the specified key store file. */
-  def fromKeyStoreFile[F[_]](
-      file: Path,
-      storePassword: Array[Char],
-      keyPassword: Array[Char]
-  )(implicit F: Network[F]): F[TLSContext] = {
+  def fromKeyStoreFile[F[_]](file: Path, storePassword: Array[Char], keyPassword: Array[Char])(
+      implicit F: Network[F]
+  ): F[TLSContext] = {
     import F.async
     val load = F.async.blocking(new FileInputStream(file.toFile): InputStream)
     val stream = Resource.make(load)(s => F.async.blocking(s.close))
@@ -290,10 +260,9 @@ object TLSContext {
   }
 
   /** Creates a `TLSContext` from the specified key store. */
-  def fromKeyStore[F[_]](
-      keyStore: KeyStore,
-      keyPassword: Array[Char]
-  )(implicit F: Network[F]): F[TLSContext] = {
+  def fromKeyStore[F[_]](keyStore: KeyStore, keyPassword: Array[Char])(
+      implicit F: Network[F]
+  ): F[TLSContext] = {
     import F.async
     F.async
       .blocking {

--- a/io/src/main/scala/fs2/io/tls/TLSEngine.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSEngine.scala
@@ -221,11 +221,7 @@ private[tls] object TLSEngine {
           .flatMap { result =>
             result.getStatus match {
               case SSLEngineResult.Status.OK | SSLEngineResult.Status.BUFFER_UNDERFLOW =>
-                doWrite(timeout) >> stepHandshake(
-                  result,
-                  true,
-                  timeout
-                )
+                doWrite(timeout) >> stepHandshake(result, true, timeout)
               case SSLEngineResult.Status.BUFFER_OVERFLOW =>
                 wrapBuffer.expandOutput >> wrapHandshake(timeout)
               case SSLEngineResult.Status.CLOSED =>

--- a/io/src/main/scala/fs2/io/tls/TLSSocket.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSSocket.scala
@@ -62,10 +62,7 @@ object TLSSocket {
   ): Resource[F, TLSSocket[F]] =
     Resource.make(mk(socket, engine))(_.close)
 
-  private def mk[F[_]: Async](
-      socket: Socket[F],
-      engine: TLSEngine[F]
-  ): F[TLSSocket[F]] =
+  private def mk[F[_]: Async](socket: Socket[F], engine: TLSEngine[F]): F[TLSSocket[F]] =
     for {
       readSem <- Semaphore(1)
     } yield new TLSSocket[F] {

--- a/io/src/main/scala/fs2/io/udp/SocketGroup.scala
+++ b/io/src/main/scala/fs2/io/udp/SocketGroup.scala
@@ -37,9 +37,7 @@ import java.nio.channels.{ClosedChannelException, DatagramChannel}
 import cats.effect.{Resource, Sync}
 import cats.syntax.all._
 
-final class SocketGroup(
-    asg: AsynchronousSocketGroup
-) {
+final class SocketGroup(asg: AsynchronousSocketGroup) {
 
   /** Provides a UDP Socket that, when run, will bind to the specified address.
     *
@@ -91,9 +89,7 @@ final class SocketGroup(
     Resource(mkChannel.flatMap(ch => mkSocket(ch).map(s => s -> s.close)))
   }
 
-  private[udp] def mkSocket[F[_]](
-      channel: DatagramChannel
-  )(implicit F: Network[F]): F[Socket[F]] =
+  private[udp] def mkSocket[F[_]](channel: DatagramChannel)(implicit F: Network[F]): F[Socket[F]] =
     F.async.blocking {
       new Socket[F] {
         private val ctx = asg.register(channel)

--- a/io/src/test/scala/fs2/io/file/FileSuite.scala
+++ b/io/src/test/scala/fs2/io/file/FileSuite.scala
@@ -195,14 +195,12 @@ class FileSuite extends BaseFileSuite {
 
   group("copy") {
     test("returns a path to the new file") {
-      assert(
-        (for {
-          filePath <- tempFile
-          tempDir <- tempDirectory
-          result <- Stream.eval(Files[IO].copy(filePath, tempDir.resolve("newfile")))
-          exists <- Stream.eval(Files[IO].exists(result))
-        } yield exists).compile.fold(true)(_ && _).unsafeRunSync() == true
-      )
+      assert((for {
+        filePath <- tempFile
+        tempDir <- tempDirectory
+        result <- Stream.eval(Files[IO].copy(filePath, tempDir.resolve("newfile")))
+        exists <- Stream.eval(Files[IO].exists(result))
+      } yield exists).compile.fold(true)(_ && _).unsafeRunSync() == true)
     }
   }
 
@@ -247,14 +245,12 @@ class FileSuite extends BaseFileSuite {
 
   group("move") {
     test("should result in the old path being deleted") {
-      assert(
-        (for {
-          filePath <- tempFile
-          tempDir <- tempDirectory
-          _ <- Stream.eval(Files[IO].move(filePath, tempDir.resolve("newfile")))
-          exists <- Stream.eval(Files[IO].exists(filePath))
-        } yield exists).compile.fold(false)(_ || _).unsafeRunSync() == false
-      )
+      assert((for {
+        filePath <- tempFile
+        tempDir <- tempDirectory
+        _ <- Stream.eval(Files[IO].move(filePath, tempDir.resolve("newfile")))
+        exists <- Stream.eval(Files[IO].exists(filePath))
+      } yield exists).compile.fold(false)(_ || _).unsafeRunSync() == false)
     }
   }
 

--- a/io/src/test/scala/fs2/io/tcp/SocketSuite.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSuite.scala
@@ -168,14 +168,8 @@ class SocketSuite extends Fs2Suite {
           Stream.resource(doNothingServer(socketGroup)) >>
             Stream.eval(localBindAddress.get).flatMap { address =>
               Stream
-                .resource(
-                  socketGroup.client[IO](address)
-                )
-                .flatMap(sock =>
-                  Stream(
-                    Stream.eval(sock.write(message)).repeatN(10L)
-                  ).repeatN(2L)
-                )
+                .resource(socketGroup.client[IO](address))
+                .flatMap(sock => Stream(Stream.eval(sock.write(message)).repeatN(10L)).repeatN(2L))
                 .parJoinUnbounded
             }
         }

--- a/io/src/test/scala/fs2/io/tls/TLSDebugExample.scala
+++ b/io/src/test/scala/fs2/io/tls/TLSDebugExample.scala
@@ -32,10 +32,7 @@ import cats.effect.{Async, IO}
 import cats.syntax.all._
 
 object TLSDebug {
-  def debug[F[_]: Async](
-      tlsContext: TLSContext,
-      address: InetSocketAddress
-  ): F[String] =
+  def debug[F[_]: Async](tlsContext: TLSContext, address: InetSocketAddress): F[String] =
     SocketGroup[F]().use { socketGroup =>
       socketGroup.client[F](address).use { rawSocket =>
         tlsContext

--- a/io/src/test/scala/fs2/io/tls/TLSSocketSuite.scala
+++ b/io/src/test/scala/fs2/io/tls/TLSSocketSuite.scala
@@ -118,9 +118,7 @@ class TLSSocketSuite extends TLSSuite {
             tlsContext
               .client[IO](
                 rawSocket,
-                TLSParameters(
-                  serverNames = Some(List(new SNIHostName("www.google.com")))
-                )
+                TLSParameters(serverNames = Some(List(new SNIHostName("www.google.com"))))
                 // logger = Some((m: String) =>
                 //   IO.delay(println(s"${Console.MAGENTA}[TLS] $m${Console.RESET}"))
                 // )

--- a/io/src/test/scala/fs2/io/tls/TLSSuite.scala
+++ b/io/src/test/scala/fs2/io/tls/TLSSuite.scala
@@ -27,9 +27,6 @@ import cats.effect.IO
 
 abstract class TLSSuite extends Fs2Suite {
   def testTlsContext: IO[TLSContext] =
-    TLSContext.fromKeyStoreResource[IO](
-      "keystore.jks",
-      "password".toCharArray,
-      "password".toCharArray
-    )
+    TLSContext
+      .fromKeyStoreResource[IO]("keystore.jks", "password".toCharArray, "password".toCharArray)
 }

--- a/io/src/test/scala/fs2/io/udp/UdpSuite.scala
+++ b/io/src/test/scala/fs2/io/udp/UdpSuite.scala
@@ -132,9 +132,7 @@ class UdpSuite extends Fs2Suite {
                     interface.getInetAddresses.asScala.exists(_.isInstanceOf[Inet4Address])
                   }
                 val server = Stream
-                  .exec(
-                    v4Interfaces.traverse_(interface => serverSocket.join(group, interface))
-                  ) ++
+                  .exec(v4Interfaces.traverse_(interface => serverSocket.join(group, interface))) ++
                   serverSocket
                     .reads()
                     .evalMap(packet => serverSocket.write(packet))

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
@@ -40,9 +40,8 @@ import org.reactivestreams._
 final class StreamSubscriber[F[_], A](
     val sub: StreamSubscriber.FSM[F, A],
     runner: Dispatcher.Runner[F]
-)(implicit
-    F: ApplicativeError[F, Throwable]
-) extends Subscriber[A] {
+)(implicit F: ApplicativeError[F, Throwable])
+    extends Subscriber[A] {
 
   /** Called by an upstream reactivestreams system */
   def onSubscribe(s: Subscription): Unit = {

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala
@@ -74,9 +74,7 @@ package object reactivestreams {
       * This publisher can only have a single subscription.
       * The stream is only ran when elements are requested.
       */
-    def toUnicastPublisher(implicit
-        F: Async[F]
-    ): Resource[F, StreamUnicastPublisher[F, A]] =
+    def toUnicastPublisher(implicit F: Async[F]): Resource[F, StreamUnicastPublisher[F, A]] =
       Dispatcher[F, StreamUnicastPublisher[F, A]] { runner =>
         Resource.pure(StreamUnicastPublisher(stream, runner))
       }


### PR DESCRIPTION
Current ScalaFMT configuration forces a new line between the parameters of a function/method declaration, or the arguments of a call, even when there are too few parameters/arguments and they fit in one line within the text width (100 characters). These configurations avoid that when there are only 2 parameters.

Also, for the implicit parameters, it may be easier to read the implicit keyword before the first parameter, rather than on a previous line at the end.