### PR TITLE
Fix Memory Leak detected on GroupWithin Benchmark.

### DIFF
--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -121,6 +121,13 @@ class MemoryLeakSpec extends FunSuite {
       .groupWithin(Int.MaxValue, 1.millis)
   }
 
+  leakTest("groupWithin --- Issue 2328") {
+    Stream
+      .range(0, 1_000_000)
+      .covary[IO]
+      .groupWithin(256, 1.second)
+  }
+
   leakTest("topic continuous publish") {
     Stream
       .eval(Topic[IO, Int])


### PR DESCRIPTION
Recently, Dmitry Golubets submitted a benchmark for the `groupWithin` stream operation, in #2328. That benchmark tapped into a memory leak that was introduced when the `CallRun` middle step was modified.

Reintroducing it in this PR seems to solve the leak.