### PR TITLE
Prepare for using cats.effect.std.Unique

### DIFF
--- a/core/shared/src/main/scala/fs2/concurrent/PubSub.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/PubSub.scala
@@ -26,7 +26,7 @@ import cats.effect.kernel.{Concurrent, Deferred, Outcome, Ref}
 import cats.effect.kernel.implicits._
 
 import fs2._
-import fs2.internal.Token
+import fs2.internal.Unique
 
 import scala.annotation.tailrec
 import scala.collection.immutable.{Queue => ScalaQueue}
@@ -94,7 +94,7 @@ private[fs2] object PubSub {
     ).map(state => new PubSubAsync(strategy, state))
 
   private final case class Publisher[F[_], A](
-      token: Token,
+      token: Unique,
       i: A,
       signal: Deferred[F, Unit]
   ) {
@@ -103,7 +103,7 @@ private[fs2] object PubSub {
   }
 
   private final case class Subscriber[F[_], A, Selector](
-      token: Token,
+      token: Unique,
       selector: Selector,
       signal: Deferred[F, A]
   ) {
@@ -220,24 +220,24 @@ private[fs2] object PubSub {
         (ps2, action >> result)
       }.flatten
 
-    private def clearPublisher(token: Token)(outcome: Outcome[F, _, _]): F[Unit] =
+    private def clearPublisher(token: Unique)(outcome: Outcome[F, _, _]): F[Unit] =
       outcome match {
         case _: Outcome.Succeeded[F, _, _] => Applicative[F].unit
         case Outcome.Errored(_) | Outcome.Canceled() =>
           state.update(ps => ps.copy(publishers = ps.publishers.filterNot(_.token == token)))
       }
 
-    private def clearSubscriber(token: Token): F[Unit] =
+    private def clearSubscriber(token: Unique): F[Unit] =
       state.update(ps => ps.copy(subscribers = ps.subscribers.filterNot(_.token == token)))
 
-    private def clearSubscriberOnCancel(token: Token)(outcome: Outcome[F, _, _]): F[Unit] =
+    private def clearSubscriberOnCancel(token: Unique)(outcome: Outcome[F, _, _]): F[Unit] =
       outcome match {
         case _: Outcome.Succeeded[F, _, _]           => Applicative[F].unit
         case Outcome.Errored(_) | Outcome.Canceled() => clearSubscriber(token)
       }
 
     def publish(i: I): F[Unit] =
-      (F.deferred[Unit], Token[F]).tupled.flatMap { case (deferred, token) =>
+      (F.deferred[Unit], Unique[F]).tupled.flatMap { case (deferred, token) =>
         update { ps =>
           if (strategy.accepts(i, ps.queue)) {
             val ps1 = publish_(i, ps)
@@ -263,7 +263,7 @@ private[fs2] object PubSub {
       }
 
     def get(selector: Selector): F[O] =
-      (F.deferred[O], Token[F]).tupled.flatMap { case (deferred, token) =>
+      (F.deferred[O], Unique[F]).tupled.flatMap { case (deferred, token) =>
         update { ps =>
           tryGet_(selector, ps) match {
             case (ps, None) =>
@@ -281,7 +281,7 @@ private[fs2] object PubSub {
       }
 
     def getStream(selector: Selector): Stream[F, O] =
-      Stream.bracket(Token[F])(clearSubscriber).flatMap { token =>
+      Stream.bracket(Unique[F])(clearSubscriber).flatMap { token =>
         def get_ =
           F.deferred[O].flatMap { deferred =>
             update { ps =>
@@ -545,7 +545,7 @@ private[fs2] object PubSub {
           last: A,
           lastStamp: Long,
           outOfOrder: Map[Long, (Long, A)],
-          seen: Set[Token]
+          seen: Set[Unique]
       )
 
       /** Strategy providing possibility for a discrete `get` in correct order.
@@ -559,8 +559,8 @@ private[fs2] object PubSub {
       def strategy[A](
           stamp: Long,
           start: A
-      ): PubSub.Strategy[(Long, (Long, A)), A, State[A], Option[Token]] =
-        new PubSub.Strategy[(Long, (Long, A)), A, State[A], Option[Token]] {
+      ): PubSub.Strategy[(Long, (Long, A)), A, State[A], Option[Unique]] =
+        new PubSub.Strategy[(Long, (Long, A)), A, State[A], Option[Unique]] {
           def initial: State[A] =
             State(start, stamp, Map.empty, Set.empty)
 
@@ -582,7 +582,7 @@ private[fs2] object PubSub {
             }
           }
 
-          def get(selector: Option[Token], state: State[A]): (State[A], Option[A]) =
+          def get(selector: Option[Unique], state: State[A]): (State[A], Option[A]) =
             selector match {
               case None => (state, Some(state.last))
               case Some(token) =>
@@ -593,13 +593,13 @@ private[fs2] object PubSub {
           def empty(state: State[A]): Boolean =
             false
 
-          def subscribe(selector: Option[Token], state: State[A]): (State[A], Boolean) =
+          def subscribe(selector: Option[Unique], state: State[A]): (State[A], Boolean) =
             selector match {
               case None    => (state, false)
               case Some(_) => (state, true)
             }
 
-          def unsubscribe(selector: Option[Token], state: State[A]): State[A] =
+          def unsubscribe(selector: Option[Unique], state: State[A]): State[A] =
             selector match {
               case None        => state
               case Some(token) => state.copy(seen = state.seen - token)
@@ -617,7 +617,7 @@ private[fs2] object PubSub {
         */
       final case class State[S](
           qs: S,
-          inspected: Set[Token]
+          inspected: Set[Unique]
       )
 
       /** Allows to enhance the supplied strategy by ability to inspect the state.
@@ -629,8 +629,8 @@ private[fs2] object PubSub {
         */
       def strategy[I, O, S: Eq, Sel](
           strategy: PubSub.Strategy[I, O, S, Sel]
-      ): PubSub.Strategy[I, Either[S, O], State[S], Either[Option[Token], Sel]] =
-        new PubSub.Strategy[I, Either[S, O], State[S], Either[Option[Token], Sel]] {
+      ): PubSub.Strategy[I, Either[S, O], State[S], Either[Option[Unique], Sel]] =
+        new PubSub.Strategy[I, Either[S, O], State[S], Either[Option[Unique], Sel]] {
           def initial: State[S] =
             State(strategy.initial, Set.empty)
 
@@ -644,7 +644,7 @@ private[fs2] object PubSub {
           }
 
           def get(
-              selector: Either[Option[Token], Sel],
+              selector: Either[Option[Unique], Sel],
               state: State[S]
           ): (State[S], Option[Either[S, O]]) =
             selector match {
@@ -656,7 +656,7 @@ private[fs2] object PubSub {
                   (state.copy(inspected = state.inspected + token), Some(Left(state.qs)))
               case Right(sel) =>
                 val (s, r) = strategy.get(sel, state.qs)
-                val tokens: Set[Token] = if (Eq[S].eqv(state.qs, s)) state.inspected else Set.empty
+                val tokens: Set[Unique] = if (Eq[S].eqv(state.qs, s)) state.inspected else Set.empty
                 (State(s, tokens), r.map(Right(_)))
             }
 
@@ -664,7 +664,7 @@ private[fs2] object PubSub {
             strategy.empty(state.qs)
 
           def subscribe(
-              selector: Either[Option[Token], Sel],
+              selector: Either[Option[Unique], Sel],
               state: State[S]
           ): (State[S], Boolean) =
             selector match {
@@ -674,13 +674,13 @@ private[fs2] object PubSub {
                 val (s, result) = strategy.subscribe(sel, state.qs)
                 (state.copy(qs = s), result)
             }
-          def unsubscribe(selector: Either[Option[Token], Sel], state: State[S]): State[S] =
+          def unsubscribe(selector: Either[Option[Unique], Sel], state: State[S]): State[S] =
             selector match {
               case Left(None)        => state
               case Left(Some(token)) => state.copy(inspected = state.inspected - token)
               case Right(sel) =>
                 val qs1 = strategy.unsubscribe(sel, state.qs)
-                val tokens: Set[Token] =
+                val tokens: Set[Unique] =
                   if (cats.Eq[S].eqv(state.qs, qs1)) state.inspected else Set.empty
                 State(qs1, tokens)
             }

--- a/core/shared/src/main/scala/fs2/concurrent/Queue.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Queue.scala
@@ -26,7 +26,7 @@ import cats.{Applicative, ApplicativeError, Eq, Functor, Id}
 import cats.effect.kernel.Concurrent
 import cats.syntax.all._
 
-import fs2.internal.{SizedQueue, Token}
+import fs2.internal.{SizedQueue, Unique}
 
 /** Provides the ability to enqueue elements to a `Queue`. */
 trait Enqueue[F[_], A] {
@@ -475,7 +475,7 @@ object InspectableQueue {
 
         def peek1: F[A] =
           Concurrent[F]
-            .bracket(Token[F]) { token =>
+            .bracket(Unique[F]) { token =>
               def take: F[A] =
                 pubSub.get(Left(Some(token))).flatMap {
                   case Left(s) =>
@@ -497,7 +497,7 @@ object InspectableQueue {
 
         def size: Stream[F, Int] =
           Stream
-            .bracket(Token[F])(token => pubSub.unsubscribe(Left(Some(token))))
+            .bracket(Unique[F])(token => pubSub.unsubscribe(Left(Some(token))))
             .flatMap { token =>
               pubSub.getStream(Left(Some(token))).flatMap {
                 case Left(s)  => Stream.emit(sizeOf(s))

--- a/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
+++ b/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
@@ -41,7 +41,7 @@ import InterruptContext.InterruptionOutcome
 final private[fs2] case class InterruptContext[F[_]](
     deferred: Deferred[F, InterruptionOutcome],
     ref: Ref[F, Option[InterruptionOutcome]],
-    interruptRoot: Token,
+    interruptRoot: Unique,
     cancelParent: F[Unit]
 )(implicit F: Concurrent[F]) { self =>
 
@@ -64,7 +64,7 @@ final private[fs2] case class InterruptContext[F[_]](
     */
   def childContext(
       interruptible: Boolean,
-      newScopeId: Token
+      newScopeId: Unique
   ): F[InterruptContext[F]] =
     if (interruptible) {
       self.deferred.get.start.flatMap { fiber =>
@@ -93,10 +93,10 @@ final private[fs2] case class InterruptContext[F[_]](
 
 private[fs2] object InterruptContext {
 
-  type InterruptionOutcome = Outcome[Id, Throwable, Token]
+  type InterruptionOutcome = Outcome[Id, Throwable, Unique]
 
   def apply[F[_]](
-      newScopeId: Token,
+      newScopeId: Unique,
       cancelParent: F[Unit]
   )(implicit F: Concurrent[F]): F[InterruptContext[F]] =
     for {

--- a/core/shared/src/main/scala/fs2/internal/ScopedResource.scala
+++ b/core/shared/src/main/scala/fs2/internal/ScopedResource.scala
@@ -60,7 +60,7 @@ private[fs2] sealed abstract class ScopedResource[F[_]] {
 
   /** Id of the resource
     */
-  def id: Token
+  def id: Unique
 
   /** Depending on resource state this will either release resource, or when resource was not yet fully
     * acquired, this will schedule releasing of the resource at earliest opportunity, that is when:
@@ -121,10 +121,10 @@ private[internal] object ScopedResource {
   def create[F[_]](implicit F: Compiler.Target[F]): F[ScopedResource[F]] =
     for {
       state <- F.ref[State[F]](initial)
-      token <- Token[F]
+      token <- F.unique
     } yield new ScopedResource[F] {
 
-      override val id: Token = token
+      override val id: Unique = token
 
       private[this] val pru: F[Either[Throwable, Unit]] =
         (Right(()): Either[Throwable, Unit]).pure[F]

--- a/core/shared/src/test/scala/fs2/UniqueSuite.scala
+++ b/core/shared/src/test/scala/fs2/UniqueSuite.scala
@@ -21,23 +21,23 @@
 
 package fs2
 
-import fs2.internal.Token
+import fs2.internal.Unique
 import cats.effect.SyncIO
 
-class TokenSuite extends Fs2Suite {
-  test("Tokens are unique") {
+class UniqueSuite extends Fs2Suite {
+  test("Uniques are unique") {
     for {
-      a <- Token[SyncIO]
-      b <- Token[SyncIO]
+      a <- Unique.sync[SyncIO]
+      b <- Unique.sync[SyncIO]
     } yield assertNotEquals(a, b)
   }
 
-  test("Tokens are stable") {
-    Token[SyncIO].map(t => assertEquals(t, t))
+  test("Uniques are stable") {
+    Unique.sync[SyncIO].map(t => assertEquals(t, t))
   }
 
-  test("Tokens are referentially transparent") {
-    val token = Token[SyncIO]
+  test("Uniques are referentially transparent") {
+    val token = Unique.sync[SyncIO]
     for {
       a <- token
       b <- token


### PR DESCRIPTION
cc @ChristopherDavenport 

Looks like we'll be able to replace the fs2 Token with `cats.effect.std.Unique` by pushing construction in to `Compiler.Target`