### PR TITLE
Update FAQ with information about REPL hangs in Scala versions 2.12.0-2.13.1

### DIFF
--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -9,11 +9,13 @@ position: 4
 
 ### Why does stream evaluation sometimes hang in the REPL?
 
-Sometimes, stream programs that call `unsafeRunSync` or other blocking operations hang in the REPL. This is a result of the Scala 2.12's lambda encoding and is tracked in [SI-9076](https://issues.scala-lang.org/browse/SI-9076). There are various workarounds:
+In versions of Scala between 2.12.0 and 2.13.1, stream programs that call `unsafeRunSync` or other blocking operations sometimes hang in the REPL. This is a result of the Scala's lambda encoding and is tracked in [SI-9076](https://issues.scala-lang.org/browse/SI-9076). There are various workarounds:
  - Add `-Ydelambdafy:inline` to REPL arguments
  - In Ammonite, run `interp.configureCompiler(_.settings.Ydelambdafy.tryToSetColon(List("inline")))`
  - In SBT, add `scalacOptions in console += "-Ydelambdafy:inline"` to `build.sbt`
  - Instead of calling `s.unsafeRunSync`, call `s.unsafeRunAsync(println)` or `Await.result(s.unsafeToFuture, timeout)`
+
+In Scala 2.13.2 and higher, this issue has been fixed (see [scala/scala#8748](https://github.com/scala/scala/pull/8748). Starting with Scala 2.13.2, the REPL uses a "class-based wrappers" implementation which fixes the problem. If you are already using a Scala 2.13.0 or 2.13.1, the easiest solution may be to upgrade to 2.13.2 or higher.
 
 ### What does `Stream.compile` do?  Is it actually compiling something?  Optimizing the stream somehow?
 

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -9,13 +9,11 @@ position: 4
 
 ### Why does stream evaluation sometimes hang in the REPL?
 
-In versions of Scala between 2.12.0 and 2.13.1, stream programs that call `unsafeRunSync` or other blocking operations sometimes hang in the REPL. This is a result of the Scala's lambda encoding and is tracked in [SI-9076](https://issues.scala-lang.org/browse/SI-9076). There are various workarounds:
+In versions of Scala between 2.12.0 and 2.13.1, stream programs that call `unsafeRunSync` or other blocking operations sometimes hang in the REPL. This is a result of Scala's lambda encoding and was tracked in [SI-9076](https://issues.scala-lang.org/browse/SI-9076). The issue was fixed in Scala 2.13.2 (see [scala/scala#8748](https://github.com/scala/scala/pull/8748). If you are already using Scala 2.13.0 or 2.13.1, the easiest solution may be to upgrade to 2.13.2 or higher. If you cannot change Scala versions, there are various workarounds:
  - Add `-Ydelambdafy:inline` to REPL arguments
  - In Ammonite, run `interp.configureCompiler(_.settings.Ydelambdafy.tryToSetColon(List("inline")))`
  - In SBT, add `scalacOptions in console += "-Ydelambdafy:inline"` to `build.sbt`
  - Instead of calling `s.unsafeRunSync`, call `s.unsafeRunAsync(println)` or `Await.result(s.unsafeToFuture, timeout)`
-
-In Scala 2.13.2 and higher, this issue has been fixed (see [scala/scala#8748](https://github.com/scala/scala/pull/8748). Starting with Scala 2.13.2, the REPL uses a "class-based wrappers" implementation which fixes the problem. If you are already using a Scala 2.13.0 or 2.13.1, the easiest solution may be to upgrade to 2.13.2 or higher.
 
 ### What does `Stream.compile` do?  Is it actually compiling something?  Optimizing the stream somehow?
 


### PR DESCRIPTION
See discussion from gitter: https://gitter.im/functional-streams-for-scala/fs2?at=5ff576eb4498e01bbf8df9e9