### PR TITLE
Fix memory leak in Channel

### DIFF
--- a/core/shared/src/main/scala/fs2/concurrent/Channel.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Channel.scala
@@ -209,7 +209,8 @@ object Channel {
                     (
                       State(values, size, waiting.some, producers, closed),
                       F.pure(
-                        (Pull.eval(waiting.get) >> consumeLoop).unlessA(closed)
+                        if (closed) Pull.done
+                        else (Pull.eval(waiting.get) >> consumeLoop)
                       )
                     )
                   }


### PR DESCRIPTION
Fixes both "hung merge" and "broadcastThrough identity". The `unlessA` breaks monadic tail recursion.

For posterity, here's how I found this one:
- bisect pointed to ef57231 as the first commit for which "hung merge" test failed
- that commit changed `Stream.merge` but none of the changes there changed the "shape" of streams besides swapping in `Channel` for `Queue`
- by poking around in the .hprof written out by `MemoryLeakSpec`, I noticed the `BindBind` chains contained lots of references to `Pull.eval(...).flatMap`, so I searched `Channel.scala` for `Pull.eval` -- there were only 2 matches, one of which had the `unlessA`