### PR TITLE
Fixes a stall in TLSSocket encountered in ember-server

### DIFF
--- a/io/src/main/scala/fs2/io/tls/TLSSocket.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSSocket.scala
@@ -95,10 +95,10 @@ object TLSSocket {
         _.chunks.evalMap(write(_, timeout))
 
       def endOfOutput: F[Unit] =
-        engine.stopWrap >> socket.endOfOutput
+        socket.endOfOutput
 
       def endOfInput: F[Unit] =
-        engine.stopUnwrap >> socket.endOfInput
+        socket.endOfInput
 
       def localAddress: F[SocketAddress] =
         socket.localAddress

--- a/io/src/test/scala/fs2/io/tls/TLSSocketSuite.scala
+++ b/io/src/test/scala/fs2/io/tls/TLSSocketSuite.scala
@@ -130,8 +130,8 @@ class TLSSocketSuite extends TLSSuite {
                     serverNames = Some(List(new SNIHostName("www.google.com")))
                   )
                   // logger = Some((m: String) =>
-                  //   IO.delay(println(s"${Console.MAGENTA}[TLS] $m${Console.RESET}"))
-                  // )
+                  //  IO.delay(println(s"${Console.MAGENTA}[TLS] $m${Console.RESET}"))
+                  //)
                 )
                 .use { socket =>
                   val send = Stream("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n")
@@ -146,7 +146,7 @@ class TLSSocketSuite extends TLSSuite {
                     .concurrently(send.delayBy(100.millis))
                     .compile
                     .string
-                    .map(it => assert(it == "HTTP/1.1 200 OK"))
+                    .map(it => assertEquals(it, "HTTP/1.1 200 OK"))
                 }
             }
           }

--- a/io/src/test/scala/fs2/io/tls/TLSSocketSuite.scala
+++ b/io/src/test/scala/fs2/io/tls/TLSSocketSuite.scala
@@ -62,6 +62,7 @@ class TLSSocketSuite extends TLSSuite {
                             .through(text.utf8Encode)
                             .through(tlsSocket.writes())
                             .drain ++
+                            Stream.eval_(tlsSocket.endOfOutput) ++
                             tlsSocket
                               .reads(8192)
                               .through(text.utf8Decode)


### PR DESCRIPTION
Fixes the issue seen here: https://github.com/http4s/http4s/issues/4458

The issue was caused by a client that closes the socket for writing while still reading.