### PR TITLE
Temp file dirs optional for file system default

### DIFF
--- a/io/src/main/scala/fs2/io/file/Files.scala
+++ b/io/src/main/scala/fs2/io/file/Files.scala
@@ -137,10 +137,14 @@ sealed trait SyncFiles[F[_]] {
     */
   def size(path: Path): F[Long]
 
-  /** Creates a resource containing the path of a temporary file.
+  /** Creates a [[Resource]] which can be used to create a temporary file.
+    *  The file is created during resource allocation, and removed during its release.
     *
-    * The temporary file is removed during the resource release.
     * @param dir the directory which the temporary file will be created in. Pass in None to use the default system temp directory
+    * @param prefix the prefix string to be used in generating the file's name
+    * @param suffix the suffix string to be used in generating the file's name
+    * @param attributes an optional list of file attributes to set atomically when creating the file
+    * @return a resource containing the path of the temporary file
     */
   def tempFile(
       dir: Option[Path] = None,
@@ -149,10 +153,13 @@ sealed trait SyncFiles[F[_]] {
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, Path]
 
-  /** Creates a resource containing the path of a temporary directory.
+  /** Creates a [[Resource]] which can be used to create a temporary directory.
+    *  The directory is created during resource allocation, and removed during its release.
     *
-    * The temporary directory is removed during the resource release.
     * @param dir the directory which the temporary directory will be created in. Pass in None to use the default system temp directory
+    * @param prefix the prefix string to be used in generating the directory's name
+    * @param attributes an optional list of file attributes to set atomically when creating the directory
+    * @return a resource containing the path of the temporary directory
     */
   def tempDirectory(
       dir: Option[Path] = None,

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -216,7 +216,7 @@ package object file {
       suffix: String = ".tmp",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Stream[F, Path] =
-    Stream.resource(SyncFiles[F].tempFile(dir, prefix, suffix, attributes))
+    Stream.resource(SyncFiles[F].tempFile(Some(dir), prefix, suffix, attributes))
 
   /** Creates a resource containing the path of a temporary file.
     *
@@ -229,7 +229,7 @@ package object file {
       suffix: String = ".tmp",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, Path] =
-    SyncFiles[F].tempFile(dir, prefix, suffix, attributes)
+    SyncFiles[F].tempFile(Some(dir), prefix, suffix, attributes)
 
   /** Creates a stream containing the path of a temporary directory.
     *
@@ -241,7 +241,7 @@ package object file {
       prefix: String = "",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Stream[F, Path] =
-    Stream.resource(SyncFiles[F].tempDirectory(dir, prefix, attributes))
+    Stream.resource(SyncFiles[F].tempDirectory(Some(dir), prefix, attributes))
 
   /** Creates a resource containing the path of a temporary directory.
     *
@@ -253,7 +253,7 @@ package object file {
       prefix: String = "",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, Path] =
-    SyncFiles[F].tempDirectory(dir, prefix, attributes)
+    SyncFiles[F].tempDirectory(Some(dir), prefix, attributes)
 
   /** Creates a new directory at the given path
     */

--- a/io/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -263,7 +263,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
               files.exists(tempDir.resolve(file.getFileName))
             }
         }
-        .map(it => assert(it))
+        .map(existsInTemp => assertEquals(existsInTemp, true))
     }
 
     test("should create the file in the default temp directory when dir is not specified") {
@@ -277,7 +277,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
             files.exists(Paths.get(dir).resolve(file.getFileName))
           )
         }
-        .map(existsInDefault => assert(existsInDefault))
+        .map(existsInDefault => assertEquals(existsInDefault, true))
     }
   }
 
@@ -317,7 +317,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
               files.exists(tempDir.resolve(directory.getFileName))
             }
         }
-        .map(it => assert(it))
+        .map(existsInTemp => assertEquals(existsInTemp, true))
     }
 
     test("should create the directory in the default temp directory when dir is not specified") {
@@ -331,7 +331,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
             files.exists(Paths.get(dir).resolve(directory.getFileName))
           )
         }
-        .map(existsInDefault => assert(existsInDefault))
+        .map(existsInDefault => assertEquals(existsInDefault, true))
     }
   }
 

--- a/io/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -263,7 +263,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
               files.exists(tempDir.resolve(file.getFileName))
             }
         }
-        .map(existsInTemp => assertEquals(existsInTemp, true))
+        .assertEquals(true)
     }
 
     test("should create the file in the default temp directory when dir is not specified") {
@@ -277,7 +277,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
             files.exists(Paths.get(dir).resolve(file.getFileName))
           )
         }
-        .map(existsInDefault => assertEquals(existsInDefault, true))
+        .assertEquals(true)
     }
   }
 
@@ -317,7 +317,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
               files.exists(tempDir.resolve(directory.getFileName))
             }
         }
