### PR TITLE
Fix appendix navigation (fixes #2235)

### DIFF
--- a/site/guide.md
+++ b/site/guide.md
@@ -23,7 +23,7 @@ This is the official FS2 guide. It gives an overview of the library and its feat
 * [Talking to the external world](#talking-to-the-external-world)
 * [Reactive streams](#reactive-streams)
 * [Learning more](#learning-more)
-* [Appendix: How interruption of streams works](#a1)
+* [Appendixes](#appendixes)
 
 _Unless otherwise noted, the type `Stream` mentioned in this document refers to the type `fs2.Stream` and NOT `scala.collection.immutable.Stream`._
 
@@ -656,7 +656,9 @@ Want to learn more?
 
 Also feel free to come discuss and ask/answer questions in [the gitter channel](https://gitter.im/functional-streams-for-scala/fs2) and/or on StackOverflow using [the tag FS2](http://stackoverflow.com/tags/fs2).
 
-### <a id="a1"></a> Appendix A1: How interruption of streams works
+### Appendixes
+
+#### Appendix A1: How interruption of streams works
 
 In FS2, a stream can terminate in one of three ways:
 


### PR DESCRIPTION
Links in navigation and table of contents to the appendix section now works correctly.

![appendix-fix](https://user-images.githubusercontent.com/12008784/106383432-d3e68200-63bd-11eb-98e7-6dfd1f740e5c.gif)
