### PR TITLE
sliding2

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2479,6 +2479,22 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     resultPull.stream
   }
 
+  /** Groups inputs in Tuple2. If the input contains less than 2 elements
+    * no elements will be emitted.
+    *
+    * @example {{{
+    * scala> Stream(1, 2, 3, 4).sliding2.toList
+    * res0: List[(Int, Int)] = List((1,2), (2,3), (3,4))
+    * scala> Stream(1).sliding2.toList
+    * res1: List[(Int, Int)] = List()
+    * }}}
+    * @throws scala.IllegalArgumentException if `n` <= 0
+    */
+  def sliding2: Stream[F, (O, O)] =
+    sliding(2).collect {
+      case chunk if chunk.size == 2 => (chunk(0), chunk(1))
+    }
+
   /** Starts this stream and cancels it as finalization of the returned stream.
     */
   def spawn[F2[x] >: F[x]: Concurrent]: Stream[F2, Fiber[F2, Throwable, Unit]] =


### PR DESCRIPTION
Imagine we want to count amount of sign inversions in `val list = List(1,-1,-1,1)`
In this scenario I prefer to use `zip(self.tail)` over `sliding(2)`, because it is more convenient to match on tuples than variable sized collections, `list.zip(list.tail).count((prev, next) => prev < 0 xor next < 0)`.
Inasmuch as side effects `zip` on streams has a different meaning.