### PR TITLE
Import from cats.effect.kernel where possible

### DIFF
--- a/core/jvm/src/main/scala/fs2/compression.scala
+++ b/core/jvm/src/main/scala/fs2/compression.scala
@@ -26,7 +26,7 @@ import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util.zip._
 
-import cats.effect.Sync
+import cats.effect.kernel.Sync
 
 /** Provides utilities for compressing/decompressing byte streams. */
 object compression {

--- a/core/shared/src/main/scala/fs2/Compiler.scala
+++ b/core/shared/src/main/scala/fs2/Compiler.scala
@@ -22,8 +22,8 @@
 package fs2
 
 import cats.{Id, Monad}
-import cats.effect._
-import cats.effect.kernel.Ref
+import cats.effect.SyncIO
+import cats.effect.kernel.{Concurrent, Poll, Ref, Resource, Sync}
 import cats.syntax.all._
 
 import fs2.internal._

--- a/core/shared/src/main/scala/fs2/Hotswap.scala
+++ b/core/shared/src/main/scala/fs2/Hotswap.scala
@@ -23,9 +23,8 @@ package fs2
 
 import cats.ApplicativeError
 import cats.syntax.all._
-import cats.effect.{Concurrent, Resource}
-import cats.effect.kernel.Ref
-import cats.effect.implicits._
+import cats.effect.kernel.{Concurrent, Ref, Resource}
+import cats.effect.kernel.implicits._
 
 /** Supports treating a linear sequence of resources as a single resource.
   *

--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -21,7 +21,7 @@
 
 package fs2
 
-import cats.effect.Concurrent
+import cats.effect.kernel.Concurrent
 
 object Pipe {
 

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -26,7 +26,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
 import cats.{Eval => _, _}
-import cats.effect._
+import cats.effect.kernel._
 import cats.syntax.all._
 
 import fs2.internal._

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -28,10 +28,10 @@ import java.io.PrintStream
 
 import cats.{Eval => _, _}
 import cats.data.Ior
-import cats.effect._
-import cats.effect.kernel.Deferred
+import cats.effect.SyncIO
+import cats.effect.kernel._
 import cats.effect.std.Semaphore
-import cats.effect.implicits._
+import cats.effect.kernel.implicits._
 import cats.implicits.{catsSyntaxEither => _, _}
 
 import fs2.compat._

--- a/core/shared/src/main/scala/fs2/concurrent/Balance.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Balance.scala
@@ -21,7 +21,7 @@
 
 package fs2.concurrent
 
-import cats.effect.Concurrent
+import cats.effect.kernel.Concurrent
 
 import fs2._
 

--- a/core/shared/src/main/scala/fs2/concurrent/Broadcast.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Broadcast.scala
@@ -21,7 +21,7 @@
 
 package fs2.concurrent
 
-import cats.effect.Concurrent
+import cats.effect.kernel.Concurrent
 
 import fs2.internal.Token
 import fs2._

--- a/core/shared/src/main/scala/fs2/concurrent/PubSub.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/PubSub.scala
@@ -22,9 +22,8 @@
 package fs2.concurrent
 
 import cats._, implicits._
-import cats.effect.{Concurrent, Outcome}
-import cats.effect.kernel.{Deferred, Ref}
-import cats.effect.implicits._
+import cats.effect.kernel.{Concurrent, Deferred, Outcome, Ref}
+import cats.effect.kernel.implicits._
 
 import fs2._
 import fs2.internal.Token

--- a/core/shared/src/main/scala/fs2/concurrent/Queue.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Queue.scala
@@ -23,7 +23,7 @@ package fs2
 package concurrent
 
 import cats.{Applicative, ApplicativeError, Eq, Functor, Id}
-import cats.effect.Concurrent
+import cats.effect.kernel.Concurrent
 import cats.syntax.all._
 
 import fs2.internal.{SizedQueue, Token}

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -24,7 +24,7 @@ package concurrent
 
 import cats.{Applicative, Functor, Invariant}
 import cats.data.OptionT
-import cats.effect.Concurrent
+import cats.effect.kernel.Concurrent
 import cats.effect.kernel.{Deferred, Ref}
 import cats.syntax.all._
 import fs2.internal.Token

--- a/core/shared/src/main/scala/fs2/concurrent/Topic.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Topic.scala
@@ -23,7 +23,7 @@ package fs2
 package concurrent
 
 import cats.Eq
-import cats.effect.Concurrent
+import cats.effect.kernel.Concurrent
 import cats.syntax.all._
 
 import fs2.internal.{SizedQueue, Token}

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -25,8 +25,7 @@ import scala.annotation.tailrec
 
 import cats.{Id, Traverse, TraverseFilter}
 import cats.data.Chain
-import cats.effect.{Outcome, Resource}
-import cats.effect.kernel.Ref
+import cats.effect.kernel.{Outcome, Ref, Resource}
 import cats.syntax.all._
 
 import fs2.{Compiler, CompositeFailure, Scope}

--- a/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
+++ b/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
@@ -22,9 +22,8 @@
 package fs2.internal
 
 import cats.{Applicative, Id}
-import cats.effect.{Concurrent, Outcome}
-import cats.effect.kernel.{Deferred, Ref}
-import cats.effect.implicits._
+import cats.effect.kernel.{Concurrent, Deferred, Outcome, Ref}
+import cats.effect.kernel.implicits._
 import cats.syntax.all._
 import InterruptContext.InterruptionOutcome
 

--- a/core/shared/src/main/scala/fs2/internal/ScopedResource.scala
+++ b/core/shared/src/main/scala/fs2/internal/ScopedResource.scala
@@ -21,7 +21,7 @@
 
 package fs2.internal
 
-import cats.effect.Resource
+import cats.effect.kernel.Resource
 import cats.implicits._
 
 import fs2.{Compiler, Scope}

--- a/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
+++ b/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
@@ -25,8 +25,8 @@ package io
 import java.io.{IOException, InputStream}
 
 import cats.syntax.all._
-import cats.effect.{Async, Outcome, Resource}
-import cats.effect.implicits._
+import cats.effect.kernel.{Async, Outcome, Resource}
+import cats.effect.kernel.implicits._
 import cats.effect.std.Dispatcher
 
 import fs2.Chunk.Bytes

--- a/io/src/main/scala/fs2/io/Network.scala
+++ b/io/src/main/scala/fs2/io/Network.scala
@@ -22,7 +22,7 @@
 package fs2
 package io
 
-import cats.effect.Async
+import cats.effect.kernel.Async
 
 /** Provides the ability to work with TCP, UDP, and TLS.
   *

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer
 import java.nio.channels.{FileChannel, FileLock}
 import java.nio.file.{OpenOption, Path}
 
-import cats.effect.{Resource, Sync}
+import cats.effect.kernel.{Resource, Sync}
 
 /** Provides the ability to read/write/lock/inspect a file in the effect `F`.
   */

--- a/io/src/main/scala/fs2/io/file/ReadCursor.scala
+++ b/io/src/main/scala/fs2/io/file/ReadCursor.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.FiniteDuration
 import cats.{Functor, ~>}
 import cats.arrow.FunctionK
 import cats.syntax.all._
-import cats.effect.{Resource, Sync, Temporal}
+import cats.effect.kernel.{Resource, Sync, Temporal}
 
 import java.nio.file._
 

--- a/io/src/main/scala/fs2/io/file/Watcher.scala
+++ b/io/src/main/scala/fs2/io/file/Watcher.scala
@@ -24,7 +24,7 @@ package io
 
 import scala.concurrent.duration._
 
-import cats.effect._
+import cats.effect.kernel._
 import cats.syntax.all._
 import java.nio.file._
 import java.nio.file.attribute.BasicFileAttributes

--- a/io/src/main/scala/fs2/io/file/WriteCursor.scala
+++ b/io/src/main/scala/fs2/io/file/WriteCursor.scala
@@ -25,7 +25,7 @@ package file
 
 import cats.{Monad, ~>}
 import cats.syntax.all._
-import cats.effect.{Resource, Sync}
+import cats.effect.kernel.{Resource, Sync}
 
 import java.nio.file._
 import cats.arrow.FunctionK

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -25,7 +25,7 @@ package io
 import java.nio.file.{Files => _, _}
 import java.nio.file.attribute.{FileAttribute, PosixFilePermission}
 
-import cats.effect.{Async, Resource, Sync}
+import cats.effect.kernel.{Async, Resource, Sync}
 import cats.syntax.all._
 
 import scala.concurrent.duration._

--- a/io/src/main/scala/fs2/io/io.scala
+++ b/io/src/main/scala/fs2/io/io.scala
@@ -22,8 +22,8 @@
 package fs2
 
 import cats._
-import cats.effect.{Async, Outcome, Resource, Sync}
-import cats.effect.implicits._
+import cats.effect.kernel.{Async, Outcome, Resource, Sync}
+import cats.effect.kernel.implicits._
 import cats.effect.kernel.Deferred
 import cats.syntax.all._
 

--- a/io/src/main/scala/fs2/io/tcp/SocketGroup.scala
+++ b/io/src/main/scala/fs2/io/tcp/SocketGroup.scala
@@ -39,8 +39,7 @@ import java.util.concurrent.{ThreadFactory, TimeUnit}
 
 import cats.Applicative
 import cats.syntax.all._
-import cats.effect.{Resource, Sync}
-import cats.effect.kernel.Ref
+import cats.effect.kernel.{Ref, Resource, Sync}
 import cats.effect.std.Semaphore
 
 import fs2.internal.ThreadFactories

--- a/io/src/main/scala/fs2/io/tls/DTLSSocket.scala
+++ b/io/src/main/scala/fs2/io/tls/DTLSSocket.scala
@@ -29,7 +29,7 @@ import java.net.{InetAddress, InetSocketAddress, NetworkInterface}
 import javax.net.ssl.SSLSession
 
 import cats.Applicative
-import cats.effect.{Async, Resource, Sync}
+import cats.effect.kernel.{Async, Resource, Sync}
 import cats.syntax.all._
 
 import fs2.io.udp.{Packet, Socket}

--- a/io/src/main/scala/fs2/io/tls/TLSContext.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSContext.scala
@@ -39,7 +39,7 @@ import javax.net.ssl.{
 }
 
 import cats.Applicative
-import cats.effect.Resource
+import cats.effect.kernel.Resource
 import cats.syntax.all._
 
 import fs2.io.tcp.Socket

--- a/io/src/main/scala/fs2/io/tls/TLSEngine.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSEngine.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.FiniteDuration
 import javax.net.ssl.{SSLEngine, SSLEngineResult, SSLSession}
 
 import cats.Applicative
-import cats.effect.{Async, Sync}
+import cats.effect.kernel.{Async, Sync}
 import cats.effect.std.Semaphore
 import cats.syntax.all._
 

--- a/io/src/main/scala/fs2/io/tls/TLSSocket.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSSocket.scala
@@ -30,7 +30,7 @@ import javax.net.ssl.SSLSession
 
 import cats.Applicative
 import cats.effect.std.Semaphore
-import cats.effect._
+import cats.effect.kernel._
 import cats.syntax.all._
 
 import fs2.io.tcp.Socket

--- a/io/src/main/scala/fs2/io/udp/AsynchronousSocketGroup.scala
+++ b/io/src/main/scala/fs2/io/udp/AsynchronousSocketGroup.scala
@@ -40,7 +40,7 @@ import java.nio.channels.{
 import java.util.ArrayDeque
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
 
-import cats.effect.{Resource, Sync}
+import cats.effect.kernel.{Resource, Sync}
 
 import CollectionCompat._
 

--- a/io/src/main/scala/fs2/io/udp/SocketGroup.scala
+++ b/io/src/main/scala/fs2/io/udp/SocketGroup.scala
@@ -34,7 +34,7 @@ import java.net.{
 }
 import java.nio.channels.{ClosedChannelException, DatagramChannel}
 
-import cats.effect.{Resource, Sync}
+import cats.effect.kernel.{Resource, Sync}
 import cats.syntax.all._
 
 final class SocketGroup(

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
@@ -24,8 +24,7 @@ package interop
 package reactivestreams
 
 import cats._
-import cats.effect._
-import cats.effect.kernel.{Deferred, Ref}
+import cats.effect.kernel.{Async, Deferred, Ref}
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
 

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -23,7 +23,7 @@ package fs2
 package interop
 package reactivestreams
 
-import cats.effect._
+import cats.effect.kernel._
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
 

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
@@ -23,7 +23,7 @@ package fs2
 package interop
 package reactivestreams
 
-import cats.effect._
+import cats.effect.kernel._
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
 

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala
@@ -22,7 +22,7 @@
 package fs2
 package interop
 
-import cats.effect._
+import cats.effect.kernel._
 import cats.effect.std.Dispatcher
 import org.reactivestreams._
 


### PR DESCRIPTION
While working on upgrading Doobie to Cats Effect 3 https://github.com/tpolecat/doobie/pull/1280 I have been advised that in order to maintain compatibility with all Cats Effect implementations, I should depend on `cats-effect-kernel` and `cats-effect-std` artifacts for compilation and on `cats-effect` only in tests. This leads to a problem for code that also depends on `fs2-core`. I'm getting compilation errors like the following:
```
[error] /home/rafal/workspace/scala/tpolecat/doobie/modules/core/src/main/scala/doobie/util/transactor.scala:167:9: Symbol 'type cats.effect.package.Resource' is missing from the classpath.
[error] This symbol is required by 'value fs2.Stream.r'.
[error] Make sure that type Resource is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
[error] A full rebuild may help if 'Stream.class' was compiled against an incompatible version of cats.effect.package.
[error]         Stream.resource(connect(kernel)).flatMap { conn =>
[error]         ^
```
Fs2 depends on `SyncIO` from `cats-effect` module in the main code and untangling it to the point of depending on `cats-effect-std` might be not feasible, but a simple workaround for the problem I'm facing would be foregoing the aliases in `cats.effect` package and importing symbols from `cats.effect.kernel` and `cats.effect.std` directly.