### PR TITLE
Some code cleanups.

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -560,9 +560,7 @@ object Pull extends PullLowPriority {
       leg: Stream.StepLeg[F, O]
   ): Pull[F, Nothing, Option[Stream.StepLeg[F, O]]] =
     Step[F, O](leg.next, Some(leg.scopeId)).map {
-      _.map { case (h, id, t) =>
-        new Stream.StepLeg[F, O](h, id, t.asInstanceOf[Pull[F, O, Unit]])
-      }
+      _.map { case (h, id, t) => new Stream.StepLeg[F, O](h, id, t) }
     }
 
   /** Wraps supplied pull in new scope, that will be opened before this pull is evaluated


### PR DESCRIPTION
- Pull.setepLeg: no need for `asInstanceOf`.
- Stream zipping method: replace unused `Option[INothing]` by unit, which allows us to remove .void calls.
- Stream.zipWith_ method: the parameter `k1` is only ever applied to  a `Left`, so we can reduce it to the left type. Similarly, the parameter `k2` is applied to either a `Right` or a `Left`, so we can split it in two parameters.