### PR TITLE
Tweak Node.js server to be more idiomatic

### DIFF
--- a/io/js/src/main/scala/fs2/io/net/SocketGroupPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/SocketGroupPlatform.scala
@@ -33,6 +33,7 @@ import com.comcast.ip4s.Host
 import com.comcast.ip4s.IpAddress
 import com.comcast.ip4s.Port
 import com.comcast.ip4s.SocketAddress
+import fs2.internal.jsdeps.node.eventsMod
 import fs2.internal.jsdeps.node.netMod
 import fs2.internal.jsdeps.node.nodeStrings
 import fs2.io.internal.EventEmitterOps._
@@ -80,14 +81,13 @@ private[net] trait SocketGroupCompanionPlatform { self: SocketGroup.type =>
     ): Resource[F, (SocketAddress[IpAddress], Stream[F, Socket[F]])] =
       (for {
         dispatcher <- Dispatcher[F]
-        queue <- Queue.unbounded[F, netMod.Socket].toResource
-        error <- F.deferred[Throwable].toResource
+        queue <- Queue.unbounded[F, Option[netMod.Socket]].toResource
         server <- Resource.make(
           F
             .delay(
               netMod.createServer(
                 netMod.ServerOpts().setPauseOnConnect(true).setAllowHalfOpen(true),
-                sock => dispatcher.unsafeRunAndForget(queue.offer(sock))
+                sock => dispatcher.unsafeRunAndForget(queue.offer(Some(sock)))
               )
             )
         )(server =>
@@ -96,24 +96,21 @@ private[net] trait SocketGroupCompanionPlatform { self: SocketGroup.type =>
               server.close(e => cb(e.toLeft(()).leftMap(js.JavaScriptException)))
             else
               cb(Right(()))
-          }
+          } >> queue.offer(None)
         )
-        _ <- registerListener[js.Error](server, nodeStrings.error)(_.once_error(_, _)) { e =>
-          dispatcher.unsafeRunAndForget(error.complete(js.JavaScriptException(e)))
-        }
-        _ <- error.get
-          .race(
-            F
-              .async_[Unit] { cb =>
-                server.listen(
-                  address.foldLeft(
-                    netMod.ListenOptions().setPort(port.fold(0.0)(_.value.toDouble))
-                  )((opts, host) => opts.setHost(host.toString)),
-                  () => cb(Right(()))
-                )
+        _ <- F
+          .async_[Unit] { cb =>
+            server.once_error(nodeStrings.error, e => cb(Left(js.JavaScriptException(e))))
+            server.listen(
+              address.foldLeft(
+                netMod.ListenOptions().setPort(port.fold(0.0)(_.value.toDouble))
+              )((opts, host) => opts.setHost(host.toString)),
+              () => {
+                server.asInstanceOf[eventsMod.EventEmitter].removeAllListeners("error")
+                cb(Right(()))
               }
-          )
-          .rethrow
+            )
+          }
           .toResource
         ipAddress <- F
           .delay(server.address())
@@ -123,10 +120,9 @@ private[net] trait SocketGroupCompanionPlatform { self: SocketGroup.type =>
           }
           .toResource
         sockets = Stream
-          .fromQueueUnterminated(queue)
+          .fromQueueNoneTerminated(queue)
           .evalTap(setSocketOptions(options))
           .flatMap(sock => Stream.resource(Socket.forAsync(sock)))
-          .concurrently(Stream.eval(error.get.flatMap(F.raiseError[Unit])))
       } yield (ipAddress, sockets)).adaptError { case IOException(ex) => ex }
 
   }


### PR DESCRIPTION
Just some minor tweaking to make the code a bit nicer.

More importantly, I think this suffers from same/similar problems as #2300, namely: how do you gracefully shutdown/handle errors? The critical thing seems to be that any sockets remaining in the queue should be destroyed.

Perhaps I'm missing something, but it seems to me that the problem lies with the `server` method. With the `serverResource` method, I can conceptualize the "listening" part of the server being tied to the resource, so that even after the resource is closed the stream of sockets is still usable. But maybe this is leaky?

cc @RaasAhsan 