### PR TITLE
Fix resource leak with bracketFull, interruption, and no polling

### DIFF
--- a/core/shared/src/main/scala/fs2/Compiler.scala
+++ b/core/shared/src/main/scala/fs2/Compiler.scala
@@ -140,6 +140,7 @@ object Compiler extends CompilerLowPriority {
         foldChunk: (Out, Chunk[O]) => Out
     ): F[Out]
     private[fs2] def uncancelable[A](poll: Poll[F] => F[A]): F[A]
+    private[fs2] def onCancel[A](fa: F[A], fin: F[Unit]): F[A]
     private[fs2] def interruptContext(root: Unique.Token): Option[F[InterruptContext[F]]]
   }
 
@@ -156,6 +157,7 @@ object Compiler extends CompilerLowPriority {
     protected abstract class MonadCancelTarget[F[_]](implicit F: MonadCancelThrow[F])
         extends MonadErrorTarget[F]()(F) {
       private[fs2] def uncancelable[A](f: Poll[F] => F[A]): F[A] = F.uncancelable(f)
+      private[fs2] def onCancel[A](fa: F[A], fin: F[Unit]): F[A] = F.onCancel(fa, fin)
       private[fs2] def compile[O, Out](
           p: Pull[F, O, Unit],
           init: Out,

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -157,13 +157,14 @@ object Pull extends PullLowPriority {
       resource: Poll[F] => F[R],
       release: (R, ExitCase) => F[Unit]
   )(implicit F: MonadCancel[F, _]): Pull[F, INothing, R] =
-    Acquire((store: R => Unit) =>
-      F.uncancelable { poll =>
-        resource(poll).map { r =>
-          store(r)
-          r
-        }
-      },
+    Acquire(
+      (store: R => Unit) =>
+        F.uncancelable { poll =>
+          resource(poll).map { r =>
+            store(r)
+            r
+          }
+        },
       release,
       cancelable = true
     )
@@ -844,8 +845,7 @@ object Pull extends PullLowPriority {
           view: Cont[Unit, G, X]
       ): F[End] = {
         val onScope = scope.acquireResource(
-          (_: Poll[F], (_: Fiber[F, Throwable, Unit] => Unit)) =>
-             scope.interruptWhen(haltOnSignal),
+          (_: Poll[F], (_: Fiber[F, Throwable, Unit] => Unit)) => scope.interruptWhen(haltOnSignal),
           (f: Fiber[F, Throwable, Unit], _: ExitCase) => f.cancel
         )
         val cont = onScope.flatMap { outcome =>

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -845,7 +845,7 @@ object Pull extends PullLowPriority {
           view: Cont[Unit, G, X]
       ): F[End] = {
         val onScope = scope.acquireResource(
-          (_: Poll[F], (_: Fiber[F, Throwable, Unit] => Unit)) => scope.interruptWhen(haltOnSignal),
+          (_: Poll[F], _: (Fiber[F, Throwable, Unit] => Unit)) => scope.interruptWhen(haltOnSignal),
           (f: Fiber[F, Throwable, Unit], _: ExitCase) => f.cancel
         )
         val cont = onScope.flatMap { outcome =>

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -151,13 +151,22 @@ object Pull extends PullLowPriority {
       resource: F[R],
       release: (R, ExitCase) => F[Unit]
   ): Pull[F, INothing, R] =
-    Acquire(resource, release, cancelable = false)
+    Acquire((_: R => Unit) => resource, release, cancelable = false)
 
   private[fs2] def acquireCancelable[F[_], R](
       resource: Poll[F] => F[R],
       release: (R, ExitCase) => F[Unit]
   )(implicit F: MonadCancel[F, _]): Pull[F, INothing, R] =
-    Acquire(F.uncancelable(resource), release, cancelable = true)
+    Acquire((store: R => Unit) =>
+      F.uncancelable { poll =>
+        resource(poll).map { r =>
+          store(r)
+          r
+        }
+      },
+      release,
+      cancelable = true
+    )
 
   /** Like [[eval]] but if the effectful value fails, the exception is returned in a `Left`
     * instead of failing the pull.
@@ -525,7 +534,7 @@ object Pull extends PullLowPriority {
   private final case class Eval[+F[_], R](value: F[R]) extends AlgEffect[F, R]
 
   private final case class Acquire[F[_], R](
-      resource: F[R],
+      resource: (R => Unit) => F[R],
       release: (R, ExitCase) => F[Unit],
       cancelable: Boolean
   ) extends AlgEffect[F, R]
@@ -812,9 +821,9 @@ object Pull extends PullLowPriority {
 
       def goAcquire[R](acquire: Acquire[G, R], view: Cont[R, G, X]): F[End] = {
         val onScope = scope.acquireResource[R](
-          poll =>
-            if (acquire.cancelable) poll(translation(acquire.resource))
-            else translation(acquire.resource),
+          (poll, store) =>
+            if (acquire.cancelable) poll(translation(acquire.resource(store)))
+            else translation(acquire.resource(_ => ())),
           (resource, exit) => translation(acquire.release(resource, exit))
         )
 
@@ -835,7 +844,8 @@ object Pull extends PullLowPriority {
           view: Cont[Unit, G, X]
       ): F[End] = {
         val onScope = scope.acquireResource(
-          _ => scope.interruptWhen(haltOnSignal),
+          (_: Poll[F], (_: Fiber[F, Throwable, Unit] => Unit)) =>
+             scope.interruptWhen(haltOnSignal),
           (f: Fiber[F, Throwable, Unit], _: ExitCase) => f.cancel
         )
         val cont = onScope.flatMap { outcome =>

--- a/core/shared/src/main/scala/fs2/internal/Scope.scala
+++ b/core/shared/src/main/scala/fs2/internal/Scope.scala
@@ -198,23 +198,20 @@ private[fs2] final class Scope[F[_]] private (
           // F ~> G and G ~> F
           @volatile var res: Option[R] = None
 
-         F.onCancel(
-            acquire(poll, (r: R) =>
-              res = r.some
-            ),
-           F.unit.flatMap { _ =>
-             res match {
-               case None => F.unit
-               // TODO
-               // which exit case is the correct one here? canceled or
-               // succeeded? current test says canceled, and the
-               // overall op is canceled, but the op whose release
-               // we're running did complete
-               case Some(r) => release(r, Resource.ExitCase.Canceled)
-             }
-           }
-         )
-          .redeemWith(
+          F.onCancel(
+            acquire(poll, (r: R) => res = r.some),
+            F.unit.flatMap { _ =>
+              res match {
+                case None => F.unit
+                // TODO
+                // which exit case is the correct one here? canceled or
+                // succeeded? current test says canceled, and the
+                // overall op is canceled, but the op whose release
+                // we're running did complete
+                case Some(r) => release(r, Resource.ExitCase.Canceled)
+              }
+            }
+          ).redeemWith(
             t => F.pure(Left(t)),
             r => {
               val finalizer = (ec: Resource.ExitCase) => release(r, ec)


### PR DESCRIPTION
See here for a (long) conversation:
https://gitter.im/functional-streams-for-scala/fs2-dev?at=60392cf8d74bbe49e0bdfa49