### PR TITLE
Fix two links in site and update site building instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ To see how to build the microsite, check [here][fs2-build-site].
 [fs2-issues]: https://github.com/functional-streams-for-scala/fs2/issues
 [fs2-pulls]: https://github.com/functional-streams-for-scala/fs2/pulls
 [fs2-dev]: https://gitter.im/functional-streams-for-scala/fs2-dev
-[fs2-build-site]: https://github.com/LLCampos/fs2/blob/main/build-site.md
+[fs2-build-site]: https://github.com/functional-streams-for-scala/fs2/blob/main/build-site.md
 [coc]: https://github.com/functional-streams-for-scala/fs2/blob/main/CODE_OF_CONDUCT.md
 [sbt]: https://www.scala-sbt.org
 [mima]: https://github.com/lightbend/mima

--- a/build-site.md
+++ b/build-site.md
@@ -31,7 +31,7 @@ sbt microsite/mdoc --watch
 and docsify in a shell session:
 
 ```
-docsify serve fs2/target/website/
+docsify serve target/website/
 ```
 
 and you'll get an updating preview.

--- a/site/concurrency-primitives.md
+++ b/site/concurrency-primitives.md
@@ -76,7 +76,7 @@ These data structures could be very handy in more complex cases. See below examp
 
 ### FIFO (First IN / First OUT)
 
-A typical use case of a `fs2.concurrent.Queue[F, A]`, also quite useful to communicate with the external world as shown in the [guide](guide.html#talking-to-the-external-world).
+A typical use case of a `fs2.concurrent.Queue[F, A]`, also quite useful to communicate with the external world as shown in the [guide](guide.md#talking-to-the-external-world).
 
 q1 has a buffer size of 1 while q2 has a buffer size of 100 so you will notice the buffering when  pulling elements out of the q2.
 

--- a/site/guide.md
+++ b/site/guide.md
@@ -395,7 +395,7 @@ It flattens the nested stream, letting up to `maxOpen` inner streams run at a ti
 
 The `Concurrent` bound on `F` is required anywhere concurrency is used in the library. As mentioned earlier, users can bring their own effect types provided they also supply an `Concurrent` instance in implicit scope.
 
-In addition, there are a number of other concurrency primitives---asynchronous queues, signals, and semaphores. See the [Concurrency Primitives section](concurrency-primitives.html) for more examples. We'll make use of some of these in the next section when discussing how to talk to the external world.
+In addition, there are a number of other concurrency primitives---asynchronous queues, signals, and semaphores. See the [Concurrency Primitives section](concurrency-primitives.md#concurrency-primitives) for more examples. We'll make use of some of these in the next section when discussing how to talk to the external world.
 
 ### Exercises Concurrency
 


### PR DESCRIPTION
Hello, while browsing docs I noticed two links which currently shows `404 - Not found`.
- In 'Guide' page 'Concurrency' section link leading to 'Concurrency Primitives'
- In 'Concurrency Primitives' page FIFO example linke leading to 'Guide' page 'Talking to the external world' section

Additionally two changes I made while following docs for building site.
- Link to build-site.md now links to main repo instead of fork
- Changed docsify command to not include `fs2/` (when I followed commands I expected that they are executed from root of directory unless specified otherwise and got confused a bit when it didn't work)