### PR TITLE
Introduce constructor: FlatMapOutput

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -1087,10 +1087,11 @@ object Pull extends PullLowPriority {
       fK: F ~> G
   ): Pull[G, O, Unit] =
     stream match {
-      case r: Result[_]          => r
-      case t: Translate[e, f, _] => translate[e, G, O](t.stream, fK.compose(t.fk))
-      case o: Output[_]          => o
-      case _                     => Translate(stream, fK)
+      case r: Result[_] => r
+      case t: Translate[e, f, _] =>
+        translate[e, G, O](t.stream, t.fk.andThen(fK.asInstanceOf[f ~> G]))
+      case o: Output[_] => o
+      case _            => Translate(stream, fK)
     }
 
   /* Applies the outputs of this pull to `f` and returns the result in a new `Pull`. */


### PR DESCRIPTION
We introduce a new Pull constructor, for the Stream-flatMap (flatMap on the output) operation. WE also introduce a smart constructor, for a quick peeks.

The old body of output-flatMap is now moved as an auxiliary method of the compile loop, called `innerFlatMapOutput`. We still keep using Pull expansion before doing the interpretation, but this is now bundled with the compile loop.

~We also turn the `interruptBoundary` function into an auxiliary method of the `innerFlatMapOutput`.~