### PR TITLE
Simpler examples of concurrency primitives

### DIFF
--- a/site/concurrency-primitives.md
+++ b/site/concurrency-primitives.md
@@ -26,7 +26,7 @@ implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 implicit val c: ConcurrentEffect[IO] = IO.ioConcurrentEffect
 
 Topic("Topic start").flatMap { topic =>
-  val publisher = Stream.emit("1").repeat.covary[IO].through(topic.publish)
+  val publisher = Stream.constant("1").covary[IO].through(topic.publish)
   val subscriber = topic.subscribe(10).take(4)
   subscriber.concurrently(publisher).compile.toVector
 }.unsafeRunSync()

--- a/site/concurrency-primitives.md
+++ b/site/concurrency-primitives.md
@@ -1,11 +1,11 @@
 # Concurrency Primitives
 
-In the [`fs2.concurrent` package](https://github.com/functional-streams-for-scala/fs2/blob/series/1.0/core/shared/src/main/scala/fs2/concurrent/) you'll find a bunch of useful concurrency primitives built on the concurrency primitives defined in `cats.effect.concurrent`. For example:
+In the [`fs2.concurrent` package](https://github.com/functional-streams-for-scala/fs2/blob/series/1.0/core/shared/src/main/scala/fs2/concurrent/) you'll find a bunch of useful concurrency primitives built on the concurrency primitives defined in `cats-effect`. For example:
 
 - `Topic[F, A]`
 - `Signal[F, A]`
 
-Beyond these, `Stream` also provides functions to interact with cats-effect's `Queue`. 
+In addition, `Stream` provides functions to interact with cats-effect's `Queue`. 
 
 ## Simple Examples
 


### PR DESCRIPTION
~~Didn't add an example for Queue because [it is being moved to cats-effect](https://github.com/typelevel/fs2/issues/2213). :)~~