### PR TITLE
Keep chunk structure when encoding text

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -172,11 +172,11 @@ object text {
 
   /** Encodes a stream of `String` in to a stream of bytes using the given charset. */
   def encode[F[_]](charset: Charset): Pipe[F, String, Byte] =
-    _.flatMap(s => Stream.chunk(Chunk.bytes(s.getBytes(charset))))
+    _.mapChunks(c => c.flatMap(s => Chunk.bytes(s.getBytes(charset))))
 
   /** Encodes a stream of `String` in to a stream of `Chunk[Byte]` using the given charset. */
   def encodeC[F[_]](charset: Charset): Pipe[F, String, Chunk[Byte]] =
-    _.map(s => Chunk.bytes(s.getBytes(charset)))
+    _.mapChunks(_.map(s => Chunk.bytes(s.getBytes(charset))))
 
   /** Encodes a stream of `String` in to a stream of bytes using the UTF-8 charset. */
   def utf8Encode[F[_]]: Pipe[F, String, Byte] =


### PR DESCRIPTION
Emitting a chunk per string in the input stream can result in huge slow
down if strings are small. Using `mapChunks` we can keep the chunk
structure, resulting in better performances.