### PR TITLE
Buffer through

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -992,6 +992,29 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   ): Stream[F2, Nothing] =
     this.chunks.noneTerminate.foreach(queue.offer)
 
+  // A builder for queues.
+  trait MakeQueue[F[_]] {
+    def create[A]: F[Queue[F, A]]
+  }
+
+  /** Buffers the elements of this stream through a queue that is created by the supplied builder,
+    * and returns a new stream that consumes the elements from that queue. The new stream terminates
+    * after this stream terminates and all elements are processed.
+    */
+  def bufferThrough[F2[x] >: F[x]: Concurrent, O2 >: O](mkQueue: MakeQueue[F2]): Stream[F2, O2] =
+    Stream.eval(mkQueue.create[Option[O2]]).flatMap { queue =>
+      this.enqueueNoneTerminated(queue).concurrently(Stream.fromQueueNoneTerminated(queue))
+    }
+
+  /** Buffers the chunks of this stream through a queue that is created by the supplied builder,
+    * and returns a new stream that consumes the chunks from that queue. The new stream terminates
+    * after this stream terminates and all chunks are processed.
+    */
+  def bufferChunksThrough[F2[x] >: F[x]: Concurrent, O2 >: O](mkQueue: MakeQueue[F2]): Stream[F2, O2] =
+    Stream.eval(mkQueue.create[Option[Chunk[O2]]]).flatMap { queue =>
+      this.enqueueNoneTerminatedChunks(queue).concurrently(Stream.fromQueueNoneTerminatedChunk(queue))
+    }
+
   /** Alias for `flatMap(o => Stream.eval(f(o)))`.
     *
     * @example {{{

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1004,7 +1004,10 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     */
   def bufferThrough[F2[x] >: F[x]: Concurrent, O2 >: O](mkQueue: MakeQueue[F2]): Stream[F2, O2] =
     Stream.eval(mkQueue.create[Option[Either[Throwable, O2]]]).flatMap { queue =>
-      Stream.fromQueueNoneTerminated(queue).rethrow.concurrently(this.attempt.enqueueNoneTerminated(queue))
+      Stream
+        .fromQueueNoneTerminated(queue)
+        .rethrow
+        .concurrently(this.attempt.enqueueNoneTerminated(queue))
     }
 
   /** Buffers the chunks of this stream through a queue that is created by the supplied builder,
@@ -1012,9 +1015,14 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * after both this stream terminates and all chunks are emitted. Errors from this stream are
     * propagated to the new stream.
     */
-  def bufferChunksThrough[F2[x] >: F[x]: Concurrent, O2 >: O](mkQueue: MakeQueue[F2]): Stream[F2, O2] =
+  def bufferChunksThrough[F2[x] >: F[x]: Concurrent, O2 >: O](
+      mkQueue: MakeQueue[F2]
+  ): Stream[F2, O2] =
     Stream.eval(mkQueue.create[Option[Chunk[Either[Throwable, O2]]]]).flatMap { queue =>
-      Stream.fromQueueNoneTerminatedChunk(queue).rethrow.concurrently(this.attempt.enqueueNoneTerminatedChunks(queue))
+      Stream
+        .fromQueueNoneTerminatedChunk(queue)
+        .rethrow
+        .concurrently(this.attempt.enqueueNoneTerminatedChunks(queue))
     }
 
   /** Alias for `flatMap(o => Stream.eval(f(o)))`.


### PR DESCRIPTION
I'm starting to explore some preliminary ideas for an fs2-oriented `Queue`. FS2 provides an integration with the Cats Effect Queue, but it is neither stream- nor chunk-aware, so there are some inefficiencies and workarounds in place to get things to play well. Based on conversation in Gitter, some desirable properties of such fs2-oriented queue are: stream termination, chunk awareness, error propagation, and backpressure.

Before I get any hopes up, I haven't actually implement a `Queue` in this PR. I add a new combinator, `bufferThrough`, which is implemented in terms of the CE queue, which I think satisfies most of the properties laid out above.

`bufferThrough` is pretty much the `identity` function, but elements are buffered through a queue. Actually, there is another function that already does exactly this: `prefetch`. The main difference is that `bufferThrough` gives you more freedom to control backpressure semantics by supplying whatever kind of queue you want, using a trick similar to the one that @SystemFw used for `Async.cont`. Accordingly, `prefetch` can be implemented in terms of `bufferThrough`.

So I'm not actually introducing anything groundbreaking here! My goal is rather to draw attention to yet another dimension of streaming queues: the topology of the system. `prefetch` and `bufferThrough` are both single-producer, single-consumer systems. I'm not sure yet how to generalize over the remaining three corners of the matrix, if that's even possible at all.

An interesting question is how stream termination would work in multiple-producer systems, if it even makes sense at all. The only behavior that makes sense to me is terminating _all_ producers and consumers whenever a single producer terminates, but that doesn't seem very useful. At that point, I think you would just use `enqueueUnterminated` and `dequeueUnterminated` freely.

I should've probably opened a separate issue or discussion for this, but oh well.