### PR TITLE
Resurrect SubscriberStabilitySpec

### DIFF
--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/SubscriberStabilitySpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/SubscriberStabilitySpec.scala
@@ -19,115 +19,72 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// package fs2
-// package interop
-// package reactivestreams
+package fs2
+package interop
+package reactivestreams
 
-// import cats.effect._
-// import cats.implicits._
+import cats.effect._
+import cats.effect.std.Random
+import org.reactivestreams._
 
-// import java.nio.ByteBuffer
-// import org.reactivestreams._
+import scala.concurrent.duration._
 
-// import scala.concurrent.duration._
+import java.nio.ByteBuffer
 
-// TODO Port to CE3
-// class SubscriberStabilitySpec extends Fs2Suite {
-//   test("StreamSubscriber has no race condition") {
-//     val io = ConcurrentEffect[IO]
-//     val testConcurrentEffect: ConcurrentEffect[IO] = new ConcurrentEffect[IO] {
-//       private val rnd = new scala.util.Random()
+class SubscriberStabilitySpec extends Fs2Suite {
+  test("StreamSubscriber has no race condition") {
+    val publisher = new Publisher[ByteBuffer] {
 
-//       private val randomDelay: IO[Unit] =
-//         for {
-//           ms <- IO.delay(rnd.nextInt(50))
-//           _ <- Timer[IO].sleep(ms.millis)
-//         } yield ()
+      class SubscriptionImpl(val s: Subscriber[_ >: ByteBuffer]) extends Subscription {
+        override def request(n: Long): Unit = {
+          s.onNext(ByteBuffer.wrap(new Array[Byte](1)))
+          s.onComplete()
+        }
 
-//       // Injecting random delay
-//       override def runCancelable[A](fa: IO[A])(
-//           cb: Either[Throwable, A] => IO[Unit]
-//       ): SyncIO[CancelToken[IO]] =
-//         io.runCancelable(randomDelay *> fa)(cb)
+        override def cancel(): Unit = {}
+      }
 
-//       // Injecting random delay
-//       override def runAsync[A](fa: IO[A])(
-//           cb: scala.util.Either[Throwable, A] => IO[Unit]
-//       ): SyncIO[Unit] =
-//         io.runAsync(randomDelay *> fa)(cb)
+      override def subscribe(s: Subscriber[_ >: ByteBuffer]): Unit =
+        s.onSubscribe(new SubscriptionImpl(s))
+    }
 
-//       // All the other methods just delegating to io
-//       def pure[A](x: A): IO[A] = io.pure(x)
-//       def handleErrorWith[A](fa: IO[A])(
-//           f: Throwable => IO[A]
-//       ): IO[A] = io.handleErrorWith(fa)(f)
-//       def raiseError[A](e: Throwable): IO[A] = io.raiseError(e)
-//       def async[A](k: (scala.util.Either[Throwable, A] => Unit) => Unit): IO[A] =
-//         io.async(k)
-//       def asyncF[A](
-//           k: (scala.util.Either[Throwable, A] => Unit) => IO[Unit]
-//       ): IO[A] = io.asyncF(k)
-//       def bracketCase[A, B](acquire: IO[A])(use: A => IO[B])(
-//           release: (A, ExitCase[Throwable]) => IO[Unit]
-//       ): IO[B] =
-//         io.bracketCase(acquire)(use)(release)
-//       def racePair[A, B](
-//           fa: IO[A],
-//           fb: IO[B]
-//       ): IO[scala.util.Either[
-//         (A, Fiber[IO, B]),
-//         (Fiber[IO, A], B)
-//       ]] =
-//         io.racePair(fa, fb)
-//       def start[A](fa: IO[A]): IO[Fiber[IO, A]] =
-//         io.start(fa)
-//       def flatMap[A, B](fa: IO[A])(f: A => IO[B]): IO[B] =
-//         io.flatMap(fa)(f)
-//       def tailRecM[A, B](a: A)(f: A => IO[Either[A, B]]): IO[B] =
-//         io.tailRecM(a)(f)
-//       def suspend[A](thunk: => IO[A]): IO[A] =
-//         io.suspend(thunk)
-//     }
+    def randomDelay(rnd: Random[IO]): IO[Unit] =
+      for {
+        ms <- rnd.nextIntBounded(50)
+        _ <- IO.sleep(ms.millis)
+      } yield ()
 
-//     val publisher = new Publisher[ByteBuffer] {
+    val randomStream = Stream.eval(Random.scalaUtilRandom[IO]).flatMap { rnd =>
+      Stream.repeatEval(randomDelay(rnd))
+    }
 
-//       class SubscriptionImpl(val s: Subscriber[_ >: ByteBuffer]) extends Subscription {
-//         override def request(n: Long): Unit = {
-//           s.onNext(ByteBuffer.wrap(new Array[Byte](1)))
-//           s.onComplete()
-//         }
+    val stream = fromPublisher[IO, ByteBuffer](publisher)
+      .map(Left(_))
+      .interleave(randomStream.map(Right(_)))
+      .collect { case Left(buf) => buf }
 
-//         override def cancel(): Unit = {}
-//       }
+    val N = 100
+    @volatile var failed: Boolean = false
+    Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler {
+      def uncaughtException(thread: Thread, error: Throwable): Unit =
+        failed = true
+    })
 
-//       override def subscribe(s: Subscriber[_ >: ByteBuffer]): Unit =
-//         s.onSubscribe(new SubscriptionImpl(s))
-//     }
+    def loop(remaining: Int): IO[Unit] =
+      IO.delay(failed).flatMap { alreadyFailed =>
+        if (!alreadyFailed) {
+          val f = stream.compile.drain
+          if (remaining > 0)
+            f *> loop(remaining - 1)
+          else
+            f
+        } else
+          IO.unit
+      }
 
-//     val stream = fromPublisher(publisher)(testConcurrentEffect)
+    loop(N).unsafeRunSync()
 
-//     val N = 100
-//     @volatile var failed: Boolean = false
-//     Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler {
-//       def uncaughtException(thread: Thread, error: Throwable): Unit =
-//         failed = true
-//     })
-
-//     def loop(remaining: Int): IO[Unit] =
-//       IO.delay(failed).flatMap { alreadyFailed =>
-//         if (!alreadyFailed) {
-//           val f = stream.compile.drain
-//           if (remaining > 0)
-//             f *> loop(remaining - 1)
-//           else
-//             f
-//         } else
-//           IO.unit
-//       }
-
-//     loop(N).unsafeRunSync()
-
-//     if (failed)
-//       fail("Uncaught exception was reported")
-//   }
-// }
+    if (failed)
+      fail("Uncaught exception was reported")
+  }
+}


### PR DESCRIPTION
Resolves #2084.

Since `Dispatcher` is not mockable, is this a suitable reimplementation of this test? Thanks.

Blocked on #2373.