### PR TITLE
Added isFile and isDirectory to Files

### DIFF
--- a/io/src/main/scala/fs2/io/file/Files.scala
+++ b/io/src/main/scala/fs2/io/file/Files.scala
@@ -198,11 +198,40 @@ sealed trait SyncFiles[F[_]] {
       append: Boolean
   ): F[WriteCursor[F]]
 
+  /** Tests whether a file is a directory.
+    *
+    * The options sequence may be used to indicate how symbolic links are handled for the case that the file is a symbolic link.
+    * By default, symbolic links are followed and the file attribute of the final target of the link is read.
+    * If the option NOFOLLOW_LINKS is present then symbolic links are not followed.
+    *
+    * Where is it required to distinguish an I/O exception from the case that the
+    * file is not a directory then the file attributes can be read with the
+    * readAttributes method and the file type tested with the BasicFileAttributes.isDirectory() method.
+    *
+    * @param path the path to the file to test
+    * @param options - options indicating how symbolic links are handled
+    * @return true if the file is a directory; false if the file does not exist, is not a directory, or it cannot be determined if the file is a directory or not.
+    */
   def isDirectory(
       path: Path,
       linkOption: Seq[LinkOption] = Nil
   ): F[Boolean]
 
+  /** Tests whether a file is a regular file with opaque content.
+    *
+    * The options sequence may be used to indicate how symbolic links are handled for the case that
+    * the file is a symbolic link. By default, symbolic links are followed and the file
+    * attribute of the final target of the link is read. If the option NOFOLLOW_LINKS is present
+    * then symbolic links are not followed.
+    *
+    * Where is it required to distinguish an I/O exception from the case that the file is
+    * not a regular file then the file attributes can be read with the readAttributes
+    * method and the file type tested with the BasicFileAttributes.isRegularFile() method.
+    *
+    * @param path the path to the file
+    * @param options options indicating how symbolic links are handled
+    * @return true if the file is a regular file; false if the file does not exist, is not a regular file, or it cannot be determined if the file is a regular file or not.
+    */
   def isFile(
       path: Path,
       linkOption: Seq[LinkOption] = Nil
@@ -382,7 +411,7 @@ object SyncFiles {
         linkOption: Seq[LinkOption]
     ): F[Boolean] =
       Sync[F].delay(
-        JFiles.getAttribute(path, "basic:isDirectory", linkOption: _*).asInstanceOf[Boolean]
+        JFiles.isDirectory(path, linkOption: _*)
       )
 
     def isFile(
@@ -390,7 +419,7 @@ object SyncFiles {
         linkOption: Seq[LinkOption]
     ): F[Boolean] =
       Sync[F].delay(
-        JFiles.getAttribute(path, "basic:isRegularFile", linkOption: _*).asInstanceOf[Boolean]
+        JFiles.isRegularFile(path, linkOption: _*)
       )
 
   }

--- a/io/src/main/scala/fs2/io/file/Files.scala
+++ b/io/src/main/scala/fs2/io/file/Files.scala
@@ -200,12 +200,12 @@ sealed trait SyncFiles[F[_]] {
 
   def isDirectory(
       path: Path,
-      linkOption: Seq[LinkOption]
+      linkOption: Seq[LinkOption] = Nil
   ): F[Boolean]
 
   def isFile(
       path: Path,
-      linkOption: Seq[LinkOption]
+      linkOption: Seq[LinkOption] = Nil
   ): F[Boolean]
 
 }

--- a/io/src/main/scala/fs2/io/file/Files.scala
+++ b/io/src/main/scala/fs2/io/file/Files.scala
@@ -379,7 +379,7 @@ object SyncFiles {
 
     def isDirectory(
         path: Path,
-        linkOption: Seq[LinkOption] = Nil
+        linkOption: Seq[LinkOption]
     ): F[Boolean] =
       Sync[F].delay(
         JFiles.getAttribute(path, "basic:isDirectory", linkOption: _*).asInstanceOf[Boolean]

--- a/io/src/main/scala/fs2/io/file/Files.scala
+++ b/io/src/main/scala/fs2/io/file/Files.scala
@@ -197,6 +197,17 @@ sealed trait SyncFiles[F[_]] {
       file: FileHandle[F],
       append: Boolean
   ): F[WriteCursor[F]]
+
+  def isDirectory(
+      path: Path,
+      linkOption: Seq[LinkOption]
+  ): F[Boolean]
+
+  def isFile(
+      path: Path,
+      linkOption: Seq[LinkOption]
+  ): F[Boolean]
+
 }
 
 object SyncFiles {
@@ -365,6 +376,22 @@ object SyncFiles {
         append: Boolean
     ): F[WriteCursor[F]] =
       if (append) file.size.map(s => WriteCursor(file, s)) else WriteCursor(file, 0L).pure[F]
+
+    def isDirectory(
+        path: Path,
+        linkOption: Seq[LinkOption] = Nil
+    ): F[Boolean] =
+      Sync[F].delay(
+        JFiles.getAttribute(path, "basic:isDirectory", linkOption: _*).asInstanceOf[Boolean]
+      )
+
+    def isFile(
+        path: Path,
+        linkOption: Seq[LinkOption]
+    ): F[Boolean] =
+      Sync[F].delay(
+        JFiles.getAttribute(path, "basic:isRegularFile", linkOption: _*).asInstanceOf[Boolean]
+      )
 
   }
 }

--- a/io/src/test/scala/fs2/io/file/FileSuite.scala
+++ b/io/src/test/scala/fs2/io/file/FileSuite.scala
@@ -465,4 +465,48 @@ class FileSuite extends BaseFileSuite {
       .compile
       .lastOrError
   }
+
+  group("isDirectory") {
+    test("returns false if the path is for a file") {
+      assert(
+        tempFile
+          .flatMap(v => Stream.eval(Files[IO].isDirectory(v, Nil)))
+          .compile
+          .lastOrError
+          .unsafeRunSync() == false
+      )
+    }
+
+    test("returns true if the path is for a directory") {
+      assert(
+        tempDirectory
+          .flatMap(v => Stream.eval(Files[IO].isDirectory(v, Nil)))
+          .compile
+          .lastOrError
+          .unsafeRunSync() == true
+      )
+    }
+  }
+
+  group("isFile") {
+    test("returns true if the path is for a file") {
+      assert(
+        tempFile
+          .flatMap(v => Stream.eval(Files[IO].isFile(v, Nil)))
+          .compile
+          .lastOrError
+          .unsafeRunSync() == true
+      )
+    }
+
+    test("returns false if the path is for a directory") {
+      assert(
+        tempDirectory
+          .flatMap(v => Stream.eval(Files[IO].isFile(v, Nil)))
+          .compile
+          .lastOrError
+          .unsafeRunSync() == false
+      )
+    }
+  }
 }


### PR DESCRIPTION
Hello,

Added a couple of small calls to the `Files` capability: `isFile` and `isDirectory`

I opted to make these more granular calls instead of the ability to fetch `BasicFileAttributes` because I wasn't sure if `BasicFileAttributes` is referentially transparent. 

I added `isDirectory` and `isFile` separately (as opposed to implementing one and allowing the other via negation of the implemented one) because according to the [javadoc](https://docs.oracle.com/javase/8/docs/api/java/nio/file/attribute/BasicFileAttributes.html) a path may also be a symbolic link or "other". I did not how to test the other 2 cases however, so I did not implement appropriate methods for them.

Lastly, according to the contributor docs I should run `fmtCheck; test; doc; mimaReportBinaryIssues; docs/mdoc; microsite/makeMicrosite`; I tried my best, but `docs/mdoc` failed due to not being a recognised task and `microsite/makeMicrosite` failed due to a dependency (org.tpolecat/tut-core) not being available for dotty, which I wasn't sure how to resolve. The other tasks succeeded fine.

Let me know if you need me to make any changes. If you'd prefer to expose `BasicFileAttributes` instead I'd be happy to make such changes.