### PR TITLE
Rework `parJoin` to work with transformers

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2069,158 +2069,162 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
     val _ = (ev, ev2)
     val outer = this.asInstanceOf[Stream[F2, Stream[F2, O2]]]
 
-    val fstream: F2[Stream[F2, O2]] = for {
-      done <- SignallingRef(None: Option[Option[Throwable]])
-      available <- Semaphore(maxOpen.toLong)
-      // starts with 1 because the outer stream is running by default
-      running <- SignallingRef(1)
-      // a queue where inner fibers can enqueue themselves so that their eventual result can be sequenced
-      // this helps with sequencing of short-circuiting monad transformers such as `OptionT` and `EitherT`
-      // a note on how the queues are closed after using:
-      // after exhausting all forked streams, or in the case of an error, the `stop` method is called which
-      // sets the `done` ref. This in turn interrupts all forked fibers, which causes them to enqueue themselves
-      // on the `fibers` queue. After the last running fiber has enqueued itself, it will close the `fibers`
-      // queue. After the `fibers` queue has been exhausted by the `fiberJoiner`, it will close the `outputQ` queue.
-      fibers <- Queue.noneTerminated[F2, Fiber[F2, Unit]]
-      // sync queue assures we won't overload heap when resulting stream is not able to catchup with inner streams
-      outputQ <- Queue.synchronousNoneTerminated[F2, Chunk[O2]]
-    } yield {
-      // stops the stream evaluation and combines multiple failures
-      def stop(rslt: Option[Throwable]): F2[Unit] =
-        done.update {
-          case rslt0 @ Some(Some(err0)) =>
-            rslt.fold[Option[Option[Throwable]]](rslt0) { err =>
-              Some(Some(CompositeFailure(err0, err)))
-            }
-          case _ => Some(rslt)
-        }
+    if (maxOpen === 1) outer.flatten
+    else {
 
-      val incrementRunning: F2[Unit] = running.update(_ + 1)
+      val fstream: F2[Stream[F2, O2]] = for {
+        done <- SignallingRef(None: Option[Option[Throwable]])
+        available <- Semaphore(maxOpen.toLong)
+        // starts with 1 because the outer stream is running by default
+        running <- SignallingRef(1)
+        // a queue where inner fibers can enqueue themselves so that their eventual result can be sequenced
+        // this helps with sequencing of short-circuiting monad transformers such as `OptionT` and `EitherT`
+        // a note on how the queues are closed after using:
+        // after exhausting all forked streams, or in the case of an error, the `stop` method is called which
+        // sets the `done` ref. This in turn interrupts all forked fibers, which causes them to enqueue themselves
+        // on the `fibers` queue. After the last running fiber has enqueued itself, it will close the `fibers`
+        // queue. After the `fibers` queue has been exhausted by the `fiberJoiner`, it will close the `outputQ` queue.
+        fibers <- Queue.noneTerminated[F2, Fiber[F2, Unit]]
+        // sync queue assures we won't overload heap when resulting stream is not able to catchup with inner streams
+        outputQ <- Queue.synchronousNoneTerminated[F2, Chunk[O2]]
+      } yield {
+        // stops the stream evaluation and combines multiple failures
+        def stop(rslt: Option[Throwable]): F2[Unit] =
+          done.update {
+            case rslt0 @ Some(Some(err0)) =>
+              rslt.fold[Option[Option[Throwable]]](rslt0) { err =>
+                Some(Some(CompositeFailure(err0, err)))
+              }
+            case _ => Some(rslt)
+          }
 
-      // the last fiber closes the `fibers` queue after enqueueing itself
-      val decrementRunning: F2[Unit] =
-        running
-          .updateAndGet(_ - 1)
-          .flatMap(now => if (now == 0) fibers.enqueue1(None) else F2.unit)
+        val incrementRunning: F2[Unit] = running.update(_ + 1)
 
-      // "block" and await until the `running` counter drops to zero.
-      val awaitWhileRunning: F2[Unit] = running.discrete.dropWhile(_ > 0).take(1).compile.drain
+        // the last fiber closes the `fibers` queue after enqueueing itself
+        val decrementRunning: F2[Unit] =
+          running
+            .updateAndGet(_ - 1)
+            .flatMap(now => if (now == 0) fibers.enqueue1(None) else F2.unit)
 
-      // runs one inner stream,
-      // each stream is forked.
-      // terminates when killSignal is true
-      // failures will be propagated through `done` Signal
-      // note that supplied scope's resources must be leased before the inner stream forks the execution to another thread
-      // and that it must be released once the inner stream terminates or fails.
-      def runInner(inner: Stream[F2, O2], outerScope: Scope[F2]): F2[Unit] =
-        F2.uncancelable {
-          outerScope.lease
-            .flatMap[Scope.Lease[F2]] {
-              case Some(lease) => lease.pure[F2]
-              case None =>
-                F2.raiseError(
-                  new Throwable("Outer scope is closed during inner stream startup")
-                )
-            }
-            .flatTap(_ => available.acquire >> incrementRunning)
-            .flatMap { lease =>
-              // a trick for obtaining the the current fiber from inside the fiber itself
-              Deferred[F2, Fiber[F2, Unit]].flatMap { fiberDef =>
+        // "block" and await until the `running` counter drops to zero.
+        val awaitWhileRunning: F2[Unit] = running.discrete.dropWhile(_ > 0).take(1).compile.drain
+
+        // runs one inner stream,
+        // each stream is forked.
+        // terminates when killSignal is true
+        // failures will be propagated through `done` Signal
+        // note that supplied scope's resources must be leased before the inner stream forks the execution to another thread
+        // and that it must be released once the inner stream terminates or fails.
+        def runInner(inner: Stream[F2, O2], outerScope: Scope[F2]): F2[Unit] =
+          F2.uncancelable {
+            outerScope.lease
+              .flatMap[Scope.Lease[F2]] {
+                case Some(lease) => lease.pure[F2]
+                case None =>
+                  F2.raiseError(
+                    new Throwable("Outer scope is closed during inner stream startup")
+                  )
+              }
+              .flatTap(_ => available.acquire >> incrementRunning)
+              .flatMap { lease =>
+                // a trick for obtaining the the current fiber from inside the fiber itself
+                Deferred[F2, Fiber[F2, Unit]].flatMap { fiberDef =>
+                  F2.start {
+                    inner.chunks
+                      .evalMap(s => outputQ.enqueue1(Some(s)))
+                      .interruptWhen(
+                        done.map(_.nonEmpty)
+                      ) // must be AFTER enqueue to the sync queue, otherwise the process may hang to enqueue last item while being interrupted
+                      .compile
+                      .drain
+                      .guaranteeCase { oc =>
+                        val runResult = oc match {
+                          case ExitCase.Error(t) => Left(t)
+                          case _                 => Right(())
+                        }
+
+                        lease.cancel.flatMap { cancelResult =>
+                          (CompositeFailure.fromResults(runResult, cancelResult) match {
+                            case Right(()) =>
+                              // the fiber enqueues itself after completing, notice that we're executing in `guaranteeCase`
+                              fiberDef.get.flatMap(f => fibers.enqueue1(Some(f)))
+                            case Left(err) =>
+                              // an error has been raised, signal to other fibers that they need to interrupt
+                              stop(Some(err))
+                          })
+                        } >> (available.release >> decrementRunning) // the inner fiber is done and deregisters
+                      }
+                      .attempt
+                      .void
+                  }.flatMap(fiberDef.complete)
+                }
+              }
+          }
+
+        def runOuter: F2[Unit] =
+          F2.uncancelable {
+            Deferred[F2, Fiber[F2, Unit]]
+              .flatMap { fiberDef =>
                 F2.start {
-                  inner.chunks
-                    .evalMap(s => outputQ.enqueue1(Some(s)))
-                    .interruptWhen(
-                      done.map(_.nonEmpty)
-                    ) // must be AFTER enqueue to the sync queue, otherwise the process may hang to enqueue last item while being interrupted
+                  outer
+                    .flatMap(inner =>
+                      Stream.getScope[F2].evalMap(outerScope => runInner(inner, outerScope))
+                    )
+                    .interruptWhen(done.map(_.nonEmpty)) // stop forking inner fibers on error
                     .compile
                     .drain
-                    .guaranteeCase { oc =>
-                      val runResult = oc match {
-                        case ExitCase.Error(t) => Left(t)
-                        case _                 => Right(())
-                      }
-
-                      lease.cancel.flatMap { cancelResult =>
-                        (CompositeFailure.fromResults(runResult, cancelResult) match {
-                          case Right(()) =>
-                            // the fiber enqueues itself after completing, notice that we're executing in `guaranteeCase`
-                            fiberDef.get.flatMap(f => fibers.enqueue1(Some(f)))
-                          case Left(err) =>
-                            // an error has been raised, signal to other fibers that they need to interrupt
-                            stop(Some(err))
-                        })
-                      } >> (available.release >> decrementRunning) // the inner fiber is done and deregisters
+                    .guaranteeCase {
+                      case ExitCase.Error(t) =>
+                        // an error has been raised, signal to other fibers that they need to interrupt
+                        stop(Some(t)) >> decrementRunning
+                      case _ =>
+                        // the fiber enqueues itself after completing, notice that we're executing in `guaranteeCase`
+                        fiberDef.get.flatMap(f => fibers.enqueue1(Some(f))) >> decrementRunning
                     }
                     .attempt
                     .void
                 }.flatMap(fiberDef.complete)
               }
-            }
-        }
-
-      def runOuter: F2[Unit] =
-        F2.uncancelable {
-          Deferred[F2, Fiber[F2, Unit]]
-            .flatMap { fiberDef =>
-              F2.start {
-                outer
-                  .flatMap(inner =>
-                    Stream.getScope[F2].evalMap(outerScope => runInner(inner, outerScope))
-                  )
-                  .interruptWhen(done.map(_.nonEmpty)) // stop forking inner fibers on error
-                  .compile
-                  .drain
-                  .guaranteeCase {
-                    case ExitCase.Error(t) =>
-                      // an error has been raised, signal to other fibers that they need to interrupt
-                      stop(Some(t)) >> decrementRunning
-                    case _ =>
-                      // the fiber enqueues itself after completing, notice that we're executing in `guaranteeCase`
-                      fiberDef.get.flatMap(f => fibers.enqueue1(Some(f))) >> decrementRunning
-                  }
-                  .attempt
-                  .void
-              }.flatMap(fiberDef.complete)
-            }
-        }
-
-      def fiberJoiner: F2[Unit] =
-        fibers.dequeue
-          .evalMap(_.join) // join all fibers as they arrive
-          .compile
-          .drain
-          .guaranteeCase {
-            case ExitCase.Error(t) =>
-              // joining a fiber led to an error, announce that all fibers need to stop
-              stop(Some(t)) >> outputQ.enqueue1(None)
-            case _ =>
-              // after all fibers have been joined, close the output queue
-              stop(None) >> outputQ.enqueue1(None)
           }
-          .attempt
-          .void
 
-      // awaits when all streams (outer + inner) finished,
-      // and then collects result of the stream (outer + inner) execution
-      def signalResult(fiber: Fiber[F2, Unit]): F2[Unit] =
-        done.get.flatMap(_.flatten.fold[F2[Unit]](F2.unit)(F2.raiseError)).guarantee(fiber.join)
+        def fiberJoiner: F2[Unit] =
+          fibers.dequeue
+            .evalMap(_.join) // join all fibers as they arrive
+            .compile
+            .drain
+            .guaranteeCase {
+              case ExitCase.Error(t) =>
+                // joining a fiber led to an error, announce that all fibers need to stop
+                stop(Some(t)) >> outputQ.enqueue1(None)
+              case _ =>
+                // after all fibers have been joined, close the output queue
+                stop(None) >> outputQ.enqueue1(None)
+            }
+            .attempt
+            .void
 
-      Stream
-        .bracket(F2.start(runOuter) >> F2.start(fiberJoiner))(f =>
-          stop(None) >>
-            // in case of short-circuiting, the `fiberJoiner` would not have had a chance
-            // to wait until all fibers have been joined, so we need to do it manually
-            // by waiting on the counter
-            awaitWhileRunning >>
-            // join the `fiberJoiner` fiber to sequence the results of all inner fibers
-            // (sequences short-circuiting monad transformers)
-            signalResult(f)
-        ) >>
-        outputQ.dequeue
-          .flatMap(Stream.chunk(_).covary[F2])
+        // awaits when all streams (outer + inner) finished,
+        // and then collects result of the stream (outer + inner) execution
+        def signalResult(fiber: Fiber[F2, Unit]): F2[Unit] =
+          done.get.flatMap(_.flatten.fold[F2[Unit]](F2.unit)(F2.raiseError)).guarantee(fiber.join)
+
+        Stream
+          .bracket(F2.start(runOuter) >> F2.start(fiberJoiner))(f =>
+            stop(None) >>
+              // in case of short-circuiting, the `fiberJoiner` would not have had a chance
+              // to wait until all fibers have been joined, so we need to do it manually
+              // by waiting on the counter
+              awaitWhileRunning >>
+              // join the `fiberJoiner` fiber to sequence the results of all inner fibers
+              // (sequences short-circuiting monad transformers)
+              signalResult(f)
+          ) >>
+          outputQ.dequeue
+            .flatMap(Stream.chunk(_).covary[F2])
+      }
+
+      Stream.eval(fstream).flatten
     }
-
-    Stream.eval(fstream).flatten
   }
 
   /** Like [[parJoin]] but races all inner streams simultaneously. */

--- a/core/shared/src/test/scala/fs2/StreamParJoinSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamParJoinSuite.scala
@@ -23,10 +23,13 @@ package fs2
 
 import scala.concurrent.duration._
 
+import cats.data.{EitherT, OptionT}
 import cats.effect.IO
 import cats.effect.concurrent.{Deferred, Ref}
 import cats.syntax.all._
 import org.scalacheck.effect.PropF.forAllF
+
+import scala.util.control.NoStackTrace
 
 class StreamParJoinSuite extends Fs2Suite {
   test("no concurrency") {
@@ -37,7 +40,7 @@ class StreamParJoinSuite extends Fs2Suite {
         .parJoin(1)
         .compile
         .toList
-        .map(it => assert(it.toSet == expected))
+        .map(it => assertEquals(it.toSet, expected))
     }
   }
 
@@ -50,7 +53,7 @@ class StreamParJoinSuite extends Fs2Suite {
         .parJoin(n)
         .compile
         .toList
-        .map(it => assert(it.toSet == expected))
+        .map(it => assertEquals(it.toSet, expected))
     }
   }
 
@@ -63,7 +66,7 @@ class StreamParJoinSuite extends Fs2Suite {
         .parJoin(n)
         .compile
         .toList
-        .map(it => assert(it.toSet == expected))
+        .map(it => assertEquals(it.toSet, expected))
     }
   }
 
@@ -71,7 +74,7 @@ class StreamParJoinSuite extends Fs2Suite {
     forAllF { (s1: Stream[Pure, Int], s2: Stream[Pure, Int]) =>
       val parJoined = Stream(s1.covary[IO], s2).parJoin(2).compile.toList.map(_.toSet)
       val merged = s1.covary[IO].merge(s2).compile.toList.map(_.toSet)
-      (parJoined, merged).tupled.map { case (pj, m) => assert(pj == m) }
+      (parJoined, merged).tupled.map { case (pj, m) => assertEquals(pj, m) }
     }
   }
 
@@ -129,10 +132,10 @@ class StreamParJoinSuite extends Fs2Suite {
                       val expectedFinalizers = streamRunned.map { idx =>
                         s"Inner $idx"
                       } :+ "Outer"
-                      assert(finalizers.toSet == expectedFinalizers.toSet)
-                      assert(finalizers.lastOption == Some("Outer"))
-                      if (streamRunned.contains(biasIdx)) assert(r == Left(err))
-                      else assert(r == Right(()))
+                      assertEquals(finalizers.toSet, expectedFinalizers.toSet)
+                      assertEquals(finalizers.lastOption, Some("Outer"))
+                      if (streamRunned.contains(biasIdx)) assertEquals(r, Left(err))
+                      else assertEquals(r, Right(()))
                     }
                   }
                 }
