### PR TITLE
Restrict Pull.ViewL to Streams (Unit result)

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1688,7 +1688,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * }}}
     */
   def map[O2](f: O => O2): Stream[F, O2] =
-    this.pull.echo.mapOutput(f).streamNoScope
+    Pull.mapOutput(underlying, f).streamNoScope
 
   /** Maps a running total according to `S` and the input with the function `f`.
     *


### PR DESCRIPTION
The ViewL operation and trait, which represents loop unrolling,  is only ever used when interpreting or compiling a Stream.
Therefore, we can assume that it onlt works on Pull with Unit as the result type. For this we remove references to it from the Pull class itself. For that:

- Remove the class method `mapOutput` of the Pull class. Instead we write a new method with large match.
- Remove the `asHandler` method of the `Pull` class and expand it in where it was used, at top of compilation.
- Remove nested object ViewL, but make all its subclasses Private to the Pull object.