### PR TITLE
FAQ - Fix line to add to build.sbt

### DIFF
--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -12,7 +12,7 @@ position: 4
 Sometimes, stream programs that call `unsafeRunSync` or other blocking operations hang in the REPL. This is a result of the Scala 2.12's lambda encoding and is tracked in [SI-9076](https://issues.scala-lang.org/browse/SI-9076). There are various workarounds:
  - Add `-Ydelambdafy:inline` to REPL arguments
  - In Ammonite, run `interp.configureCompiler(_.settings.Ydelambdafy.tryToSetColon(List("inline")))`
- - In SBT, add `scalacOptions in Console += "-Ydelambdafy:inline"`
+ - In SBT, add `scalacOptions in console += "-Ydelambdafy:inline"` to `build.sbt`
  - Instead of calling `s.unsafeRunSync`, call `s.unsafeRunAsync(println)` or `Await.result(s.unsafeToFuture, timeout)`
 
 ### What does `Stream.compile` do?  Is it actually compiling something?  Optimizing the stream somehow?


### PR DESCRIPTION
`scalacOptions in Console += "-Ydelambdafy:inline"` fails with 

```
/home/lcampos/Development/experiment-with-stuff-scala/build.sbt:90: error: overloaded method value in with alternatives:
  (scope: sbt.Scope)sbt.TaskKey[Seq[String]] <and>
  (c: sbt.ConfigKey)sbt.TaskKey[Seq[String]] <and>
  (t: sbt.Scoped)sbt.TaskKey[Seq[String]] <and>
  (p: sbt.Reference)sbt.TaskKey[Seq[String]]
 cannot be applied to (sbt.Console.type)
scalacOptions in Console += "-Ydelambdafy:inline"
              ^
[error] Type error in expression
[warn] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)
```