### PR TITLE
Make internal method `private[TLSParameters]`

### DIFF
--- a/io/js/src/main/scala/fs2/io/net/tls/TLSParameters.scala
+++ b/io/js/src/main/scala/fs2/io/net/tls/TLSParameters.scala
@@ -129,7 +129,7 @@ object TLSParameters {
 
   trait SNICallback {
     def apply[F[_]: Async](servername: String): F[Either[Throwable, Option[SecureContext]]]
-    def toJS[F[_]](dispatcher: Dispatcher[F])(implicit
+    private[TLSParameters] def toJS[F[_]](dispatcher: Dispatcher[F])(implicit
         F: Async[F]
     ): js.Function2[String, js.Function2[js.Error | Null, tlsMod.SecureContext, Unit], Unit] = {
       (servername, cb) =>


### PR DESCRIPTION
This one slipped through the cracks, hope it's okay to make this change.