### PR TITLE
Pull 'onCons' function

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -587,6 +587,14 @@ object Pull extends PullLowPriority {
   ): Pull[F, INothing, Option[(Chunk[O], Pull[F, O, Unit])]] =
     Step(s, None).map(_.map { case (h, _, t) => (h, t.asInstanceOf[Pull[F, O, Unit]]) })
 
+  private[fs2] def onCons[F[_], O, O2, R](s: Pull[F, O, Unit])(
+      fun: Option[(Chunk[O], Pull[F, O, Unit])] => Pull[F, O2, R]
+  ): Pull[F, O2, R] =
+    Step(s, None).flatMap {
+      case None              => fun(None)
+      case Some((hd, _, tl)) => fun(Some((hd, tl)))
+    }
+
   private type Cont[-Y, +G[_], +X] = Result[Y] => Pull[G, X, Unit]
 
   /* Left-folds the output of a stream.


### PR DESCRIPTION
Looking through the code of `Stream`, we noticed that the `uncons` method is used to implement a lot of the Stream combinators. The `uncons` is often followed by that of `Pull.flatMap`. Furthermore, the `uncons` implementation itself includes a `map` operation. 

This commit introduces an `onCons` method, that combines the `uncons` and the `flatMap`, to provide a better combinator.
The `onCons` function takes a function on what to do upon the first "cons", which is to say, on the first Output from the stream.