### PR TITLE
Pull - FlatMapOutput - Remove middle map.

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -936,16 +936,16 @@ object Pull extends PullLowPriority {
       p: Pull[F, O, Unit],
       f: O => Pull[F2, O2, Unit]
   ): Pull[F2, O2, Unit] =
-    uncons(p).flatMap {
+    Step(p, None).flatMap {
       case None => Result.unit
 
-      case Some((chunk, Result.Succeeded(_))) if chunk.size == 1 =>
+      case Some((chunk, _, Result.Succeeded(_))) if chunk.size == 1 =>
         // nb: If tl is Pure, there's no need to propagate flatMap through the tail. Hence, we
         // check if hd has only a single element, and if so, process it directly instead of folding.
         // This allows recursive infinite streams of the form `def s: Stream[Pure,O] = Stream(o).flatMap { _ => s }`
         f(chunk(0))
 
-      case Some((chunk, tail)) =>
+      case Some((chunk, _, tail)) =>
         def go(idx: Int): Pull[F2, O2, Unit] =
           if (idx == chunk.size)
             flatMapOutput[F, F2, O, O2](tail, f)


### PR DESCRIPTION
The definition of flatMapOutput was using the method `uncons`, which
includes a call to `Pull.map` and thus to `Pull.flatMap`, which
can incur extra allocations, all to remove second element of 3-tuple.

We can easy do that in the continuation of the flatMap.