### PR TITLE
Compile fs2 on all supported Scala versions without warnings

### DIFF
--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -1,5 +1,6 @@
 package fs2
 
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 
 import java.lang.management.ManagementFactory
@@ -13,6 +14,7 @@ import munit.{FunSuite, TestOptions}
 
 import fs2.concurrent._
 
+@nowarn("cat=w-flag-dead-code")
 class MemoryLeakSpec extends FunSuite {
 
   override def munitFlakyOK = true

--- a/core/jvm/src/main/scala/fs2/compression/Compression.scala
+++ b/core/jvm/src/main/scala/fs2/compression/Compression.scala
@@ -779,7 +779,7 @@ object Compression {
     ): Stream[F, Byte] => Stream[F, (Option[String], Stream[F, Byte])] =
       stream =>
         if (isPresent)
-          unconsUntil[F, Byte](_ == zeroByte, fieldBytesSoftLimit)
+          unconsUntil[Byte](_ == zeroByte, fieldBytesSoftLimit)
             .apply(stream)
             .flatMap {
               case Some((chunk, rest)) =>
@@ -896,7 +896,7 @@ object Compression {
       *
       * `Pull.pure(None)` is returned if the end of the source stream is reached.
       */
-    private def unconsUntil[F[_], O: ClassTag](
+    private def unconsUntil[O: ClassTag](
         predicate: O => Boolean,
         softLimit: Int
     ): Stream[F, O] => Pull[F, INothing, Option[(Chunk[O], Stream[F, O])]] =

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -320,8 +320,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] { self =>
     }
 
   /** Converts this chunk to a `java.nio.ByteBuffer`. */
-  def toByteBuffer[B >: O](implicit ev: B =:= Byte): JByteBuffer = {
-    val _ = ev // Convince scalac that ev is used
+  def toByteBuffer[B >: O](implicit ev: B =:= Byte): JByteBuffer =
     this match {
       case c: Chunk.ArraySlice[_] if c.values.isInstanceOf[Array[Byte]] =>
         JByteBuffer.wrap(c.values.asInstanceOf[Array[Byte]], c.offset, c.length)
@@ -336,7 +335,6 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] { self =>
       case _ =>
         JByteBuffer.wrap(this.asInstanceOf[Chunk[Byte]].toArray, 0, size)
     }
-  }
 
   /** Converts this chunk to a NonEmptyList */
   def toNel: Option[NonEmptyList[O]] =
@@ -375,22 +373,18 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] { self =>
     }
 
   /** Converts this chunk to a scodec-bits ByteVector. */
-  def toByteVector[B >: O](implicit ev: B =:= Byte): ByteVector = {
-    val _ = ev // convince scalac that ev is used
+  def toByteVector[B >: O](implicit ev: B =:= Byte): ByteVector =
     this match {
       case c: Chunk.ByteVectorChunk => c.toByteVector
       case other                    => ByteVector.view(other.asInstanceOf[Chunk[Byte]].toArray)
     }
-  }
 
   /** Converts this chunk to a scodec-bits BitVector. */
-  def toBitVector[B >: O](implicit ev: B =:= Byte): BitVector = {
-    val _ = ev // convince scalac that ev is used
+  def toBitVector[B >: O](implicit ev: B =:= Byte): BitVector =
     this match {
       case c: Chunk.ByteVectorChunk => c.toByteVector.bits
       case other                    => BitVector.view(other.asInstanceOf[Chunk[Byte]].toArray)
     }
-  }
 
   def traverse[F[_], O2](f: O => F[O2])(implicit F: Applicative[F]): F[Chunk[O2]] =
     if (isEmpty) F.pure(Chunk.empty[O2])

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -328,7 +328,7 @@ object Pull extends PullLowPriority {
     * The `F` type must be explicitly provided (e.g., via `raiseError[IO]`
     * or `raiseError[Fallible]`).
     */
-  @nowarn("cat=unused")
+  @nowarn("cat=unused-params")
   def raiseError[F[_]: RaiseThrowable](err: Throwable): Pull[F, INothing, INothing] = Fail(err)
 
   /** Creates a pull that evaluates the supplied effect `fr`, emits no

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -819,10 +819,10 @@ object Pull extends PullLowPriority {
           case r: Terminal[_] => r.asInstanceOf[Terminal[Unit]]
           case v: View[K, C, x] =>
             val mstep: Pull[K, D, x] = (v.step: Action[K, C, x]) match {
-              case o: Output[C] =>
+              case o: Output[_] =>
                 try Output(o.values.map(fun))
                 catch { case NonFatal(t) => Fail(t) }
-              case t: Translate[l, k, C] => // k= K
+              case t: Translate[l, k, _] => // k= K
                 Translate[l, k, D](innerMapOutput[l, C, D](t.stream, fun), t.fk)
               case s: Uncons[k, _]    => s
               case s: StepLeg[k, _]   => s
@@ -1129,10 +1129,10 @@ object Pull extends PullLowPriority {
                 endRunner.out(output.values, scope, view(unit))
               )
 
-            case fmout: FlatMapOutput[g, z, X] => // y = Unit
+            case fmout: FlatMapOutput[g, z, _] => // y = Unit
               goFlatMapOut[z](fmout, view.asInstanceOf[View[g, X, Unit]])
 
-            case tst: Translate[h, g, X] => // y = Unit
+            case tst: Translate[h, g, _] => // y = Unit
               val composed: h ~> F = translation.asInstanceOf[g ~> F].compose[h](tst.fk)
 
               val translateRunner: Run[h, X, F[End]] = new Run[h, X, F[End]] {
@@ -1168,10 +1168,10 @@ object Pull extends PullLowPriority {
               val result = Succeeded(scope.asInstanceOf[y])
               go(scope, extendedTopLevelScope, translation, endRunner, view(result))
 
-            case mout: MapOutput[g, z, X] => goMapOutput[z](mout, view)
+            case mout: MapOutput[g, z, _] => goMapOutput[z](mout, view)
             case eval: Eval[G, r]         => goEval[r](eval, view)
             case acquire: Acquire[G, y]   => goAcquire(acquire, view)
-            case inScope: InScope[g, X]   => goInScope(inScope.stream, inScope.useInterruption, view)
+            case inScope: InScope[g, _]   => goInScope(inScope.stream, inScope.useInterruption, view)
             case int: InterruptWhen[g]    => goInterruptWhen(translation(int.haltOnSignal), view)
             case close: CloseScope        => goCloseScope(close, view)
           }

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -21,7 +21,7 @@
 
 package fs2
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
@@ -328,6 +328,7 @@ object Pull extends PullLowPriority {
     * The `F` type must be explicitly provided (e.g., via `raiseError[IO]`
     * or `raiseError[Fallible]`).
     */
+  @nowarn("cat=unused")
   def raiseError[F[_]: RaiseThrowable](err: Throwable): Pull[F, INothing, INothing] = Fail(err)
 
   /** Creates a pull that evaluates the supplied effect `fr`, emits no
@@ -956,7 +957,7 @@ object Pull extends PullLowPriority {
         def out(head: Chunk[Y], outScope: Scope[F], tail: Pull[G, Y, Unit]): F[End] = {
           val fmoc = unconsed(head, tail)
           val next = outView match {
-            case ev: EvalView[G, X] => fmoc
+            case _: EvalView[G, X] => fmoc
             case bv: BindView[G, X, Unit] =>
               val del = bv.b.asInstanceOf[Bind[G, X, Unit, Unit]].delegate
               new Bind[G, X, Unit, Unit](fmoc) {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -21,7 +21,7 @@
 
 package fs2
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
@@ -1121,12 +1121,11 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * res0: List[Int] = List(1, 2, 2, 3, 3, 3)
     * }}}
     */
+  @nowarn("cat=unused-params")
   def flatMap[F2[x] >: F[x], O2](
       f: O => Stream[F2, O2]
-  )(implicit ev: NotGiven[O <:< Nothing]): Stream[F2, O2] = {
-    val _ = ev
+  )(implicit ev: NotGiven[O <:< Nothing]): Stream[F2, O2] =
     new Stream(Pull.flatMapOutput[F, F2, O, O2](underlying, (o: O) => f(o).underlying))
-  }
 
   /** Alias for `flatMap(_ => s2)`. */
   def >>[F2[x] >: F[x], O2](
@@ -2252,8 +2251,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   def rethrow[F2[x] >: F[x], O2](implicit
       ev: O <:< Either[Throwable, O2],
       rt: RaiseThrowable[F2]
-  ): Stream[F2, O2] = {
-    val _ = ev // Convince scalac that ev is used
+  ): Stream[F2, O2] =
     this.asInstanceOf[Stream[F, Either[Throwable, O2]]].chunks.flatMap { c =>
       val firstError = c.collectFirst { case Left(err) => err }
       firstError match {
@@ -2261,7 +2259,6 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
         case Some(h) => Stream.raiseError[F2](h)
       }
     }
-  }
 
   /** Left fold which outputs all intermediate results.
     *
@@ -3675,7 +3672,6 @@ object Stream extends StreamLowPriority {
         left: Pipe[F, L, INothing],
         right: Pipe[F, R, INothing]
     )(implicit F: Concurrent[F], ev: O <:< Either[L, R]): Stream[F, Either[L, R]] = {
-      val _ = ev
       val src = self.asInstanceOf[Stream[F, Either[L, R]]]
       src
         .observe(_.collect { case Left(l) => l }.through(left))
@@ -4492,10 +4488,8 @@ object Stream extends StreamLowPriority {
       * res0: String = Hello world!
       * }}}
       */
-    def string(implicit ev: O <:< String): G[String] = {
-      val _ = ev
+    def string(implicit ev: O <:< String): G[String] =
       new Stream(underlying).asInstanceOf[Stream[F, String]].compile.to(Collector.string)
-    }
 
     /** Compiles this stream into a value of the target effect type `F` by collecting
       * all of the output values in a collection.

--- a/core/shared/src/test/scala-2.12/fs2/ChunkGeneratorsCompat.scala
+++ b/core/shared/src/test/scala-2.12/fs2/ChunkGeneratorsCompat.scala
@@ -1,0 +1,42 @@
+package fs2
+
+import org.scalacheck.Shrink
+
+import scala.collection.immutable.{Stream => StdStream}
+
+private[fs2] trait ChunkGeneratorsCompat {
+
+  protected implicit def shrinkChunk[A]: Shrink[Chunk[A]] =
+    Shrink[Chunk[A]](c => removeChunks(c.size, c))
+
+  // The removeChunks function and the interleave function were ported from Scalacheck,
+  // from Shrink.scala, licensed under a Revised BSD license.
+  //
+  // /*-------------------------------------------------------------------------*\
+  // **  ScalaCheck                                                             **
+  // **  Copyright (c) 2007-2016 Rickard Nilsson. All rights reserved.          **
+  // **  http://www.scalacheck.org                                              **
+  // **                                                                         **
+  // **  This software is released under the terms of the Revised BSD License.  **
+  // **  There is NO WARRANTY. See the file LICENSE for the full text.          **
+  // \*------------------------------------------------------------------------ */
+
+  private def removeChunks[A](size: Int, xs: Chunk[A]): StdStream[Chunk[A]] =
+    if (xs.isEmpty) StdStream.empty
+    else if (xs.size == 1) StdStream(Chunk.empty)
+    else {
+      val n1 = size / 2
+      val n2 = size - n1
+      lazy val xs1 = xs.take(n1)
+      lazy val xs2 = xs.drop(n1)
+      lazy val xs3 =
+        for (ys1 <- removeChunks(n1, xs1) if !ys1.isEmpty) yield Chunk.Queue(ys1, xs2)
+      lazy val xs4 =
+        for (ys2 <- removeChunks(n2, xs2) if !ys2.isEmpty) yield Chunk.Queue(xs1, ys2)
+
+      StdStream.cons(xs1, StdStream.cons(xs2, interleave(xs3, xs4)))
+    }
+
+  private def interleave[A](xs: StdStream[A], ys: StdStream[A]): StdStream[A] =
+    if (xs.isEmpty) ys else if (ys.isEmpty) xs else xs.head +: ys.head +: (xs.tail ++ ys.tail)
+}

--- a/core/shared/src/test/scala-2.12/fs2/ChunkGeneratorsCompat.scala
+++ b/core/shared/src/test/scala-2.12/fs2/ChunkGeneratorsCompat.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package fs2
 
 import org.scalacheck.Shrink

--- a/core/shared/src/test/scala-2.13/fs2/ChunkGeneratorsCompat.scala
+++ b/core/shared/src/test/scala-2.13/fs2/ChunkGeneratorsCompat.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package fs2
 
 import org.scalacheck.Shrink

--- a/core/shared/src/test/scala-2.13/fs2/ChunkGeneratorsCompat.scala
+++ b/core/shared/src/test/scala-2.13/fs2/ChunkGeneratorsCompat.scala
@@ -1,0 +1,42 @@
+package fs2
+
+import org.scalacheck.Shrink
+
+import scala.collection.immutable.LazyList
+
+private[fs2] trait ChunkGeneratorsCompat {
+
+  protected implicit def shrinkChunk[A]: Shrink[Chunk[A]] =
+    Shrink.withLazyList[Chunk[A]](c => removeChunks(c.size, c))
+
+  // The removeChunks function and the interleave function were ported from Scalacheck,
+  // from Shrink.scala, licensed under a Revised BSD license.
+  //
+  // /*-------------------------------------------------------------------------*\
+  // **  ScalaCheck                                                             **
+  // **  Copyright (c) 2007-2016 Rickard Nilsson. All rights reserved.          **
+  // **  http://www.scalacheck.org                                              **
+  // **                                                                         **
+  // **  This software is released under the terms of the Revised BSD License.  **
+  // **  There is NO WARRANTY. See the file LICENSE for the full text.          **
+  // \*------------------------------------------------------------------------ */
+
+  private def removeChunks[A](size: Int, xs: Chunk[A]): LazyList[Chunk[A]] =
+    if (xs.isEmpty) LazyList.empty
+    else if (xs.size == 1) LazyList(Chunk.empty)
+    else {
+      val n1 = size / 2
+      val n2 = size - n1
+      lazy val xs1 = xs.take(n1)
+      lazy val xs2 = xs.drop(n1)
+      lazy val xs3 =
+        for (ys1 <- removeChunks(n1, xs1) if !ys1.isEmpty) yield Chunk.Queue(ys1, xs2)
+      lazy val xs4 =
+        for (ys2 <- removeChunks(n2, xs2) if !ys2.isEmpty) yield Chunk.Queue(xs1, ys2)
+
+      LazyList.cons(xs1, LazyList.cons(xs2, interleave(xs3, xs4)))
+    }
+
+  private def interleave[A](xs: LazyList[A], ys: LazyList[A]): LazyList[A] =
+    if (xs.isEmpty) ys else if (ys.isEmpty) xs else xs.head +: ys.head +: (xs.tail ++ ys.tail)
+}

--- a/core/shared/src/test/scala-2.13/fs2/ChunkPlatformSuite.scala
+++ b/core/shared/src/test/scala-2.13/fs2/ChunkPlatformSuite.scala
@@ -21,6 +21,7 @@
 
 package fs2
 
+import scala.annotation.nowarn
 import scala.collection.immutable.ArraySeq
 import scala.collection.{immutable, mutable}
 import scala.reflect.ClassTag
@@ -30,6 +31,7 @@ import Arbitrary.arbitrary
 
 class ChunkPlatformSuite extends Fs2Suite {
 
+  @nowarn("cat=unused")
   private implicit def genArraySeq[A: Arbitrary: ClassTag]: Arbitrary[ArraySeq[A]] =
     Arbitrary(Gen.listOf(arbitrary[A]).map(ArraySeq.from))
   private implicit def genMutableArraySeq[A: Arbitrary: ClassTag]: Arbitrary[mutable.ArraySeq[A]] =

--- a/core/shared/src/test/scala-2.13/fs2/ChunkPlatformSuite.scala
+++ b/core/shared/src/test/scala-2.13/fs2/ChunkPlatformSuite.scala
@@ -31,7 +31,7 @@ import Arbitrary.arbitrary
 
 class ChunkPlatformSuite extends Fs2Suite {
 
-  @nowarn("cat=unused")
+  @nowarn("cat=unused-params")
   private implicit def genArraySeq[A: Arbitrary: ClassTag]: Arbitrary[ArraySeq[A]] =
     Arbitrary(Gen.listOf(arbitrary[A]).map(ArraySeq.from))
   private implicit def genMutableArraySeq[A: Arbitrary: ClassTag]: Arbitrary[mutable.ArraySeq[A]] =

--- a/core/shared/src/test/scala-3/fs2/ChunkGeneratorsCompat.scala
+++ b/core/shared/src/test/scala-3/fs2/ChunkGeneratorsCompat.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package fs2
 
 import org.scalacheck.Shrink

--- a/core/shared/src/test/scala-3/fs2/ChunkGeneratorsCompat.scala
+++ b/core/shared/src/test/scala-3/fs2/ChunkGeneratorsCompat.scala
@@ -1,0 +1,42 @@
+package fs2
+
+import org.scalacheck.Shrink
+
+import scala.collection.immutable.LazyList
+
+private[fs2] trait ChunkGeneratorsCompat {
+
+  protected implicit def shrinkChunk[A]: Shrink[Chunk[A]] =
+    Shrink.withLazyList[Chunk[A]](c => removeChunks(c.size, c))
+
+  // The removeChunks function and the interleave function were ported from Scalacheck,
+  // from Shrink.scala, licensed under a Revised BSD license.
+  //
+  // /*-------------------------------------------------------------------------*\
+  // **  ScalaCheck                                                             **
+  // **  Copyright (c) 2007-2016 Rickard Nilsson. All rights reserved.          **
+  // **  http://www.scalacheck.org                                              **
+  // **                                                                         **
+  // **  This software is released under the terms of the Revised BSD License.  **
+  // **  There is NO WARRANTY. See the file LICENSE for the full text.          **
+  // \*------------------------------------------------------------------------ */
+
+  private def removeChunks[A](size: Int, xs: Chunk[A]): LazyList[Chunk[A]] =
+    if (xs.isEmpty) LazyList.empty
+    else if (xs.size == 1) LazyList(Chunk.empty)
+    else {
+      val n1 = size / 2
+      val n2 = size - n1
+      lazy val xs1 = xs.take(n1)
+      lazy val xs2 = xs.drop(n1)
+      lazy val xs3 =
+        for (ys1 <- removeChunks(n1, xs1) if !ys1.isEmpty) yield Chunk.Queue(ys1, xs2)
+      lazy val xs4 =
+        for (ys2 <- removeChunks(n2, xs2) if !ys2.isEmpty) yield Chunk.Queue(xs1, ys2)
+
+      LazyList.cons(xs1, LazyList.cons(xs2, interleave(xs3, xs4)))
+    }
+
+  private def interleave[A](xs: LazyList[A], ys: LazyList[A]): LazyList[A] =
+    if (xs.isEmpty) ys else if (ys.isEmpty) xs else xs.head +: ys.head +: (xs.tail ++ ys.tail)
+}

--- a/core/shared/src/test/scala/fs2/ChunkGenerators.scala
+++ b/core/shared/src/test/scala/fs2/ChunkGenerators.scala
@@ -23,11 +23,10 @@ package fs2
 
 import cats.data.Chain
 import scala.reflect.ClassTag
-import scala.collection.immutable.{Stream => StdStream}
 import scodec.bits.ByteVector
 import java.nio.{Buffer => JBuffer, CharBuffer => JCharBuffer, ByteBuffer => JByteBuffer}
 
-import org.scalacheck.{Arbitrary, Cogen, Gen, Shrink}
+import org.scalacheck.{Arbitrary, Cogen, Gen}
 import Arbitrary.arbitrary
 
 trait ChunkGeneratorsLowPriority1 extends MiscellaneousGenerators {
@@ -74,7 +73,7 @@ trait ChunkGeneratorsLowPriority extends ChunkGeneratorsLowPriority1 {
     )
 }
 
-trait ChunkGenerators extends ChunkGeneratorsLowPriority {
+trait ChunkGenerators extends ChunkGeneratorsLowPriority with ChunkGeneratorsCompat {
   private def arrayChunkGenerator[A](genA: Gen[A])(implicit ct: ClassTag[A]): Gen[Chunk[A]] =
     for {
       values <- Gen.listOf(genA).map(_.toArray)
@@ -149,40 +148,6 @@ trait ChunkGenerators extends ChunkGeneratorsLowPriority {
 
   implicit def cogenChunk[A: Cogen]: Cogen[Chunk[A]] =
     Cogen[List[A]].contramap(_.toList)
-
-  implicit def shrinkChunk[A]: Shrink[Chunk[A]] =
-    Shrink[Chunk[A]](c => removeChunks(c.size, c))
-
-  // The removeChunks function and the interleave function were ported from Scalacheck,
-  // from Shrink.scala, licensed under a Revised BSD license.
-  //
-  // /*-------------------------------------------------------------------------*\
-  // **  ScalaCheck                                                             **
-  // **  Copyright (c) 2007-2016 Rickard Nilsson. All rights reserved.          **
-  // **  http://www.scalacheck.org                                              **
-  // **                                                                         **
-  // **  This software is released under the terms of the Revised BSD License.  **
-  // **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-  // \*------------------------------------------------------------------------ */
-
-  private def removeChunks[A](size: Int, xs: Chunk[A]): StdStream[Chunk[A]] =
-    if (xs.isEmpty) StdStream.empty
-    else if (xs.size == 1) StdStream(Chunk.empty)
-    else {
-      val n1 = size / 2
-      val n2 = size - n1
-      lazy val xs1 = xs.take(n1)
-      lazy val xs2 = xs.drop(n1)
-      lazy val xs3 =
-        for (ys1 <- removeChunks(n1, xs1) if !ys1.isEmpty) yield Chunk.Queue(ys1, xs2)
-      lazy val xs4 =
-        for (ys2 <- removeChunks(n2, xs2) if !ys2.isEmpty) yield Chunk.Queue(xs1, ys2)
-
-      StdStream.cons(xs1, StdStream.cons(xs2, interleave(xs3, xs4)))
-    }
-
-  private def interleave[A](xs: StdStream[A], ys: StdStream[A]): StdStream[A] =
-    if (xs.isEmpty) ys else if (ys.isEmpty) xs else xs.head +: ys.head +: (xs.tail ++ ys.tail)
 }
 
 object ChunkGenerators extends ChunkGenerators

--- a/core/shared/src/test/scala/fs2/StreamObserveSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamObserveSuite.scala
@@ -21,6 +21,7 @@
 
 package fs2
 
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 
 import cats.effect.IO
@@ -28,6 +29,7 @@ import cats.effect.kernel.Ref
 import cats.syntax.all._
 import org.scalacheck.effect.PropF.forAllF
 
+@nowarn("cat=w-flag-dead-code")
 class StreamObserveSuite extends Fs2Suite {
   trait Observer {
     def apply[O](s: Stream[IO, O])(observation: Pipe[IO, O, INothing]): Stream[IO, O]

--- a/core/shared/src/test/scala/fs2/StreamSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamSuite.scala
@@ -21,7 +21,7 @@
 
 package fs2
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.concurrent.duration._
 
 import cats.data.Chain
@@ -35,6 +35,7 @@ import org.scalacheck.effect.PropF.forAllF
 
 import fs2.concurrent.SignallingRef
 
+@nowarn("cat=w-flag-dead-code")
 class StreamSuite extends Fs2Suite {
 
   group("basics") {

--- a/core/shared/src/test/scala/fs2/StreamZipSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamZipSuite.scala
@@ -24,11 +24,13 @@ package fs2
 import cats.effect.{IO, SyncIO}
 import cats.syntax.all._
 
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 
 import org.scalacheck.Prop.forAll
 import org.scalacheck.effect.PropF.forAllF
 
+@nowarn("cat=w-flag-dead-code")
 class StreamZipSuite extends Fs2Suite {
 
   group("zip") {

--- a/io/src/test/scala/fs2/io/IoSuite.scala
+++ b/io/src/test/scala/fs2/io/IoSuite.scala
@@ -130,10 +130,10 @@ class IoSuite extends Fs2Suite {
       case class ChunkSize(value: Int)
       val defaultPipedInputStreamBufferSize = 1024 // private in PipedInputStream.DEFAULT_PIPE_SIZE
       implicit val arbChunkSize: Arbitrary[ChunkSize] = Arbitrary {
-        Gen.chooseNum(defaultPipedInputStreamBufferSize + 1, 65536).map(ChunkSize)
+        Gen.chooseNum(defaultPipedInputStreamBufferSize + 1, 65536).map(ChunkSize(_))
       }
       implicit val shrinkChunkSize: Shrink[ChunkSize] =
-        Shrink.xmap[Int, ChunkSize](ChunkSize, _.value) {
+        Shrink.xmap[Int, ChunkSize](ChunkSize(_), _.value) {
           Shrink.shrinkIntegral[Int].suchThat(_ > defaultPipedInputStreamBufferSize)
         }
 


### PR DESCRIPTION
Resolves #1887. And then some.

I'm hoping none of these changes are controversial. It's just some code reordering to help the Scala 2.13 pattern matcher in `Pull.scala` and using `scala.annotation.nowarn` to get rid of the `dead code` warnings around the `INothing` type in tests, as well as silencing of `unused implicit parameters` warnings.

I also trusted the Scala 3 compiler to figure out whether some type tests cannot be checked at runtime (although this is consistent across Scala 2.13 and 3).

Blocked on #2373.