### PR TITLE
Improve Node.js `Readable`/`Writable` converters, introduce `Duplex` converter

### DIFF
--- a/io/js/src/main/scala/fs2/io/NodeStream.scala
+++ b/io/js/src/main/scala/fs2/io/NodeStream.scala
@@ -34,3 +34,9 @@ sealed trait Readable extends js.Object
   */
 @js.native
 sealed trait Writable extends js.Object
+
+/** A facade for Node.js `stream.Duplex`. Cast to/from your own bindings.
+  * @see [[https://nodejs.org/api/stream.html]]
+  */
+@js.native
+sealed trait Duplex extends js.Object with Readable with Writable

--- a/io/js/src/main/scala/fs2/io/file/PosixFiles.scala
+++ b/io/js/src/main/scala/fs2/io/file/PosixFiles.scala
@@ -328,7 +328,7 @@ object PosixFiles {
       readAll(path, Flags.r)
 
     override def readAll(path: Path, flags: Flags): Stream[F, Byte] =
-      fromReadable(
+      readReadable(
         F.delay(
           fsMod
             .createReadStream(
@@ -340,7 +340,7 @@ object PosixFiles {
       )
 
     override def readRange(path: Path, chunkSize: Int, start: Long, end: Long): Stream[F, Byte] =
-      fromReadable(
+      readReadable(
         F.delay(
           fsMod
             .createReadStream(
@@ -418,7 +418,7 @@ object PosixFiles {
       open(path, flags, mode).map(WriteCursor(_, 0L))
 
     override def writeAll(path: Path, flags: Flags, mode: FileAccessMode): Pipe[F, Byte, INothing] =
-      fromWritable(
+      writeWritable(
         F.delay(
           fsMod
             .createWriteStream(

--- a/io/js/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/js/src/main/scala/fs2/io/ioplatform.scala
@@ -41,7 +41,7 @@ import scala.scalajs.js.|
 
 private[fs2] trait ioplatform {
 
-  def fromReadable[F[_]](readable: F[Readable])(implicit F: Async[F]): Stream[F, Byte] =
+  def readReadable[F[_]](readable: F[Readable])(implicit F: Async[F]): Stream[F, Byte] =
     Stream
       .resource(for {
         readable <- Resource.makeCase(readable.map(_.asInstanceOf[streamMod.Readable])) {
@@ -112,7 +112,7 @@ private[fs2] trait ioplatform {
       }
     } yield readable.asInstanceOf[Readable]
 
-  def fromWritable[F[_]](
+  def writeWritable[F[_]](
       writable: F[Writable]
   )(implicit F: Async[F]): Pipe[F, Byte, INothing] =
     in =>
@@ -137,7 +137,7 @@ private[fs2] trait ioplatform {
         }.drain
       }
 
-  def mkWritable[F[_]: Async](f: Writable => F[Unit]): Stream[F, Byte] =
+  def readWritable[F[_]: Async](f: Writable => F[Unit]): Stream[F, Byte] =
     Stream.resource(mkWritable).flatMap { case (writable, stream) =>
       stream.concurrently(Stream.eval(f(writable)))
     }

--- a/io/js/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/js/src/main/scala/fs2/io/ioplatform.scala
@@ -48,10 +48,10 @@ private[fs2] trait ioplatform {
       .resource(for {
         readable <- Resource.makeCase(readable.map(_.asInstanceOf[streamMod.Readable])) {
           case (readable, Resource.ExitCase.Succeeded) =>
-            if (!readable.readableEnded & destroyIfNotEnded)
-              F.delay(readable.destroy())
-            else
-              F.unit
+            F.delay {
+              if (!readable.readableEnded & destroyIfNotEnded)
+                readable.destroy()
+            }
           case (readable, Resource.ExitCase.Errored(ex)) =>
             F.delay(readable.destroy(js.Error(ex.getMessage())))
           case (readable, Resource.ExitCase.Canceled) => F.delay(readable.destroy())

--- a/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -33,7 +33,7 @@ class IoPlatformSuite extends Fs2Suite {
       bytes
         .through(toReadable[IO])
         .flatMap { readable =>
-          fromReadable(IO.pure(readable))
+          readReadable(IO.pure(readable))
         }
         .compile
         .toVector
@@ -43,8 +43,8 @@ class IoPlatformSuite extends Fs2Suite {
 
   test("mk/from Writable") {
     forAllF { bytes: Stream[Pure, Byte] =>
-      mkWritable[IO] { writable =>
-        bytes.covary[IO].through(fromWritable(IO.pure(writable))).compile.drain
+      readWritable[IO] { writable =>
+        bytes.covary[IO].through(writeWritable(IO.pure(writable))).compile.drain
       }.compile.toVector.assertEquals(bytes.compile.toVector)
     }
   }

--- a/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -28,7 +28,7 @@ import org.scalacheck.effect.PropF.forAllF
 
 class IoPlatformSuite extends Fs2Suite {
 
-  test("to/from Readable") {
+  test("to/read Readable") {
     forAllF { bytes: Stream[Pure, Byte] =>
       bytes
         .through(toReadable[IO])
@@ -41,7 +41,7 @@ class IoPlatformSuite extends Fs2Suite {
     }
   }
 
-  test("mk/from Writable") {
+  test("read/write Writable") {
     forAllF { bytes: Stream[Pure, Byte] =>
       readWritable[IO] { writable =>
         bytes.covary[IO].through(writeWritable(IO.pure(writable))).compile.drain

--- a/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -49,4 +49,22 @@ class IoPlatformSuite extends Fs2Suite {
     }
   }
 
+  test("toDuplexAndRead") {
+    forAllF { (bytes1: Stream[Pure, Byte], bytes2: Stream[Pure, Byte]) =>
+      bytes1
+        .through {
+          toDuplexAndRead[IO] { duplex =>
+            readReadable[IO](IO.pure(duplex))
+              .merge(bytes2.covary[IO].through(writeWritable[IO](IO.pure(duplex))))
+              .compile
+              .toVector
+              .assertEquals(bytes1.compile.toVector)
+          }
+        }
+        .compile
+        .toVector
+        .assertEquals(bytes2.compile.toVector)
+    }
+  }
+
 }


### PR DESCRIPTION
Idiomatic APIs as inspired by their [JVM cousins](https://github.com/typelevel/fs2/blob/main/io/jvm/src/main/scala/fs2/io/ioplatform.scala).

Edit: this PR is becoming a catch-all for other fixes.

Edit 2: okay, I ended up doing some major reworking in anticipation of new socket implementations.