### PR TITLE
Stream replace evidence & asInstanceOf to implicit class

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2603,11 +2603,6 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       }
     }
 
-  /** Converts a `Stream[F, Nothing]` to a `Stream[F, Unit]` which emits a single `()` after this stream completes.
-    */
-  def unitary(implicit ev: O <:< Nothing): Stream[F, Unit] =
-    this.asInstanceOf[Stream[F, Nothing]] ++ Stream.emit(())
-
   /** Alias for [[filter]]
     * Implemented to enable filtering in for comprehensions
     */
@@ -3712,8 +3707,16 @@ object Stream extends StreamLowPriority {
       Pull.loop(f.andThen(_.map(_.map(_.pull))))(pull).stream
   }
 
+  implicit final class NothingStreamOps[F[_]](private val self: Stream[F, Nothing]) extends AnyVal {
+
+    /** Converts a `Stream[F, Nothing]` to a `Stream[F, Unit]` which emits a single `()` after this stream completes.
+      */
+    def unitary: Stream[F, Unit] =
+      self ++ Stream.emit(())
+  }
+  
   implicit final class StringStreamOps[F[_]](private val self: Stream[F, String]) extends AnyVal {
-    
+
     /** Writes this stream of strings to the supplied `PrintStream`, emitting a unit
       * for each line that was written.
       */

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3714,7 +3714,7 @@ object Stream extends StreamLowPriority {
     def unitary: Stream[F, Unit] =
       self ++ Stream.emit(())
   }
-  
+
   implicit final class StringStreamOps[F[_]](private val self: Stream[F, String]) extends AnyVal {
 
     /** Writes this stream of strings to the supplied `PrintStream`, emitting a unit
@@ -3726,7 +3726,8 @@ object Stream extends StreamLowPriority {
       self.foreach(str => F.blocking(out.println(str)))
   }
 
-  implicit final class OptionStreamOps[F[_], O](private val self: Stream[F, Option[O]]) extends AnyVal {
+  implicit final class OptionStreamOps[F[_], O](private val self: Stream[F, Option[O]])
+      extends AnyVal {
 
     /** Filters any 'None'.
       *
@@ -4680,8 +4681,6 @@ object Stream extends StreamLowPriority {
       lhs(left).stream.mergeHaltBoth(rhs(right).stream)
     }
   }
-
-
 
   /** Provides operations on effectful pipes for syntactic convenience. */
   implicit final class PipeOps[F[_], I, O](private val self: Pipe[F, I, O]) extends AnyVal {


### PR DESCRIPTION
extensions are placed in companion object, thus no imports should be required