### PR TITLE
Shared server sockets

### DIFF
--- a/core/shared/src/main/scala/fs2/Shared.scala
+++ b/core/shared/src/main/scala/fs2/Shared.scala
@@ -22,7 +22,6 @@
 package fs2
 
 import cats.effect._
-import cats.effect.kernel.Resource
 import cats.syntax.all._
 
 sealed trait Shared[F[_], A] {

--- a/core/shared/src/main/scala/fs2/Shared.scala
+++ b/core/shared/src/main/scala/fs2/Shared.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import cats.effect._
+import cats.effect.kernel.Resource
+import cats.syntax.all._
+
+sealed trait Shared[F[_], A] {
+  def resource: Resource[F, A]
+}
+
+object Shared {
+  def allocate[F[_], A](
+      resource: Resource[F, A]
+  )(implicit F: Concurrent[F]): Resource[F, (Shared[F, A], A)] = {
+    final case class State(value: A, finalizer: F[Unit], permits: Int) {
+      def addPermit: State = copy(permits = permits + 1)
+      def releasePermit: State = copy(permits = permits - 1)
+    }
+
+    MonadCancel[Resource[F, *]].uncancelable { _ =>
+      for {
+        shared <- Resource.eval(resource.allocated.flatMap { case (a, fin) =>
+          F.ref[Option[State]](Some(State(a, fin, 0))).map { state =>
+            def acquire: F[A] =
+              state.modify {
+                case Some(st) => (Some(st.addPermit), F.pure(st.value))
+                case None =>
+                  (None, F.raiseError[A](new Throwable("finalization has already occurred")))
+              }.flatten
+
+            def release: F[Unit] =
+              state.modify {
+                case Some(st) if st.permits > 1 => (Some(st.releasePermit), F.unit)
+                case Some(st)                   => (None, st.finalizer)
+                case None                       => (None, F.raiseError[Unit](new Throwable("can't finalize")))
+              }.flatten
+
+            new Shared[F, A] {
+              override def resource: Resource[F, A] =
+                Resource.make(acquire)(_ => release)
+            }
+          }
+        })
+        a <- shared.resource
+      } yield (shared, a)
+    }
+  }
+}

--- a/core/shared/src/main/scala/fs2/Shared.scala
+++ b/core/shared/src/main/scala/fs2/Shared.scala
@@ -44,21 +44,15 @@ object Shared {
         shared = new Shared[F, A] {
           def acquire: F[A] =
             state.modify {
-              case Some(st) => 
-                println("acquired")
-                (Some(st.addPermit), F.pure(st.value))
+              case Some(st) => (Some(st.addPermit), F.pure(st.value))
               case None =>
                 (None, F.raiseError[A](new Throwable("finalization has already occurred")))
             }.flatten
 
           def release: F[Unit] =
             state.modify {
-              case Some(st) if st.permits > 1 => 
-                println("released with many")
-                (Some(st.releasePermit), F.unit)
-              case Some(st)                   => 
-                println("released with one")
-                (None, st.finalizer)
+              case Some(st) if st.permits > 1 => (Some(st.releasePermit), F.unit)
+              case Some(st)                   => (None, st.finalizer)
               case None                       => (None, F.raiseError[Unit](new Throwable("can't finalize")))
             }.flatten
 

--- a/io/src/main/scala/fs2/io/net/Network.scala
+++ b/io/src/main/scala/fs2/io/net/Network.scala
@@ -132,13 +132,13 @@ object Network {
           address: Option[Host],
           port: Option[Port],
           options: List[SocketOption]
-      ): Stream[F, Socket[F]] = globalSocketGroup.server(address, port, options)
+      ): Stream[F, Shared[F, Socket[F]]] = globalSocketGroup.server(address, port, options)
 
       def serverResource(
           address: Option[Host],
           port: Option[Port],
           options: List[SocketOption]
-      ): Resource[F, (SocketAddress[IpAddress], Stream[F, Socket[F]])] =
+      ): Resource[F, (SocketAddress[IpAddress], Stream[F, Shared[F, Socket[F]]])] =
         globalSocketGroup.serverResource(address, port, options)
 
       def openDatagramSocket(

--- a/io/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/src/main/scala/fs2/io/net/Socket.scala
@@ -24,7 +24,7 @@ package io
 package net
 
 import com.comcast.ip4s.{IpAddress, SocketAddress}
-import cats.effect.{Async, Resource}
+import cats.effect.Async
 import cats.effect.std.Semaphore
 import cats.syntax.all._
 
@@ -79,12 +79,10 @@ trait Socket[F[_]] {
 object Socket {
   private[net] def forAsync[F[_]: Async](
       ch: AsynchronousSocketChannel
-  ): Resource[F, Socket[F]] =
-    Resource.make {
-      (Semaphore[F](1), Semaphore[F](1)).mapN { (readSemaphore, writeSemaphore) =>
-        new AsyncSocket[F](ch, readSemaphore, writeSemaphore)
-      }
-    }(_ => Async[F].delay(if (ch.isOpen) ch.close else ()))
+  ): F[Socket[F]] =
+    (Semaphore[F](1), Semaphore[F](1)).mapN { (readSemaphore, writeSemaphore) =>
+      new AsyncSocket[F](ch, readSemaphore, writeSemaphore)
+    }
 
   private final class AsyncSocket[F[_]](
       ch: AsynchronousSocketChannel,

--- a/io/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -118,7 +118,7 @@ class TLSSocketSuite extends TLSSuite {
         (serverAddress, server) = addressAndConnections
         client <- Network[IO].client(serverAddress).flatMap(tlsContext.client(_))
       } yield {
-        val tlsServer = server.flatMap { shared => 
+        val tlsServer = server.flatMap { shared =>
           Stream.resource(shared.resource.flatMap(tlsContext.server(_)))
         }
         tlsServer -> client

--- a/io/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -117,7 +117,12 @@ class TLSSocketSuite extends TLSSuite {
         addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))
         (serverAddress, server) = addressAndConnections
         client <- Network[IO].client(serverAddress).flatMap(tlsContext.client(_))
-      } yield server.flatMap(s => Stream.resource(tlsContext.server(s))) -> client
+      } yield {
+        val tlsServer = server.flatMap { shared => 
+          Stream.resource(shared.resource.flatMap(tlsContext.server(_)))
+        }
+        tlsServer -> client
+      }
 
       Stream
         .resource(setup)


### PR DESCRIPTION
Intends to fix #2289. Relevant Gitter conversation located here: https://gitter.im/functional-streams-for-scala/fs2?at=6035dec142f30f75c7c35746

So, the idea here is that the lifecycles of server sockets and client sockets have independent lifecycles, so it should be possible for us to finalize them separately. This was possible to do in 2.5.x because the `SocketGroup` server signature returned a `Stream[F, Resource[F, Socket[F]]]`, in conjunction with the `forking` combinator that was developed in Ember. Unfortunately, that method is leaky (what happens if you don't call `use` on the inner resource?), so the signature changed to `Stream[F, Socket[F]]`, where the sockets are actually bound to the server stream. `parJoin` is necessary here in order to lease the scope and prevent the socket from immediately finalizing, but this sneakily also leases the server socket, preventing that from finalizing until _all_ client sockets have finalized!

One solution to maintaining independent resource lifecycles while preserving safety is to implement a data structure called `Shared` that can facilitate the transfer of ownership of resources, which is captured in this PR. A client socket can be allocated on the server stream into a shared resource and handed off to the client stream which will acquire the resource. After that, the server socket can release the resource before moving onto accepting the next socket (this won't actually happen when using `parJoin` because of leasing).

I think the `forking` function is going to have change a bit; it'll have to operate on a `Stream[F, Stream[F, Shared[F, O]]]` because we need to ensure that the shared socket is acquired _before_ control is returned to the accept stream. If it doesn't, the accepted socket is going to be immediately finalized after return. See: https://github.com/http4s/http4s/blob/main/ember-server/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala#L71 . In comparison to `parJoin`, `forking` replaces the notion of implicit scope leasing with the notion of explicit resource transfer. 

Notes:
1. The current `server` signatures are completely safe when used with `parJoin`, but I think we can even just revert them to their previous versions, and add a separate signature that exposes `Shared`.
2. I'm wondering if we should try to include a (safer) variant of `forking` in fs2 that people can use to exercise the graceful shutdown behavior
3. Need to look at fs2-netty to see how this plays out there