### PR TITLE
Pull.loop: change stream return type, from Option to Unit.

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -226,8 +226,12 @@ object Pull extends PullLowPriority {
   /** Repeatedly uses the output of the pull as input for the next step of the pull.
     * Halts when a step terminates with `None` or `Pull.raiseError`.
     */
-  def loop[F[_], O, R](f: R => Pull[F, O, Option[R]]): R => Pull[F, O, Option[R]] =
-    r => f(r).flatMap(_.map(loop(f)).getOrElse(Pull.pure(None)))
+  def loop[F[_], O, R](f: R => Pull[F, O, Option[R]]): R => Pull[F, O, Unit] =
+    (r: R) =>
+      f(r).flatMap {
+        case None    => Pull.done
+        case Some(s) => loop(f)(s)
+      }
 
   /** Outputs a single value. */
   def output1[F[x] >: Pure[x], O](o: O): Pull[F, O, Unit] = Output(Chunk.singleton(o))

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3600,7 +3600,6 @@ object Stream extends StreamLowPriority {
         val (o, sOpt) = f(s)
         Pull.output1(o) >> Pull.pure(sOpt)
       }(s)
-      .void
       .stream
 
   /** Like [[unfoldLoop]], but takes an effectful function. */
@@ -3611,7 +3610,6 @@ object Stream extends StreamLowPriority {
           Pull.output1(o) >> Pull.pure(sOpt)
         }
       )(s)
-      .void
       .stream
 
   /** Provides syntax for streams that are invariant in `F` and `O`. */
@@ -3714,7 +3712,7 @@ object Stream extends StreamLowPriority {
     def repeatPull[O2](
         f: Stream.ToPull[F, O] => Pull[F, O2, Option[Stream[F, O]]]
     ): Stream[F, O2] =
-      Pull.loop(f.andThen(_.map(_.map(_.pull))))(pull).void.stream
+      Pull.loop(f.andThen(_.map(_.map(_.pull))))(pull).stream
   }
 
   /** Provides syntax for streams of streams. */
@@ -4587,7 +4585,6 @@ object Stream extends StreamLowPriority {
         .loop[F, O, StepLeg[F, O]](leg => Pull.output(leg.head).flatMap(_ => leg.stepLeg))(
           self.setHead(Chunk.empty)
         )
-        .void
         .stream
 
     /** Replaces head of this leg. Useful when the head was not fully consumed. */


### PR DESCRIPTION
The `Pull.loop` had the return type `Pull[F, O, Option[R]]`, which suggests that at the end of loop there would be some r or none. But in truth, the loop ends when there is none, with none. So we can just say that it ends with Unit.

This makes `Pull.loop` more similar to the _unfold_ method for building lists from an `A => Option[B]` method. Here we can even build the Stream from it.

Along the way, we save a few calls to `Pull.void`, which will shave some allocations.