### PR TITLE
Don't mention a non-existent function (interrupt) in the docs (fix #1561)

### DIFF
--- a/site/guide.md
+++ b/site/guide.md
@@ -381,7 +381,7 @@ import cats.effect.unsafe.implicits.global
 Stream(1,2,3).merge(Stream.eval(IO { Thread.sleep(200); 4 })).compile.toVector.unsafeRunSync()
 ```
 
-The `merge` function supports concurrency. FS2 has a number of other useful concurrency functions like `concurrently` (runs another stream concurrently and discards its output), `interrupt` (halts if the left branch produces `false`), `either` (like `merge` but returns an `Either`), `mergeHaltBoth` (halts if either branch halts), and others.
+The `merge` function supports concurrency. FS2 has a number of other useful concurrency functions like `concurrently` (runs another stream concurrently and discards its output), `interruptWhen` (halts if the left branch produces `true`), `either` (like `merge` but returns an `Either`), `mergeHaltBoth` (halts if either branch halts), and others.
 
 The function `parJoin` runs multiple streams concurrently. The signature is:
 


### PR DESCRIPTION
Solves https://github.com/typelevel/fs2/issues/1561.