### PR TITLE
make readOutputStream use chunkSize consistently

### DIFF
--- a/io/src/main/scala/fs2/io/io.scala
+++ b/io/src/main/scala/fs2/io/io.scala
@@ -158,7 +158,7 @@ package object io {
     val mkOutput: Resource[F, (OutputStream, InputStream)] =
       Resource.make(Sync[F].delay {
         val os = new PipedOutputStream()
-        val is = new PipedInputStream(os)
+        val is = new PipedInputStream(os, chunkSize)
         (os: OutputStream, is: InputStream)
       })(ois =>
         blocker.delay {


### PR DESCRIPTION
I noticed that regardless of the `chunkSize` passed into `readOutputStream`, the resulting stream has 1024-byte chunks, due to the default buffer size in `PipedInputStream`. Passing the chunk size into the `PipedInputStream` constructor syncs the two up.