### PR TITLE
Disable OSGI for Scala.js build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -202,7 +202,7 @@ lazy val coreJS = core.js
 
 lazy val io = crossProject(JVMPlatform, JSPlatform)
   .in(file("io"))
-  .enablePlugins(SbtOsgi)
+  .jvmConfigure(_.enablePlugins(SbtOsgi))
   .jsConfigure(_.enablePlugins(ScalablyTypedConverterGenSourcePlugin))
   .settings(
     name := "fs2-io",


### PR DESCRIPTION
Hopefully solves #2479.

Not sure how to test this, since it seems #2479 doesn't affect `publishLocal`.