### PR TITLE
Stream - Concurrently - Require INothing

### DIFF
--- a/core/shared/src/main/scala/fs2/concurrent/Balance.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Balance.scala
@@ -74,6 +74,7 @@ object Balance {
         source.chunks
           .evalMap(chunk => pubSub.publish(Some(chunk)))
           .onFinalize(pubSub.publish(None))
+          .drain
 
       Stream.constant(subscriber).concurrently(push)
     }

--- a/core/shared/src/main/scala/fs2/concurrent/Broadcast.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Broadcast.scala
@@ -75,7 +75,7 @@ object Broadcast {
             .evalMap(chunk => pubSub.publish(Some(chunk)))
             .onFinalize(pubSub.publish(None))
 
-        Stream.constant(subscriber).concurrently(publish)
+        Stream.constant(subscriber).concurrently(publish.drain)
       }
   }
 


### PR DESCRIPTION
The type signature of the `concurrently` method accepts any type `O2`. Perhaps it would be better to require it to be `INothing`, so that the caller is aware that no outputs can come off it. 