### PR TITLE
Fix for interruption skipping error handlers in certain cases

### DIFF
--- a/core/shared/src/test/scala/fs2/StreamConcurrentlySuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamConcurrentlySuite.scala
@@ -149,4 +149,24 @@ class StreamConcurrentlySuite extends Fs2Suite {
     }
   }
 
+  test("bug 2197".only) {
+    val iterations = 1000
+    Stream
+      .eval((IO.deferred[Unit], IO.ref[Int](0)).tupled)
+      .flatMap { case (done, innerErrorCountRef) =>
+        def handled: IO[Unit] =
+          innerErrorCountRef.modify { old => 
+            (old + 1, if (old < iterations) IO.unit else done.complete(()).void)
+          }.flatten
+        Stream(Stream(()) ++ Stream.raiseError[IO](new Err)).repeat.flatMap { fg =>
+          fg.prefetch.handleErrorWith(_ => Stream.eval(handled)).flatMap(_ => Stream.empty)
+        }
+        .interruptWhen(done.get.attempt)
+        .handleErrorWith(_ => Stream.empty)
+        .drain ++ Stream.eval(innerErrorCountRef.get)
+      }
+      .compile
+      .lastOrError
+      .map(cnt => assert(cnt >= iterations, s"cnt: $cnt, iterations: $iterations"))
+  }
 }

--- a/core/shared/src/test/scala/fs2/StreamConcurrentlySuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamConcurrentlySuite.scala
@@ -149,21 +149,22 @@ class StreamConcurrentlySuite extends Fs2Suite {
     }
   }
 
-  test("bug 2197".only) {
+  test("bug 2197") {
     val iterations = 1000
     Stream
       .eval((IO.deferred[Unit], IO.ref[Int](0)).tupled)
       .flatMap { case (done, innerErrorCountRef) =>
         def handled: IO[Unit] =
-          innerErrorCountRef.modify { old => 
+          innerErrorCountRef.modify { old =>
             (old + 1, if (old < iterations) IO.unit else done.complete(()).void)
           }.flatten
-        Stream(Stream(()) ++ Stream.raiseError[IO](new Err)).repeat.flatMap { fg =>
-          fg.prefetch.handleErrorWith(_ => Stream.eval(handled)).flatMap(_ => Stream.empty)
-        }
-        .interruptWhen(done.get.attempt)
-        .handleErrorWith(_ => Stream.empty)
-        .drain ++ Stream.eval(innerErrorCountRef.get)
+        Stream(Stream(()) ++ Stream.raiseError[IO](new Err)).repeat
+          .flatMap { fg =>
+            fg.prefetch.handleErrorWith(_ => Stream.eval(handled)).flatMap(_ => Stream.empty)
+          }
+          .interruptWhen(done.get.attempt)
+          .handleErrorWith(_ => Stream.empty)
+          .drain ++ Stream.eval(innerErrorCountRef.get)
       }
       .compile
       .lastOrError


### PR DESCRIPTION
Fixes #2197

Based on the analysis from @RaasAhsan. All tests pass with this change and while it feels pretty adhoc, I think we should fix this in the simplest way possible and then look at revamping stream interruption in general later.