### PR TITLE
Change: all Output operators are non-empty.

### DIFF
--- a/core/jvm/src/main/scala/fs2/compression.scala
+++ b/core/jvm/src/main/scala/fs2/compression.scala
@@ -261,7 +261,7 @@ object compression {
       crc32: Option[CRC32],
       deflatedBuffer: Array[Byte]
   ): Stream[F, Byte] => Pull[F, Byte, Unit] =
-    _.pull.unconsNonEmpty.flatMap {
+    _.pull.uncons.flatMap {
       case Some((inflatedChunk, inflatedStream)) =>
         _deflate_chunk(
           deflateParams,
@@ -341,7 +341,7 @@ object compression {
     in =>
       Stream.suspend {
         val inflatedBuffer = new Array[Byte](inflateParams.bufferSizeOrMinimum)
-        in.pull.unconsNonEmpty.flatMap {
+        in.pull.uncons.flatMap {
           case Some((deflatedChunk, deflatedStream)) =>
             _inflate_chunk(
               inflater,
@@ -426,7 +426,7 @@ object compression {
       crc32: Option[CRC32],
       inflatedBuffer: Array[Byte]
   )(implicit SyncF: Sync[F]): Stream[F, Byte] => Pull[F, Byte, Unit] =
-    _.pull.unconsNonEmpty.flatMap {
+    _.pull.uncons.flatMap {
       case Some((deflatedChunk, deflatedStream)) =>
         _inflate_chunk(
           inflater,
@@ -1059,7 +1059,7 @@ object compression {
           } else Pull.raiseError(new ZipException("Failed to read trailer (1)"))
 
         def streamUntilTrailer(last: Chunk[Byte]): Stream[F, Byte] => Pull[F, Byte, Unit] =
-          _.pull.unconsNonEmpty
+          _.pull.uncons
             .flatMap {
               case Some((next, rest)) =>
                 if (inflater.finished())

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -495,6 +495,7 @@ object Pull extends PullLowPriority {
    */
   private abstract class Action[+F[_], +O, +R] extends Pull[F, O, R]
 
+  /* A Pull Action to emit a non-empty chunk of outputs */
   private final case class Output[+O](values: Chunk[O]) extends Action[Pure, O, Unit]
 
   /* A translation point, that wraps an inner stream written in another effect
@@ -578,6 +579,11 @@ object Pull extends PullLowPriority {
       haltOnSignal: F[Either[Throwable, Unit]]
   ): Pull[F, O, Unit] = InterruptWhen(haltOnSignal)
 
+  /* Pull transformation that takes the given stream (pull), unrolls it until it either:
+   * - Reaches the end of the stream, and returns None; or
+   * - Reaches an Output action, and emits Some pair with
+   *   the non-empty chunk of values and the rest of the stream.
+   */
   private[fs2] def uncons[F[_], O](
       s: Pull[F, O, Unit]
   ): Pull[F, INothing, Option[(Chunk[O], Pull[F, O, Unit])]] =


### PR DESCRIPTION
Currently, the constructors of a Stream (or Pull) ensure that every Chunk in a Stream, that is every `Output` node in a pull, must have a non-empty Chunk. Therefore, where we uncons we always stop at a non-empty chunk-stream, so we can omit the "nonEmpty" methods..