### PR TITLE
Avoid allocations in TLSEngine when logging is disabled

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,12 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[MissingClassProblem]("fs2.Pull$CloseScope$"),
   ProblemFilters.exclude[ReversedAbstractMethodProblem]("fs2.Pull#CloseScope.*"),
   ProblemFilters.exclude[Problem]("fs2.io.Watcher#Registration.*"),
-  ProblemFilters.exclude[Problem]("fs2.io.Watcher#DefaultWatcher.*")
+  ProblemFilters.exclude[Problem]("fs2.io.Watcher#DefaultWatcher.*"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.io.net.tls.TLSContext.clientBuilder"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.io.net.tls.TLSContext.serverBuilder"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.io.net.tls.TLSContext.dtlsClientBuilder"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.io.net.tls.TLSContext.dtlsServerBuilder"),
+  ProblemFilters.exclude[Problem]("fs2.io.net.tls.TLSEngine*")
 )
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -98,8 +98,12 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[Problem]("fs2.io.Watcher#DefaultWatcher.*"),
   ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.io.net.tls.TLSContext.clientBuilder"),
   ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.io.net.tls.TLSContext.serverBuilder"),
-  ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.io.net.tls.TLSContext.dtlsClientBuilder"),
-  ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.io.net.tls.TLSContext.dtlsServerBuilder"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "fs2.io.net.tls.TLSContext.dtlsClientBuilder"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "fs2.io.net.tls.TLSContext.dtlsServerBuilder"
+  ),
   ProblemFilters.exclude[Problem]("fs2.io.net.tls.TLSEngine*")
 )
 

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -25,7 +25,6 @@ import scala.concurrent.duration._
 import scala.concurrent.TimeoutException
 import cats.effect.{IO, SyncIO}
 import cats.effect.kernel.Ref
-import cats.effect.std.Queue
 import cats.effect.std.Semaphore
 import cats.syntax.all._
 import org.scalacheck.Gen
