### PR TITLE
Added the scala docs API links on the main site. This should fix the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ FS2: Functional Streams for Scala
 
 [![Continuous Integration](https://github.com/functional-streams-for-scala/fs2/workflows/Continuous%20Integration/badge.svg)](https://github.com/functional-streams-for-scala/fs2/actions?query=workflow%3A%22Continuous+Integration%22)
 [![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/9V8FZTVZ9R)
-[![Maven Central](https://img.shields.io/maven-central/v/co.fs2/fs2-core_2.12)](https://maven-badges.herokuapp.com/maven-central/co.fs2/fs2-core_2.12)
+[![Maven Central](https://img.shields.io/maven-central/v/co.fs2/fs2-core_2.13)](https://maven-badges.herokuapp.com/maven-central/co.fs2/fs2-core_2.13)
 
 ### Overview
 
@@ -29,9 +29,9 @@ Quick links:
 * [Docs and getting help](#docs)
 
 [microsite]: http://fs2.io
-[core-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.12/3.0.4/fs2-core_2.12-3.0.4-javadoc.jar/!/fs2/index.html
-[io-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.12/3.0.4/fs2-io_2.12-3.0.4-javadoc.jar/!/fs2/io/index.html
-[rx-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.12/3.0.4/fs2-reactive-streams_2.12-3.0.4-javadoc.jar/!/fs2/interop/reactivestreams/index.html
+[core-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.13/3.1.0/fs2-core_2.13-3.1.0-javadoc.jar/!/fs2/index.html
+[io-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.13/3.1.0/fs2-io_2.13-3.1.0-javadoc.jar/!/fs2/io/index.html
+[rx-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.13/3.1.0/fs2-reactive-streams_2.13-3.1.0-javadoc.jar/!/fs2/interop/reactivestreams/index.html
 
 ### <a id="docs"></a>Documentation and getting help ###
 

--- a/site/_sidebar.md
+++ b/site/_sidebar.md
@@ -5,6 +5,7 @@
 - [Guide](guide.md)
 - [Concurrency Primitives](concurrency-primitives.md)
 - [I/O](io.md)
+- [API Reference](api-reference.md)
 - [FAQ](faq.md)
 - [Documentation](documentation.md)
 - [Adopters](adopters.md)

--- a/site/api-reference.md
+++ b/site/api-reference.md
@@ -1,0 +1,20 @@
+# API Reference
+
+###Cats Effect 3:
+
+* [fs2-core][core-api-v3]
+* [fs2-io][io-api-v3]
+* [fs2-reactive-streams][rx-api-v3]
+
+###Cats Effect 2:
+
+* [fs2-core][core-api-v2]
+* [fs2-io][io-api-v2]
+* [fs2-reactive-streams][rx-api-v2]
+
+[core-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.13/3.1.0/fs2-core_2.13-3.1.0-javadoc.jar/!/fs2/index.html
+[io-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.13/3.1.0/fs2-io_2.13-3.1.0-javadoc.jar/!/fs2/io/index.html
+[rx-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.13/3.1.0/fs2-reactive-streams_2.13-3.1.0-javadoc.jar/!/fs2/interop/reactivestreams/index.html
+[core-api-v2]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.13/2.5.9/fs2-core_2.13-2.5.9-javadoc.jar/!/fs2/index.html
+[io-api-v2]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.13/2.5.9/fs2-io_2.13-2.5.9-javadoc.jar/!/fs2/io/index.html
+[rx-api-v2]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.13/2.5.9/fs2-reactive-streams_2.13-2.5.9-javadoc.jar/!/fs2/interop/reactivestreams/index.html

--- a/site/getstarted/install.md
+++ b/site/getstarted/install.md
@@ -1,6 +1,6 @@
 # Install
 
-The latest version for Cats Effect 3 is `3.0.6`, which supports Cats Effect 3 and is cross built for Scala 2.12, 2.13, and 3.0.
+The latest version for Cats Effect 3 is `3.1.0`, which supports Cats Effect 3 and is cross built for Scala 2.12, 2.13, and 3.0.
 
 The latest version for Cats Effect 2 is `2.5.9`, which supports Cats Effect 2 and is similarly cross built for various Scala versions.
 


### PR DESCRIPTION
Resolves #2356

This is attempt to fix the documentation issue #2356. I have tested the links for both v3 and v2 and they seam to work as expected. I also made a small change to point to scala 2.13 artifacts as that would be most relevant for many users at this time.

The Page looks like this:

![image](https://user-images.githubusercontent.com/4037044/129274397-e1c95c2d-4a2a-48bd-989f-7d6ba8bc0993.png)
