### PR TITLE
Pull.outputOption

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -559,6 +559,9 @@ object Chunk extends CollectorK[Chunk] with ChunkCompanionPlatform {
   /** Chunk with no elements. */
   def empty[A]: Chunk[A] = empty_
 
+  /** Creates a singleton chunk or returns an empty one */
+  def fromOption[O](opt: Option[O]): Chunk[O] = opt.map(singleton).getOrElse(empty_)
+
   /** Creates a chunk consisting of a single element. */
   def singleton[O](o: O): Chunk[O] = new Singleton(o)
   final class Singleton[O](val value: O) extends Chunk[O] {

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -350,6 +350,13 @@ object Pull extends PullLowPriority {
     */
   def output1[F[x] >: Pure[x], O](o: O): Pull[F, O, Unit] = Output(Chunk.singleton(o))
 
+  /** Lifts the given optional value `O` into a pull that performs no
+    * effects, emits the content of that option, and always
+    * terminates successfully with a unit result.
+    */
+  def outputOption[F[x] >: Pure[x], O](opt: Option[O]): Pull[Pure, O, Unit] =
+    output(Chunk.fromOption(opt))
+
   /** Creates a pull that emits the elements of the given chunk.
     * The new pull performs no effects and terminates successfully with a unit result.
     */

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -354,8 +354,8 @@ object Pull extends PullLowPriority {
     * effects, emits the content of that option, and always
     * terminates successfully with a unit result.
     */
-  def outputOption[F[x] >: Pure[x], O](opt: Option[O]): Pull[Pure, O, Unit] =
-    output(Chunk.fromOption(opt))
+  def outputOption1[F[x] >: Pure[x], O](opt: Option[O]): Pull[Pure, O, Unit] =
+    opt.map(output1).getOrElse(done)
 
   /** Creates a pull that emits the elements of the given chunk.
     * The new pull performs no effects and terminates successfully with a unit result.


### PR DESCRIPTION
```scala
import cats.effect.IOApp
import cats.effect.{ExitCode, IO}
import scala.concurrent.duration._
import cats.syntax.all._

object PullOptionApp extends IOApp {

  def run(args: List[String]): IO[ExitCode] = {
    val single = Pull.outputOption(Some(1))
    val empty = Pull.outputOption(None)

    val msg = s"single: ${single.stream.compile.toList}\nempty: ${empty.stream.compile.toList}"

    IO(println(msg)).as(ExitCode.Success)
  }
}
```

```
[info] running fs2.PullOptionApp 
single: List(1)
empty: List()
```