### PR TITLE
Pull: split Step operation in two constructors.

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4573,7 +4573,7 @@ object Stream extends StreamLowPriority {
     * Once the stream will stop to be interleaved (merged), then `stream` allows to return to normal stream
     * invocation.
     */
-  final class StepLeg[F[_], O](
+  final class StepLeg[+F[_], O](
       val head: Chunk[O],
       private[fs2] val scopeId: Unique,
       private[fs2] val next: Pull[F, O, Unit]


### PR DESCRIPTION
The `Step` Pull constructor is used to turn a closed pull (a Stream) into a pull that stops at the first `Output` node. It had an optional scopeId parameter, to indicate if we shift to a scope or not.
- The `None` case is used for the `uncons` operation, which maps the return triplet to the tuple and ignores the second element. 
- The `Some` case is used for the `stepLeg`, which maps the triplet to a `StepLeg`.

Since these are different usages with different data and different end return type, it may be better to split the `Step` into two cases `StepCons` and `StepLeg`.

- StepCons is a step without shifting scopes, and it returns just the (option of) tuple of Chunk and tail pull.
- StepLeg is a step that is run in a separate scope, shifting there and back again. Upon reaching an `Output`, it gives back all three elements in a `StepLeg` object.