### PR TITLE
Question - Eager and Strict pull append?

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -105,6 +105,19 @@ sealed abstract class Pull[+F[_], +O, +R] {
         }
     }
 
+  /** Appends the given `post` pull after `this` pull.
+    * This is like `*>` except that the `post` pull is eagerly evaluated.
+    */
+  def *>[F2[x] >: F[x], O2 >: O, R2](p2: Pull[F2, O2, R2]): Pull[F2, O2, R2] =
+    new Bind[F2, O2, R, R2](this) {
+      def cont(r: Terminal[R]): Pull[F2, O2, R2] =
+        r match {
+          case _: Succeeded[_] => p2
+          case r: Interrupted  => r
+          case r: Fail         => r
+        }
+    }
+
   /** Lifts this pull to the specified effect type. */
   def covary[F2[x] >: F[x]]: Pull[F2, O, R] = this
 


### PR DESCRIPTION
In `Pull` we have the `>>` method which performs a lazy append: although the receiver `Pull` object is allocated before the call, the `p2` or `post`  pull argument is passed lazily. Lazy evaluation may have some allocation costs. When the receiver / prefix pull is simple enough that, barring interruption, the post is certain to be allocated.

The proposal (not certain how useful it would be) is to complement `Pull.>>` with a `Pull.*>` method, which much like the method in the `cats.Applicative` typeclass, is strict on the second argument (the suffix pull) 

The risk of this, of course, is that by preallocating the right-hand side we may be leaking memory, for instance if the prefix is expanded in an infinite pull. However, wouldn't that risk also exist with thunks? Lazy evaluation, at least in Haskell, is not free; so the one in Scala may not be either.