### PR TITLE
Rework parJoin to work with transformers

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2118,6 +2118,8 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
                       })
                     }
                   }
+                  .attempt
+                  .void
               }
             }
         }
@@ -2130,11 +2132,12 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
           .compile
           .fold(F2.unit)(_ >> _.join)
           .flatten
-          .void
           .guaranteeCase {
             case ExitCase.Error(err) => stop(Left(err))
             case _                   => stop(Right(()))
           }
+          .attempt
+          .void
 
       // awaits when all streams (outer + inner) finished,
       // and then collects result of the stream (outer + inner) execution

--- a/core/shared/src/test/scala/fs2/StreamParJoinSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamParJoinSuite.scala
@@ -23,10 +23,13 @@ package fs2
 
 import scala.concurrent.duration._
 
+import cats.data.{EitherT, OptionT}
 import cats.effect.IO
 import cats.effect.concurrent.{Deferred, Ref}
 import cats.syntax.all._
 import org.scalacheck.effect.PropF.forAllF
+
+import scala.util.control.NoStackTrace
 
 class StreamParJoinSuite extends Fs2Suite {
   test("no concurrency") {
@@ -201,5 +204,93 @@ class StreamParJoinSuite extends Fs2Suite {
       .emit(Stream.raiseError[IO](err))
       .parJoinUnbounded ++ Stream.emit(1)).compile.toList.attempt
       .map(it => assert(it == Left(err)))
+  }
+
+  group("short-circuiting transformers") {
+    test("do not block while evaluating a stream of streams in IO in parallel") {
+      def f(n: Int): Stream[IO, String] = Stream(n).map(_.toString)
+
+      Stream(1, 2, 3)
+        .map(f)
+        .parJoinUnbounded
+        .compile
+        .toList
+        .map(_.toSet)
+        .flatMap { actual =>
+          IO(assertEquals(actual, Set("1", "2", "3")))
+        }
+    }
+
+    test(
+      "do not block while evaluating a stream of streams in EitherT[IO, Throwable, *] in parallel - right"
+    ) {
+      def f(n: Int): Stream[EitherT[IO, Throwable, *], String] = Stream(n).map(_.toString)
+
+      Stream(1, 2, 3)
+        .map(f)
+        .parJoinUnbounded
+        .compile
+        .toList
+        .map(_.toSet)
+        .value
+        .flatMap { actual =>
+          IO(assertEquals(actual, Right(Set("1", "2", "3"))))
+        }
+    }
+
+    test(
+      "do not block while evaluating a stream of streams in EitherT[IO, Throwable, *] in parallel - left"
+    ) {
+      case object TestException extends Throwable with NoStackTrace
+
+      def f(n: Int): Stream[EitherT[IO, Throwable, *], String] =
+        if (n % 2 != 0) Stream(n).map(_.toString)
+        else Stream.eval[EitherT[IO, Throwable, *], String](EitherT.leftT(TestException))
+
+      Stream(1, 2, 3)
+        .map(f)
+        .parJoinUnbounded
+        .compile
+        .toList
+        .value
+        .flatMap { actual =>
+          IO(assertEquals(actual, Left(TestException)))
+        }
+    }
+
+    test(
+      "do not block while evaluating a stream of streams in OptionT[IO, *] in parallel - some"
+    ) {
+      def f(n: Int): Stream[OptionT[IO, *], String] = Stream(n).map(_.toString)
+
+      Stream(1, 2, 3)
+        .map(f)
+        .parJoinUnbounded
+        .compile
+        .toList
+        .map(_.toSet)
+        .value
+        .flatMap { actual =>
+          IO(assertEquals(actual, Some(Set("1", "2", "3"))))
+        }
+    }
+
+    test(
+      "do not block while evaluating a stream of streams in OptionT[IO, *] in parallel - none"
+    ) {
+      def f(n: Int): Stream[OptionT[IO, *], String] =
+        if (n % 2 != 0) Stream(n).map(_.toString)
+        else Stream.eval[OptionT[IO, *], String](OptionT.none)
+
+      Stream(1, 2, 3)
+        .map(f)
+        .parJoinUnbounded
+        .compile
+        .toList
+        .value
+        .flatMap { actual =>
+          IO(assertEquals(actual, None))
+        }
+    }
   }
 }


### PR DESCRIPTION
Resolves #1945.

The reasoning behind this change is the following.

It is ok to join the _inner_ forked fibers because they are `uncancelable` and cannot result in a deadlock. It is also ok to join the _outer_ forked fiber because we completely control it.

The `.fold(F2.unit)(_ >> _.join)` does indeed create a potentially big `flatMap` chain, but IMO, this is warranted due to the inherent complexity of this combinator, which already had significant overhead in terms of allocations.