### PR TITLE
Minor fixes in Pull docs

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -192,7 +192,7 @@ sealed abstract class Pull[+F[_], +O, +R] {
     * - If an error occurs, the supplied function is used to build a new handler
     *   pull, and it starts running it. However, the pull cannot be resumed from
     *   the point at which the error arose.
-    * - If no error is raised, the resulting  pull just does what `this` pull does.
+    * - If no error is raised, the resulting pull just does what `this` pull does.
     */
   def handleErrorWith[F2[x] >: F[x], O2 >: O, R2 >: R](
       handler: Throwable => Pull[F2, O2, R2]
@@ -248,7 +248,7 @@ sealed abstract class Pull[+F[_], +O, +R] {
     * If `this` pull ends in success with a result `r`, then the function `f`
     * is applied to its result `r`, and the image `f(r)` is the result of the
     * mapped pull. However, if the evaluation of `f(r)` throws an error, the
-    * mapped  pull fails with that error.
+    * mapped pull fails with that error.
     *
     * Note: for some simple cases of Pull, the  `map` function may be eagerly
     * applied, or discarded, _before_ the pull starts being run.
@@ -305,7 +305,7 @@ object Pull extends PullLowPriority {
       * in streams that otherwise would execute in constant memory.
       *
       * May only be called on pulls whose result type is `Unit`.
-      * Use `p.void.stream` to explicitly  ignore the result of a pull.
+      * Use `p.void.stream` to explicitly ignore the result of a pull.
       */
     def streamNoScope: Stream[F, O] = new Stream(self)
   }

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -250,7 +250,7 @@ sealed abstract class Pull[+F[_], +O, +R] {
     * mapped pull. However, if the evaluation of `f(r)` throws an error, the
     * mapped pull fails with that error.
     *
-    * Note: for some simple cases of Pull, the  `map` function may be eagerly
+    * Note: for some simple cases of Pull, the `map` function may be eagerly
     * applied, or discarded, _before_ the pull starts being run.
     *
     * If `this` pull terminates abnormally, so does the mapped pull.

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -218,7 +218,7 @@ sealed abstract class Pull[+F[_], +O, +R] {
     *   However, if the `post` pull succeeds, then the combined `onComplete` pull
     *   fails again with the error that was raised from `this` pull.
     *
-    * - If `this` pull is interrupted, then the `post` error is never run
+    * - If `this` pull is interrupted, then the `post` pull is never run
     *   and the combined pull ends with that same interruption.
     */
   def onComplete[F2[x] >: F[x], O2 >: O, R2](post: => Pull[F2, O2, R2]): Pull[F2, O2, R2] =

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -214,7 +214,7 @@ sealed abstract class Pull[+F[_], +O, +R] {
     *   success, error, interruption, is how the combined pull ends.
     *
     * - If `this` pull fails, the `post` pull is run next. If the `post` pull
-    *   ends fails or is interrupted, that is how the combined pull ends.
+    *   ends, fails, or is interrupted, that is how the combined pull ends.
     *   However, if the `post` pull succeeds, then the combined `onComplete` pull
     *   fails again with the error that was raised from `this` pull.
     *

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -132,7 +132,7 @@ sealed abstract class Pull[+F[_], +O, +R] {
     *   just as the new pull `f(r)` does.
     * - If `this` pull fails or is interrupted, then the composed pull
     *   terminates with that same failure or interruption.
-    * - If evaluating `f(r)` to build the throws an exception, the result
+    * - If evaluating `f(r)` to build the pull throws an exception, the result
     *   is a pull that fails with that exception.
     *
     * The composed pull emits all outputs emitted by `this` pull,

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -243,7 +243,7 @@ sealed abstract class Pull[+F[_], +O, +R] {
   def attempt: Pull[F, O, Either[Throwable, R]] =
     map(r => Right(r)).handleErrorWith(t => Succeeded(Left(t)))
 
-  /** Maps the result of this pull with the `f` mapping funciton.
+  /** Maps the result of this pull with the `f` mapping function.
     *
     * If `this` pull ends in success with a result `r`, then the function `f`
     * is applied to its result `r`, and the image `f(r)` is the result of the


### PR DESCRIPTION
This PR fixes a handful of things in the `Pull` docs.

In this I noticed that only `as` has the `@tparam` and `@param` annotations, I could add these to the other methods like `map` and `flatMap` if that's desired. I'm not sure what the best practice is here.

The docs for fs2 are really great and helpful, thank you so much!