@@ -158,7 +161,7 @@ class StreamParJoinSuite extends Fs2Suite {
         .take(1)
         .compile
         .toList
-        .map(it => assert(it == List(42)))
+        .map(it => assertEquals(it, List(42)))
     }
     test("2") {
       Stream(full, hang2)
@@ -166,7 +169,7 @@ class StreamParJoinSuite extends Fs2Suite {
         .take(1)
         .compile
         .toList
-        .map(it => assert(it == List(42)))
+        .map(it => assertEquals(it, List(42)))
     }
     test("3") {
       Stream(full, hang3)
@@ -174,7 +177,7 @@ class StreamParJoinSuite extends Fs2Suite {
         .take(1)
         .compile
         .toList
-        .map(it => assert(it == List(42)))
+        .map(it => assertEquals(it, List(42)))
     }
     test("4") {
       Stream(hang3, hang2, full)
@@ -182,7 +185,7 @@ class StreamParJoinSuite extends Fs2Suite {
         .take(1)
         .compile
         .toList
-        .map(it => assert(it == List(42)))
+        .map(it => assertEquals(it, List(42)))
     }
   }
 
@@ -200,6 +203,94 @@ class StreamParJoinSuite extends Fs2Suite {
     (Stream
       .emit(Stream.raiseError[IO](err))
       .parJoinUnbounded ++ Stream.emit(1)).compile.toList.attempt
-      .map(it => assert(it == Left(err)))
+      .map(it => assertEquals(it, Left(err)))
+  }
+
+  group("short-circuiting transformers") {
+    test("do not block while evaluating a stream of streams in IO in parallel") {
+      def f(n: Int): Stream[IO, String] = Stream(n).map(_.toString)
+
+      Stream(1, 2, 3)
+        .map(f)
+        .parJoinUnbounded
+        .compile
+        .toList
+        .map(_.toSet)
+        .flatMap { actual =>
+          IO(assertEquals(actual, Set("1", "2", "3")))
+        }
+    }
+
+    test(
+      "do not block while evaluating a stream of streams in EitherT[IO, Throwable, *] in parallel - right"
+    ) {
+      def f(n: Int): Stream[EitherT[IO, Throwable, *], String] = Stream(n).map(_.toString)
+
+      Stream(1, 2, 3)
+        .map(f)
+        .parJoinUnbounded
+        .compile
+        .toList
+        .map(_.toSet)
+        .value
+        .flatMap { actual =>
+          IO(assertEquals(actual, Right(Set("1", "2", "3"))))
+        }
+    }
+
+    test(
+      "do not block while evaluating a stream of streams in EitherT[IO, Throwable, *] in parallel - left"
+    ) {
+      case object TestException extends Throwable with NoStackTrace
+
+      def f(n: Int): Stream[EitherT[IO, Throwable, *], String] =
+        if (n % 2 != 0) Stream(n).map(_.toString)
+        else Stream.eval[EitherT[IO, Throwable, *], String](EitherT.leftT(TestException))
+
+      Stream(1, 2, 3)
+        .map(f)
+        .parJoinUnbounded
+        .compile
+        .toList
+        .value
+        .flatMap { actual =>
+          IO(assertEquals(actual, Left(TestException)))
+        }
+    }
+
+    test(
+      "do not block while evaluating a stream of streams in OptionT[IO, *] in parallel - some"
+    ) {
+      def f(n: Int): Stream[OptionT[IO, *], String] = Stream(n).map(_.toString)
+
+      Stream(1, 2, 3)
+        .map(f)
+        .parJoinUnbounded
+        .compile
+        .toList
+        .map(_.toSet)
+        .value
+        .flatMap { actual =>
+          IO(assertEquals(actual, Some(Set("1", "2", "3"))))
+        }
+    }
+
+    test(
+      "do not block while evaluating a stream of streams in OptionT[IO, *] in parallel - none"
+    ) {
+      def f(n: Int): Stream[OptionT[IO, *], String] =
+        if (n % 2 != 0) Stream(n).map(_.toString)
+        else Stream.eval[OptionT[IO, *], String](OptionT.none)
+
+      Stream(1, 2, 3)
+        .map(f)
+        .parJoinUnbounded
+        .compile
+        .toList
+        .value
+        .flatMap { actual =>
+          IO(assertEquals(actual, None))
+        }
+    }
   }
 }


### PR DESCRIPTION
Resolves #1945.

The memory leak tests seem happy, I ran the CI many times yesterday and this morning.

I will follow this up with a PR that fixes this issue on `main`. It should be even simpler given that Cats Effect 3 has support for the `Outcome` in `guaranteeCase`, which we can use to sequence short-circuiting monad transformers.