### PR TITLE
Catch errors during Node.js socket initialization

### DIFF
--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -160,10 +160,10 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
     }
 
     test("errors - should be captured in the effect") {
-      (for {
+      (for { // Connection refused
         bindAddress <- Network[IO].serverResource(Some(ip"127.0.0.1")).use(s => IO.pure(s._1))
         _ <- Network[IO].client(bindAddress).use(_ => IO.unit)
-      } yield ()).attempt.map(r => assert(r.isLeft)) >> (for {
+      } yield ()).attempt.map(r => assert(r.isLeft)) >> (for { // Address already in use
         bindAddress <- Network[IO].serverResource(Some(ip"127.0.0.1")).map(_._1)
         _ <- Network[IO].serverResource(Some(bindAddress.host), Some(bindAddress.port))
       } yield ()).attempt.use(r => IO(assert(r.isLeft)))

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -158,6 +158,15 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
         .drain
     }
 
+    test("errors - should be captured in the effect") {
+      (for {
+        bindAddress <- Network[IO].serverResource(Some(ip"127.0.0.1")).use(s => IO.pure(s._1))
+        _ <- Network[IO].client(bindAddress).use { client =>
+          client.write(Chunk.array("hello world".getBytes()))
+        }
+      } yield ()).attempt.map(r => assert(r.isLeft))
+    }
+
     test("options - should work with socket options") {
       val opts = List(
         SocketOption.keepAlive(true),


### PR DESCRIPTION
Adds a listener for errors thrown during client socket connection and server binding. Also adds test coverage.