### PR TITLE
Stream: add execMap and execMapChunk functions.

### DIFF
--- a/core/shared/src/main/scala/fs2/concurrent/Balance.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Balance.scala
@@ -70,9 +70,9 @@ object Balance {
           .getStream(chunkSize)
           .unNoneTerminate
           .flatMap(Stream.chunk)
-      def push =
-        source.chunks
-          .evalMap(chunk => pubSub.publish(Some(chunk)))
+      def push: Stream[F, INothing] =
+        source
+          .execMapChunk(chunk => pubSub.publish(Some(chunk)))
           .onFinalize(pubSub.publish(None))
 
       Stream.constant(subscriber).concurrently(push)

--- a/core/shared/src/main/scala/fs2/concurrent/Broadcast.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Broadcast.scala
@@ -70,9 +70,9 @@ object Broadcast {
               .flatMap(Stream.chunk)
           }
 
-        def publish =
-          source.chunks
-            .evalMap(chunk => pubSub.publish(Some(chunk)))
+        val publish: Stream[F, INothing] =
+          source
+            .execMapChunk(chunk => pubSub.publish(Some(chunk)))
             .onFinalize(pubSub.publish(None))
 
         Stream.constant(subscriber).concurrently(publish)

--- a/core/shared/src/main/scala/fs2/concurrent/Topic.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Topic.scala
@@ -134,7 +134,7 @@ object Topic {
               }
 
           def publish: Pipe[F, A, Nothing] =
-            _.evalMap(publish1).drain
+            _.execMap(publish1)
 
           def subscribe(maxQueued: Int): Stream[F, A] =
             Stream.resource(subscribeAwait(maxQueued)).flatten

--- a/core/shared/src/main/scala/fs2/concurrent/Topic.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Topic.scala
@@ -134,7 +134,7 @@ object Topic {
               }
 
           def publish: Pipe[F, A, Nothing] =
-            _.execMap(publish1)
+            _.evalMap(publish1).drain
 
           def subscribe(maxQueued: Int): Stream[F, A] =
             Stream.resource(subscribeAwait(maxQueued)).flatten

--- a/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
+++ b/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
@@ -67,8 +67,8 @@ private[io] object JavaInputOutputStream {
         upState: SignallingRef[F, UpStreamState],
         dnState: SignallingRef[F, DownStreamState]
     ): F[Unit] =
-      source.chunks
-        .evalMap(ch => queue.offer(Right(ch.toArraySlice)))
+      source
+        .execMapChunk(ch => queue.offer(Right(ch.toArraySlice)))
         .interruptWhen(dnState.discrete.map(_.isDone).filter(identity))
         .compile
         .drain


### PR DESCRIPTION
This introduces the functions `execMap` and `execMapChunk`. The latter takes an effectful action on chunks, performs it, and emit nothing. The former does the action on elements, but running them on all elements of each chunk. 