### PR TITLE
Stream - Rewrite some concurrent methods.

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -655,7 +655,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
 
       def go(tl: Pull[F2, O, Unit]): Pull[F2, INothing, Unit] =
         Pull.uncons(tl).flatMap {
-          // Note: hd is non-empty, so hd.last.get is sage
+          // Note: hd is non-empty, so hd.last.get is safe
           case Some((hd, tl)) => Pull.eval(enqueueItem(hd.last.get)) >> go(tl)
           case None           => Pull.eval(enqueueLatest >> queue.offer(None))
         }


### PR DESCRIPTION
List of several changes to improve code readability.

- Concurrently: extract inner `watch` method, and rename some vairables.
- Format some scaladocs, to keep on the 80 flexible line.
- InterruptWhen: use a `Stream.force` form, without the  `Stream.eval` operations. Use some variables.
- observeAsync: use the `Stream.force` form, and make some use of recursive pull functions for the sinkers.