### PR TITLE
Improve performance of TCP socket reads

### DIFF
--- a/io/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/src/main/scala/fs2/io/net/Socket.scala
@@ -93,7 +93,7 @@ object Socket {
       writeSemaphore: Semaphore[F]
   )(implicit F: Async[F])
       extends Socket[F] {
-    private var readBuffer: ByteBuffer = ByteBuffer.allocateDirect(8192)
+    private[this] var readBuffer: ByteBuffer = ByteBuffer.allocateDirect(8192)
 
     private def getBufferForRead(size: Int): F[ByteBuffer] = F.delay {
       if (readBuffer.capacity() < size)

--- a/io/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/src/main/scala/fs2/io/net/Socket.scala
@@ -24,6 +24,13 @@ package io
 package net
 
 import com.comcast.ip4s.{IpAddress, SocketAddress}
+import cats.effect.{Async, Resource}
+import cats.effect.std.Semaphore
+import cats.syntax.all._
+
+import java.net.InetSocketAddress
+import java.nio.channels.{AsynchronousSocketChannel, CompletionHandler}
+import java.nio.{Buffer, ByteBuffer}
 
 /** Provides the ability to read/write from a TCP socket in the effect `F`.
   */
@@ -68,4 +75,140 @@ trait Socket[F[_]] {
   /** Writes the supplied stream of bytes to this socket via `write` semantics.
     */
   def writes: Pipe[F, Byte, INothing]
+}
+
+object Socket {
+  private[net] def forAsync[F[_]: Async](
+      ch: AsynchronousSocketChannel
+  ): Resource[F, Socket[F]] =
+    Resource.make {
+      (Semaphore[F](1), Semaphore[F](1)).mapN { (readSemaphore, writeSemaphore) =>
+        new AsyncSocket[F](ch, readSemaphore, writeSemaphore)
+      }
+    }(_ => Async[F].delay(if (ch.isOpen) ch.close else ()))
+
+  private final class AsyncSocket[F[_]](
+      ch: AsynchronousSocketChannel,
+      readSemaphore: Semaphore[F],
+      writeSemaphore: Semaphore[F]
+  )(implicit F: Async[F])
+      extends Socket[F] {
+    private var readBuffer: ByteBuffer = ByteBuffer.allocateDirect(8192)
+
+    private def getBufferForRead(size: Int): F[ByteBuffer] = F.delay {
+      if (readBuffer.capacity() < size)
+        readBuffer = ByteBuffer.allocateDirect(size)
+      else
+        (readBuffer: Buffer).limit(size)
+      readBuffer
+    }
+
+    /** Performs a single channel read operation in to the supplied buffer. */
+    private def readChunk(buffer: ByteBuffer): F[Int] =
+      F.async_[Int] { cb =>
+        ch.read(
+          buffer,
+          null,
+          new CompletionHandler[Integer, AnyRef] {
+            def completed(result: Integer, attachment: AnyRef): Unit =
+              cb(Right(result))
+            def failed(err: Throwable, attachment: AnyRef): Unit =
+              cb(Left(err))
+          }
+        )
+      }
+
+    /** Copies the contents of the supplied buffer to a `Chunk[Byte]` and clears the buffer contents. */
+    private def releaseBuffer(buffer: ByteBuffer): F[Chunk[Byte]] =
+      Async[F].delay {
+        val read = buffer.position()
+        val result =
+          if (read == 0) Chunk.empty
+          else {
+            val dest = new Array[Byte](read)
+            (buffer: Buffer).flip()
+            buffer.get(dest)
+            Chunk.array(dest)
+          }
+        (buffer: Buffer).clear()
+        result
+      }
+
+    def read(max: Int): F[Option[Chunk[Byte]]] =
+      readSemaphore.permit.use { _ =>
+        getBufferForRead(max).flatMap { buffer =>
+          readChunk(buffer).flatMap { read =>
+            if (read < 0) Async[F].pure(None)
+            else releaseBuffer(buffer).map(Some(_))
+          }
+        }
+      }
+
+    def reads(maxBytes: Int): Stream[F, Byte] =
+      Stream.eval(read(maxBytes)).flatMap {
+        case Some(bytes) =>
+          Stream.chunk(bytes) ++ reads(maxBytes)
+        case None => Stream.empty
+      }
+
+    def readN(max: Int): F[Option[Chunk[Byte]]] =
+      readSemaphore.permit.use { _ =>
+        getBufferForRead(max).flatMap { buffer =>
+          def go: F[Option[Chunk[Byte]]] =
+            readChunk(buffer).flatMap { readBytes =>
+              if (readBytes < 0 || buffer.position() >= max)
+                // read is done
+                releaseBuffer(buffer).map(Some(_))
+              else go
+            }
+          go
+        }
+      }
+
+    def write(bytes: Chunk[Byte]): F[Unit] = {
+      def go(buff: ByteBuffer): F[Unit] =
+        Async[F]
+          .async_[Unit] { cb =>
+            ch.write(
+              buff,
+              (),
+              new CompletionHandler[Integer, Unit] {
+                def completed(result: Integer, attachment: Unit): Unit =
+                  cb(Right(()))
+                def failed(err: Throwable, attachment: Unit): Unit =
+                  cb(Left(err))
+              }
+            )
+          }
+      writeSemaphore.permit.use { _ =>
+        go(bytes.toByteBuffer)
+      }
+    }
+
+    def writes: Pipe[F, Byte, INothing] =
+      _.chunks.foreach(write)
+
+    def localAddress: F[SocketAddress[IpAddress]] =
+      Async[F].delay(
+        SocketAddress.fromInetSocketAddress(
+          ch.getLocalAddress.asInstanceOf[InetSocketAddress]
+        )
+      )
+    def remoteAddress: F[SocketAddress[IpAddress]] =
+      Async[F].delay(
+        SocketAddress.fromInetSocketAddress(
+          ch.getRemoteAddress.asInstanceOf[InetSocketAddress]
+        )
+      )
+    def isOpen: F[Boolean] = Async[F].delay(ch.isOpen)
+    def close: F[Unit] = Async[F].delay(ch.close())
+    def endOfOutput: F[Unit] =
+      Async[F].delay {
+        ch.shutdownOutput(); ()
+      }
+    def endOfInput: F[Unit] =
+      Async[F].delay {
+        ch.shutdownInput(); ()
+      }
+  }
 }

--- a/io/src/main/scala/fs2/io/net/tls/TLSSocket.scala
+++ b/io/src/main/scala/fs2/io/net/tls/TLSSocket.scala
@@ -92,8 +92,8 @@ object TLSSocket {
       def read(maxBytes: Int): F[Option[Chunk[Byte]]] =
         readSem.permit.use(_ => read0(maxBytes))
 
-      def reads(maxBytes: Int): Stream[F, Byte] =
-        Stream.repeatEval(read(maxBytes)).unNoneTerminate.flatMap(Stream.chunk)
+      def reads: Stream[F, Byte] =
+        Stream.repeatEval(read(8192)).unNoneTerminate.flatMap(Stream.chunk)
 
       def writes: Pipe[F, Byte, INothing] =
         _.chunks.foreach(write)

--- a/io/src/main/scala/fs2/io/net/tls/TLSSocket.scala
+++ b/io/src/main/scala/fs2/io/net/tls/TLSSocket.scala
@@ -75,15 +75,15 @@ object TLSSocket {
       private def read0(maxBytes: Int): F[Option[Chunk[Byte]]] =
         engine.read(maxBytes)
 
-      def readN(numBytes: Int): F[Option[Chunk[Byte]]] =
+      def readN(numBytes: Int): F[Chunk[Byte]] =
         readSem.permit.use { _ =>
-          def go(acc: Chunk[Byte]): F[Option[Chunk[Byte]]] = {
+          def go(acc: Chunk[Byte]): F[Chunk[Byte]] = {
             val toRead = numBytes - acc.size
-            if (toRead <= 0) Applicative[F].pure(Some(acc))
+            if (toRead <= 0) Applicative[F].pure(acc)
             else
               read0(toRead).flatMap {
-                case Some(chunk) => go(acc ++ chunk): F[Option[Chunk[Byte]]]
-                case None        => Applicative[F].pure(Some(acc)): F[Option[Chunk[Byte]]]
+                case Some(chunk) => go(acc ++ chunk)
+                case None        => Applicative[F].pure(acc)
               }
           }
           go(Chunk.empty)

--- a/io/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -52,7 +52,7 @@ class SocketSuite extends Fs2Suite {
         .flatMap { case (server, clients) =>
           val echoServer = server.map { socket =>
             socket
-              .reads(1024)
+              .reads
               .through(socket.writes)
               .onFinalize(socket.endOfOutput)
           }.parJoinUnbounded
@@ -65,7 +65,7 @@ class SocketSuite extends Fs2Suite {
                 .through(socket.writes)
                 .onFinalize(socket.endOfOutput) ++
                 socket
-                  .reads(1024)
+                  .reads
                   .chunks
                   .map(bytes => new String(bytes.toArray))
             }
@@ -121,7 +121,7 @@ class SocketSuite extends Fs2Suite {
       Stream
         .resource(setup)
         .flatMap { case (server, clients) =>
-          val readOnlyServer = server.map(_.reads(1024)).parJoinUnbounded
+          val readOnlyServer = server.map(_.reads).parJoinUnbounded
           val client =
             clients.take(1).flatMap { socket =>
               // concurrent writes

--- a/io/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -51,8 +51,7 @@ class SocketSuite extends Fs2Suite {
         .resource(setup)
         .flatMap { case (server, clients) =>
           val echoServer = server.map { socket =>
-            socket
-              .reads
+            socket.reads
               .through(socket.writes)
               .onFinalize(socket.endOfOutput)
           }.parJoinUnbounded
@@ -64,9 +63,7 @@ class SocketSuite extends Fs2Suite {
                 .chunk(message)
                 .through(socket.writes)
                 .onFinalize(socket.endOfOutput) ++
-                socket
-                  .reads
-                  .chunks
+                socket.reads.chunks
                   .map(bytes => new String(bytes.toArray))
             }
             .parJoin(10)

--- a/io/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -100,7 +100,6 @@ class SocketSuite extends Fs2Suite {
                 Stream
                   .emits(sizes)
                   .evalMap(socket.readN(_))
-                  .unNone
                   .map(_.size)
               }
               .take(sizes.length.toLong)

--- a/io/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -63,8 +63,7 @@ class TLSSocketSuite extends TLSSuite {
                 .covary[IO]
                 .through(text.utf8Encode)
                 .through(tlsSocket.writes) ++
-                tlsSocket
-                  .reads
+                tlsSocket.reads
                   .through(text.utf8Decode)
                   .through(text.lines)
             }
@@ -82,8 +81,7 @@ class TLSSocketSuite extends TLSSuite {
               val send = Stream(googleDotCom)
                 .through(text.utf8Encode)
                 .through(socket.writes)
-              val receive = socket
-                .reads
+              val receive = socket.reads
                 .through(text.utf8Decode)
                 .through(text.lines)
 

--- a/io/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -64,7 +64,7 @@ class TLSSocketSuite extends TLSSuite {
                 .through(text.utf8Encode)
                 .through(tlsSocket.writes) ++
                 tlsSocket
-                  .reads(size)
+                  .reads
                   .through(text.utf8Decode)
                   .through(text.lines)
             }
@@ -83,7 +83,7 @@ class TLSSocketSuite extends TLSSuite {
                 .through(text.utf8Encode)
                 .through(socket.writes)
               val receive = socket
-                .reads(size)
+                .reads
                 .through(text.utf8Decode)
                 .through(text.lines)
 
@@ -124,12 +124,12 @@ class TLSSocketSuite extends TLSSuite {
         .resource(setup)
         .flatMap { case (server, clientSocket) =>
           val echoServer = server.map { socket =>
-            socket.reads(size).chunks.foreach(socket.write(_))
+            socket.reads.chunks.foreach(socket.write(_))
           }.parJoinUnbounded
 
           val client =
             Stream.exec(clientSocket.write(msg)) ++
-              clientSocket.reads(size).take(msg.size.toLong)
+              clientSocket.reads.take(msg.size.toLong)
 
           client.concurrently(echoServer)
         }


### PR DESCRIPTION
- Initializes the socket read buffer to 8192 bytes instead of 0
- Uses `allocateDirect`
- Stores read buffer in a private var instead of a `Ref`