### PR TITLE
PipedStreamBuffer circular copying fix

### DIFF
--- a/io/src/main/scala/fs2/io/internal/PipedStreamBuffer.scala
+++ b/io/src/main/scala/fs2/io/internal/PipedStreamBuffer.scala
@@ -270,7 +270,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
             // or just a part of it.
             val toWrite = math.min(available, length)
             // Transfer the bytes to the provided byte array.
-            System.arraycopy(b, offset, buffer, tail % capacity, toWrite)
+            circularWrite(b, offset, buffer, tail, capacity, toWrite)
             // The bytes are marked as written by advancing the tail of the
             // circular buffer.
             tail += toWrite
@@ -314,6 +314,35 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         // state of the Input/OutputStream.
         writerPermit.release()
         readerPermit.release()
+      }
+    }
+
+    /** Writes bytes into a circular buffer by copying them from a regular
+      * buffer.
+      *
+      * @param src the source buffer
+      * @param srcPos the offset into the source buffer
+      * @param dst the destination circular buffer
+      * @param dstPos the offset into the destination circular buffer
+      * @param dstCap the capacity of the destination circular buffer
+      * @param length the number of bytes to be transferred
+      */
+    private[this] def circularWrite(
+        src: Array[Byte],
+        srcPos: Int,
+        dst: Array[Byte],
+        dstPos: Int,
+        dstCap: Int,
+        length: Int
+    ): Unit = {
+      val dstOffset = dstPos % dstCap
+      if (dstOffset + length >= dstCap) {
+        val batch1 = dstCap - dstOffset
+        val batch2 = length - batch1
+        System.arraycopy(src, srcPos, dst, dstOffset, batch1)
+        System.arraycopy(src, srcPos + batch1, dst, 0, batch2)
+      } else {
+        System.arraycopy(src, srcPos, dst, dstOffset, length)
       }
     }
   }


### PR DESCRIPTION
Resolves #2457.

I honestly don't know how I ever expected this to work. I must have wanted to iterate on the initial code but obviously forgot to do it. I apologize for the mistake.