### PR TITLE
FS2-Core: use lower dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,9 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-core" % "2.4.2",
       "org.typelevel" %%% "cats-laws" % "2.4.2" % Test,
-      "org.typelevel" %%% "cats-effect" % "3.0.0-RC3",
+      "org.typelevel" %%% "cats-effect-kernel" % "3.0.0-RC3",
+      "org.typelevel" %%% "cats-effect-std" % "3.0.0-RC3",
+      "org.typelevel" %%% "cats-effect" % "3.0.0-RC3" % Test,
       "org.typelevel" %%% "cats-effect-laws" % "3.0.0-RC3" % Test,
       "org.typelevel" %%% "cats-effect-testkit" % "3.0.0-RC3" % Test,
       "org.scodec" %%% "scodec-bits" % "1.1.24",

--- a/core/shared/src/main/scala/fs2/Compiler.scala
+++ b/core/shared/src/main/scala/fs2/Compiler.scala
@@ -22,7 +22,7 @@
 package fs2
 
 import cats.{Id, Monad, MonadError}
-import cats.effect.SyncIO
+//import cats.effect.SyncIO
 import cats.effect.kernel.{Concurrent, MonadCancelThrow, Poll, Ref, Resource, Sync, Unique}
 import cats.syntax.all._
 

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -27,11 +27,10 @@ import scala.concurrent.duration._
 
 import cats.{Eval => _, _}
 import cats.data.Ior
-import cats.effect.SyncIO
 import cats.effect.kernel._
 import cats.effect.kernel.implicits._
+import cats.effect.kernel.Resource.ExitCase
 import cats.effect.std.{Console, Queue, Semaphore}
-import cats.effect.Resource.ExitCase
 import cats.syntax.all._
 
 import fs2.compat._


### PR DESCRIPTION
Since cats has split into modules, and we do not always use IO, we can instead depend on the Kernel (for typeclasses) and std (for the semaphores and refs)