### PR TITLE
Improve empty broadcastThrough error message

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -222,7 +222,8 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     */
   def broadcastThrough[F2[x] >: F[x]: Concurrent, O2](
       pipes: Pipe[F2, O, O2]*
-  ): Stream[F2, O2] =
+  ): Stream[F2, O2] = {
+    assert(pipes.nonEmpty, s"pipes should not be empty")
     Stream
       .eval {
         (
@@ -250,6 +251,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
           .parJoinUnbounded
           .concurrently(Stream.eval(latch.await) ++ produce)
       }
+  }
 
   /** Behaves like the identity function, but requests `n` elements at a time from the input.
     *

--- a/core/shared/src/test/scala/fs2/concurrent/BroadcastSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/BroadcastSuite.scala
@@ -81,4 +81,10 @@ class BroadcastSuite extends Fs2Suite {
         }
     }
   }
+
+  test("pipes should not be empty") {
+    interceptMessage[AssertionError]("assertion failed: pipes should not be empty")(
+      Stream.empty.broadcastThrough[IO, INothing]()
+    )
+  }
 }


### PR DESCRIPTION
As discussed on Gitter. I'm still not sure if an error is better than `.drain`, but at least this way the behaviour is explicit and gives a clearer error.