### PR TITLE
Remove some uses of Sync constraint, fixes #2338

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3306,7 +3306,7 @@ object Stream extends StreamLowPriority {
     * }}}
     */
   def range[F[x] >: Pure[x], O: Numeric](start: O, stopExclusive: O): Stream[F, O] =
-    range(start, stopExclusive, Numeric[O].one)
+    range(start, stopExclusive, implicitly[Numeric[O]].one)
 
   /** Lazily produce the sequence `[start, start + step, start + 2 * step, ..., stopExclusive)`.
     * If you want to produce the sequence in one chunk, instead of lazily, use
@@ -3320,7 +3320,7 @@ object Stream extends StreamLowPriority {
   def range[F[x] >: Pure[x], O: Numeric](start: O, stopExclusive: O, step: O): Stream[F, O] = {
     import Numeric.Implicits._
     import Ordering.Implicits._
-    val zero = Numeric[O].zero
+    val zero = implicitly[Numeric[O]].zero
     def go(o: O): Stream[F, O] =
       if (
         (step > zero && o < stopExclusive && start < stopExclusive) ||

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -30,7 +30,7 @@ import cats.data.Ior
 import cats.effect.SyncIO
 import cats.effect.kernel._
 import cats.effect.kernel.implicits._
-import cats.effect.std.{Console, Queue, Random, Semaphore}
+import cats.effect.std.{Console, Queue, Semaphore}
 import cats.effect.Resource.ExitCase
 import cats.syntax.all._
 

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2061,7 +2061,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       F: Console[F2],
       showO: Show[O2] = Show.fromToString[O2]
   ): Stream[F2, INothing] =
-    foreach( (o: O2) => F.println(o.show))
+    foreach((o: O2) => F.println(o.show))
 
   /** Rechunks the stream such that output chunks are within `[inputChunk.size * minFactor, inputChunk.size * maxFactor]`.
     * The pseudo random generator is deterministic based on the supplied seed.

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2061,7 +2061,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       F: Console[F2],
       showO: Show[O2] = Show.fromToString[O2]
   ): Stream[F2, INothing] =
-    covaryAll[F2, O2].map(_.show).foreach(F.println)
+    foreach( (o: O2) => F.println(o.show))
 
   /** Rechunks the stream such that output chunks are within `[inputChunk.size * minFactor, inputChunk.size * maxFactor]`.
     * The pseudo random generator is deterministic based on the supplied seed.

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -1104,21 +1104,6 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
   }
 
-  test("random") {
-    val x = Random.scalaUtilRandom[SyncIO].flatMap { implicit r =>
-      Stream.random[SyncIO].take(100).compile.toList
-    }
-    (x, x).tupled.map { case (first, second) =>
-      assertNotEquals(first, second)
-    }
-  }
-
-  test("randomSeeded") {
-    val x = Stream.randomSeeded(1L).take(100).toList
-    val y = Stream.randomSeeded(1L).take(100).toList
-    assertEquals(x, y)
-  }
-
   test("range") {
     assertEquals(Stream.range(0, 100).toList, List.range(0, 100))
     assertEquals(Stream.range(0, 1).toList, List.range(0, 1))

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -33,6 +33,7 @@ import org.scalacheck.Prop.forAll
 import org.scalacheck.effect.PropF.forAllF
 
 import fs2.concurrent.SignallingRef
+import cats.effect.std.Random
 
 class StreamCombinatorsSuite extends Fs2Suite {
 
@@ -1104,7 +1105,9 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   test("random") {
-    val x = Stream.random[SyncIO].take(100).compile.toList
+    val x = Random.scalaUtilRandom[SyncIO].flatMap { implicit r =>
+      Stream.random[SyncIO].take(100).compile.toList
+    }
     (x, x).tupled.map { case (first, second) =>
       assertNotEquals(first, second)
     }


### PR DESCRIPTION
This PR removes `lines`, `showLines`, and `showLinesStdOut` and replaces them with `printlns`.

`Stream.random` was also updated to use `cats.effect.std.Random`.

The only uses of `Sync` constraints left are:
1) Creating a stream from an interator
2) Compression package

Thoughts on updating compression package to use a capability trait?