### PR TITLE
Fix Issue 2362 - bug in InterruptAfter

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1621,7 +1621,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   def interruptWhen[F2[x] >: F[x]](
       haltOnSignal: F2[Either[Throwable, Unit]]
   ): Stream[F2, O] =
-    (Pull.interruptWhen(haltOnSignal) >> this.pull.echo).stream.interruptScope
+    (Pull.interruptWhen(haltOnSignal) >> this.pull.echo).streamNoScope.interruptScope
 
   /** Creates a scope that may be interrupted by calling scope#interrupt.
     */


### PR DESCRIPTION
This change, to replace a `.stream` by a `.streamNoScope`, seems to fix Issue 2362. 

_Note_ This was the result of a quick look and first lucky try, but I am not quite fully able, at present, to explain why it fixes it. I can guess that, by not introducing the two scopes, the exception or interruption was not hold on the first inner scope. However, this may be wrong and introduce problems elsewhere.