@@ -1316,7 +1315,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
       val action =
         Vector.fill(streamSize)(Deferred[IO, Unit]).sequence.map { seenArr =>
           def peek(ind: Int)(f: Option[Unit] => Boolean) =
-            seenArr.get(ind).fold(true.pure[IO])(_.tryGet.map(f))
+            seenArr.get(ind.toLong).fold(true.pure[IO])(_.tryGet.map(f))
 
           Stream
             .emits(0 until streamSize)

--- a/io/src/main/scala/fs2/io/net/tls/TLSContext.scala
+++ b/io/src/main/scala/fs2/io/net/tls/TLSContext.scala
@@ -60,10 +60,7 @@ sealed trait TLSContext[F[_]] {
       params: TLSParameters = TLSParameters.Default,
       logger: Option[String => F[Unit]] = None
   ): Resource[F, TLSSocket[F]] =
-    clientBuilder(socket).
-      withParameters(params).
-      withOldLogging(logger).
-      build
+    clientBuilder(socket).withParameters(params).withOldLogging(logger).build
 
   /** Creates a `TLSSocket` builder in server mode. */
   def server(socket: Socket[F]): Resource[F, TLSSocket[F]] =
@@ -78,10 +75,7 @@ sealed trait TLSContext[F[_]] {
       params: TLSParameters = TLSParameters.Default,
       logger: Option[String => F[Unit]] = None
   ): Resource[F, TLSSocket[F]] =
-    serverBuilder(socket).
-      withParameters(params).
-      withOldLogging(logger).
-      build
+    serverBuilder(socket).withParameters(params).withOldLogging(logger).build
 
   /** Creates a `DTLSSocket` builder in client mode. */
   def dtlsClient(
@@ -96,17 +90,17 @@ sealed trait TLSContext[F[_]] {
       remoteAddress: SocketAddress[IpAddress]
   ): TLSContext.SocketBuilder[F, DTLSSocket]
 
-  @deprecated("Use dtlsClient(socket, remoteAddress) or dtlsClientBuilder(socket, remoteAddress).with(...).build", "3.0.6")
+  @deprecated(
+    "Use dtlsClient(socket, remoteAddress) or dtlsClientBuilder(socket, remoteAddress).with(...).build",
+    "3.0.6"
+  )
   def dtlsClient(
       socket: DatagramSocket[F],
       remoteAddress: SocketAddress[IpAddress],
       params: TLSParameters = TLSParameters.Default,
       logger: Option[String => F[Unit]] = None
   ): Resource[F, DTLSSocket[F]] =
-    dtlsClientBuilder(socket, remoteAddress).
-      withParameters(params).
-      withOldLogging(logger).
-      build
+    dtlsClientBuilder(socket, remoteAddress).withParameters(params).withOldLogging(logger).build
 
   /** Creates a `DTLSSocket` builder in server mode. */
   def dtlsServer(
@@ -119,19 +113,19 @@ sealed trait TLSContext[F[_]] {
   def dtlsServerBuilder(
       socket: DatagramSocket[F],
       remoteAddress: SocketAddress[IpAddress]
-  ): TLSContext.SocketBuilder[F, DTLSSocket] 
+  ): TLSContext.SocketBuilder[F, DTLSSocket]
 
-  @deprecated("Use dtlsServer(socket, remoteAddress) or dtlsClientBuilder(socket, remoteAddress).with(...).build", "3.0.6")
+  @deprecated(
+    "Use dtlsServer(socket, remoteAddress) or dtlsClientBuilder(socket, remoteAddress).with(...).build",
+    "3.0.6"
+  )
   def dtlsServer(
       socket: DatagramSocket[F],
       remoteAddress: SocketAddress[IpAddress],
       params: TLSParameters = TLSParameters.Default,
       logger: Option[String => F[Unit]] = None
   ): Resource[F, DTLSSocket[F]] =
-    dtlsServerBuilder(socket, remoteAddress).
-      withParameters(params).
-      withOldLogging(logger).
-      build
+    dtlsServerBuilder(socket, remoteAddress).withParameters(params).withOldLogging(logger).build
 }
 
 object TLSContext {
@@ -176,9 +170,11 @@ object TLSContext {
           ctx: SSLContext
       ): TLSContext[F] =
         new TLSContext[F] {
-          def clientBuilder(socket: Socket[F]) = SocketBuilder((p, l) => mkSocket(socket, true, p, l))
+          def clientBuilder(socket: Socket[F]) =
+            SocketBuilder((p, l) => mkSocket(socket, true, p, l))
 
-          def serverBuilder(socket: Socket[F]) = SocketBuilder((p, l) => mkSocket(socket, false, p, l))
+          def serverBuilder(socket: Socket[F]) =
+            SocketBuilder((p, l) => mkSocket(socket, false, p, l))
 
           private def mkSocket(
               socket: Socket[F],
@@ -202,10 +198,16 @@ object TLSContext {
               )
               .flatMap(engine => TLSSocket(socket, engine))
 
-          def dtlsClientBuilder(socket: DatagramSocket[F], remoteAddress: SocketAddress[IpAddress]) =
+          def dtlsClientBuilder(
+              socket: DatagramSocket[F],
+              remoteAddress: SocketAddress[IpAddress]
+          ) =
             SocketBuilder((p, l) => mkDtlsSocket(socket, remoteAddress, true, p, l))
 
-          def dtlsServerBuilder(socket: DatagramSocket[F], remoteAddress: SocketAddress[IpAddress]) =
+          def dtlsServerBuilder(
+              socket: DatagramSocket[F],
+              remoteAddress: SocketAddress[IpAddress]
+          ) =
             SocketBuilder((p, l) => mkDtlsSocket(socket, remoteAddress, false, p, l))
 
           private def mkDtlsSocket(
@@ -362,9 +364,12 @@ object TLSContext {
   }
 
   object SocketBuilder {
-    private[TLSContext] type Build[F[_], Socket[_[_]]] = (TLSParameters, TLSLogger[F]) => Resource[F, Socket[F]]
+    private[TLSContext] type Build[F[_], Socket[_[_]]] =
+      (TLSParameters, TLSLogger[F]) => Resource[F, Socket[F]]
 
-    private[TLSContext] def apply[F[_], Socket[_[_]]](mkSocket: Build[F, Socket]): SocketBuilder[F, Socket] =
+    private[TLSContext] def apply[F[_], Socket[_[_]]](
+        mkSocket: Build[F, Socket]
+    ): SocketBuilder[F, Socket] =
       instance(mkSocket, TLSParameters.Default, TLSLogger.Disabled)
 
     private def instance[F[_], Socket[_[_]]](
@@ -381,7 +386,9 @@ object TLSContext {
           withLogger(TLSLogger.Disabled)
         def withLogger(logger: TLSLogger[F]): SocketBuilder[F, Socket] =
           instance(mkSocket, params, logger)
-        private[TLSContext] def withOldLogging(log: Option[String => F[Unit]]): SocketBuilder[F, Socket] =
+        private[TLSContext] def withOldLogging(
+            log: Option[String => F[Unit]]
+        ): SocketBuilder[F, Socket] =
           log.map(f => withLogging(m => f(m))).getOrElse(withoutLogging)
         def build: Resource[F, Socket[F]] =
           mkSocket(params, logger)

--- a/io/src/main/scala/fs2/io/net/tls/TLSEngine.scala
+++ b/io/src/main/scala/fs2/io/net/tls/TLSEngine.scala
@@ -72,8 +72,8 @@ private[tls] object TLSEngine {
     } yield new TLSEngine[F] {
       private val doLog: (() => String) => F[Unit] =
         logger match {
-          case TLSLogger.Enabled(f) => msg => f(msg())
-          case TLSLogger.Disabled   => _ => Applicative[F].unit
+          case e: TLSLogger.Enabled[_] => msg => e.log(msg())
+          case TLSLogger.Disabled      => _ => Applicative[F].unit
         }
 
       private def log(msg: => String): F[Unit] = doLog(() => msg)

--- a/io/src/main/scala/fs2/io/net/tls/TLSEngine.scala
+++ b/io/src/main/scala/fs2/io/net/tls/TLSEngine.scala
@@ -54,7 +54,7 @@ private[tls] object TLSEngine {
   def apply[F[_]: Async](
       engine: SSLEngine,
       binding: Binding[F],
-      logger: Option[String => F[Unit]] = None
+      logger: TLSLogger[F]
   ): F[TLSEngine[F]] =
     for {
       wrapBuffer <- InputOutputBuffer[F](
@@ -70,8 +70,13 @@ private[tls] object TLSEngine {
       handshakeSemaphore <- Semaphore[F](1)
       sslEngineTaskRunner = SSLEngineTaskRunner[F](engine)
     } yield new TLSEngine[F] {
-      private def log(msg: String): F[Unit] =
-        logger.map(_(msg)).getOrElse(Applicative[F].unit)
+      private val doLog: (() => String) => F[Unit] =
+        logger match {
+          case TLSLogger.Enabled(f) => msg => f(msg())
+          case TLSLogger.Disabled   => _ => Applicative[F].unit
+        }
+
+      private def log(msg: => String): F[Unit] = doLog(() => msg)
 
       def beginHandshake = Sync[F].delay(engine.beginHandshake())
       def session = Sync[F].delay(engine.getSession())

--- a/io/src/main/scala/fs2/io/net/tls/TLSLogger.scala
+++ b/io/src/main/scala/fs2/io/net/tls/TLSLogger.scala
@@ -19,22 +19,11 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package fs2
-package io
-package net
-package tls
+package fs2.io.net.tls
 
-import cats.effect.IO
+sealed trait TLSLogger[+F[_]]
 
-abstract class TLSSuite extends Fs2Suite {
-  def testTlsContext: IO[TLSContext[IO]] =
-    Network[IO].tlsContext
-      .fromKeyStoreResource(
-        "keystore.jks",
-        "password".toCharArray,
-        "password".toCharArray
-      )
-
-  val logger = TLSLogger.Disabled
-  // val logger = TLSLogger.Enabled(msg => IO(println(s"\u001b[33m${msg}\u001b[0m")))
+object TLSLogger {
+  case object Disabled extends TLSLogger[Nothing]
+  case class Enabled[F[_]](log: (=> String) => F[Unit]) extends TLSLogger[F]
 }

--- a/io/src/test/scala/fs2/io/net/tls/DTLSSocketSuite.scala
+++ b/io/src/test/scala/fs2/io/net/tls/DTLSSocketSuite.scala
@@ -45,8 +45,14 @@ class DTLSSocketSuite extends TLSSuite {
         serverAddress <- address(serverSocket)
         clientSocket <- Network[IO].openDatagramSocket()
         clientAddress <- address(clientSocket)
-        tlsServerSocket <- tlsContext.dtlsServerBuilder(serverSocket, clientAddress).withLogger(logger).build
-        tlsClientSocket <- tlsContext.dtlsClientBuilder(clientSocket, serverAddress).withLogger(logger).build
+        tlsServerSocket <- tlsContext
+          .dtlsServerBuilder(serverSocket, clientAddress)
+          .withLogger(logger)
+          .build
+        tlsClientSocket <- tlsContext
+          .dtlsClientBuilder(clientSocket, serverAddress)
+          .withLogger(logger)
+          .build
       } yield (tlsServerSocket, tlsClientSocket, serverAddress)
 
       Stream

--- a/io/src/test/scala/fs2/io/net/tls/DTLSSocketSuite.scala
+++ b/io/src/test/scala/fs2/io/net/tls/DTLSSocketSuite.scala
@@ -45,8 +45,8 @@ class DTLSSocketSuite extends TLSSuite {
         serverAddress <- address(serverSocket)
         clientSocket <- Network[IO].openDatagramSocket()
         clientAddress <- address(clientSocket)
-        tlsServerSocket <- tlsContext.dtlsServer(serverSocket, clientAddress, logger = logger)
-        tlsClientSocket <- tlsContext.dtlsClient(clientSocket, serverAddress, logger = logger)
+        tlsServerSocket <- tlsContext.dtlsServerBuilder(serverSocket, clientAddress).withLogger(logger).build
+        tlsClientSocket <- tlsContext.dtlsClientBuilder(clientSocket, serverAddress).withLogger(logger).build
       } yield (tlsServerSocket, tlsClientSocket, serverAddress)
 
       Stream

--- a/io/src/test/scala/fs2/io/net/tls/TLSDebugExample.scala
+++ b/io/src/test/scala/fs2/io/net/tls/TLSDebugExample.scala
@@ -39,10 +39,9 @@ object TLSDebug {
     host.resolve.flatMap { socketAddress =>
       Network[F].client(socketAddress).use { rawSocket =>
         tlsContext
-          .client(
-            rawSocket,
-            TLSParameters(serverNames = Some(List(new SNIHostName(host.host.toString))))
-          )
+          .clientBuilder(rawSocket)
+          .withParameters(TLSParameters(serverNames = Some(List(new SNIHostName(host.host.toString)))))
+          .build
           .use { tlsSocket =>
             tlsSocket.write(Chunk.empty) >>
               tlsSocket.session.map { session =>

--- a/io/src/test/scala/fs2/io/net/tls/TLSDebugExample.scala
+++ b/io/src/test/scala/fs2/io/net/tls/TLSDebugExample.scala
@@ -40,7 +40,9 @@ object TLSDebug {
       Network[F].client(socketAddress).use { rawSocket =>
         tlsContext
           .clientBuilder(rawSocket)
-          .withParameters(TLSParameters(serverNames = Some(List(new SNIHostName(host.host.toString)))))
+          .withParameters(
+            TLSParameters(serverNames = Some(List(new SNIHostName(host.host.toString))))
+          )
           .build
           .use { tlsSocket =>
             tlsSocket.write(Chunk.empty) >>

--- a/io/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -43,12 +43,14 @@ class TLSSocketSuite extends TLSSuite {
         for {
           tlsContext <- Resource.eval(Network[IO].tlsContext.system)
           socket <- Network[IO].client(SocketAddress(host"google.com", port"443"))
-          tlsSocket <- tlsContext.clientBuilder(socket)
+          tlsSocket <- tlsContext
+            .clientBuilder(socket)
             .withParameters(
-            TLSParameters(
-              serverNames = List(new SNIHostName("www.google.com")).some,
-              protocols = List(protocol).some
-            ))
+              TLSParameters(
+                serverNames = List(new SNIHostName("www.google.com")).some,
+                protocols = List(protocol).some
+              )
+            )
             .build
         } yield tlsSocket
 


### PR DESCRIPTION
This gives us syntax like:
```scala
tlsContext.client(socket).use(...)
tlsContext.clientBuilder(socket).withLogging(...).build.use(...)
```