-        .map(existsInTemp => assertEquals(existsInTemp, true))
+        .assertEquals(true)
     }
 
     test("should create the directory in the default temp directory when dir is not specified") {
@@ -331,7 +331,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
             files.exists(Paths.get(dir).resolve(directory.getFileName))
           )
         }
-        .map(existsInDefault => assertEquals(existsInDefault, true))
+        .assertEquals(true)
     }
   }
 

--- a/io/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -252,6 +252,35 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
         .compile
         .lastOrError
     }
+
+    test("should create the file in the specified directory") {
+      tempDirectory
+        .evalMap { tempDir =>
+          val files = Files[IO]
+          files
+            .tempFile(Some(tempDir))
+            .use { file =>
+              files.exists(tempDir.resolve(file.getFileName))
+            }
+        }
+        .compile
+        .lastOrError
+        .map(it => assert(it))
+    }
+
+    test("should create the file in the default temp directory when dir is not specified") {
+
+      val files = Files[IO]
+
+      files
+        .tempFile(None)
+        .use { file =>
+          IO(System.getProperty("java.io.tmpdir")).flatMap(dir =>
+            files.exists(Paths.get(dir).resolve(file.getFileName))
+          )
+        }
+        .map(existsInDefault => assert(existsInDefault))
+    }
   }
 
   group("tempDirectoryStream") {
@@ -259,7 +288,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
       Stream
         .resource {
           Files[IO]
-            .tempFile(Paths.get(""))
+            .tempDirectory(Paths.get(""))
             .evalMap(path => Files[IO].exists(path).tupleRight(path))
         }
         .compile
@@ -278,6 +307,35 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
         .evalMap(Files[IO].delete)
         .compile
         .lastOrError
+    }
+
+    test("should create the directory in the specified directory") {
+      tempDirectory
+        .evalMap { tempDir =>
+          val files = Files[IO]
+          files
+            .tempDirectory(Some(tempDir))
+            .use { directory =>
+              files.exists(tempDir.resolve(directory.getFileName))
+            }
+        }
+        .compile
+        .lastOrError
+        .map(it => assert(it))
+    }
+
+    test("should create the directory in the default temp directory when dir is not specified") {
+
+      val files = Files[IO]
+
+      files
+        .tempDirectory(None)
+        .use { directory =>
+          IO(System.getProperty("java.io.tmpdir")).flatMap(dir =>
+            files.exists(Paths.get(dir).resolve(directory.getFileName))
+          )
+        }
+        .map(existsInDefault => assert(existsInDefault))
     }
   }
 

--- a/io/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -232,7 +232,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
       Stream
         .resource {
           Files[IO]
-            .tempFile(Paths.get(""))
+            .tempFile(Some(Paths.get("")))
             .evalMap(path => Files[IO].exists(path).tupleRight(path))
         }
         .compile
@@ -247,7 +247,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
 
     test("should not fail if the file is deleted before the stream completes") {
       Stream
-        .resource(Files[IO].tempFile(Paths.get("")))
+        .resource(Files[IO].tempFile(Some(Paths.get(""))))
         .evalMap(Files[IO].delete)
         .compile
         .lastOrError
@@ -255,7 +255,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
 
     test("should create the file in the specified directory") {
       tempDirectory
-        .evalMap { tempDir =>
+        .use { tempDir =>
           val files = Files[IO]
           files
             .tempFile(Some(tempDir))
@@ -263,8 +263,6 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
               files.exists(tempDir.resolve(file.getFileName))
             }
         }
-        .compile
-        .lastOrError
         .map(it => assert(it))
     }
 
@@ -288,7 +286,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
       Stream
         .resource {
           Files[IO]
-            .tempDirectory(Paths.get(""))
+            .tempDirectory(Some(Paths.get("")))
             .evalMap(path => Files[IO].exists(path).tupleRight(path))
         }
         .compile
@@ -303,7 +301,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
 
     test("should not fail if the directory is deleted before the stream completes") {
       Stream
-        .resource(Files[IO].tempDirectory(Paths.get("")))
+        .resource(Files[IO].tempDirectory(Some(Paths.get(""))))
         .evalMap(Files[IO].delete)
         .compile
         .lastOrError
@@ -311,7 +309,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
 
     test("should create the directory in the specified directory") {
       tempDirectory
-        .evalMap { tempDir =>
+        .use { tempDir =>
           val files = Files[IO]
           files
             .tempDirectory(Some(tempDir))
@@ -319,8 +317,6 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
               files.exists(tempDir.resolve(directory.getFileName))
             }
         }
-        .compile
-        .lastOrError
         .map(it => assert(it))
     }
 


### PR DESCRIPTION
Hello.

Made the dir parameter on `tempFile` and `tempDirectory` an `Option[Path]`. Specifying `None` (which is also the default) delegates to using the system's default temp directory. Specifying `Some` works same as it did previously.