### PR TITLE
Slightly optimize Monad.pure for Stream

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4801,7 +4801,7 @@ object Stream extends StreamLowPriority {
 private[fs2] trait StreamLowPriority {
   implicit def monadInstance[F[_]]: Monad[Stream[F, *]] =
     new Monad[Stream[F, *]] {
-      override def pure[A](x: A): Stream[F, A] = Stream(x)
+      override def pure[A](x: A): Stream[F, A] = Stream.emit(x)
 
       override def flatMap[A, B](fa: Stream[F, A])(f: A => Stream[F, B]): Stream[F, B] =
         fa.flatMap(f)


### PR DESCRIPTION
Leverage `Stream.emit` in `Monad.pure` implementation instead of `Stream.apply` (which always takes `Seq`).
Conversation it [here](https://gitter.im/functional-streams-for-scala/fs2?at=5f90715aa0a3072b43973c3c)