### PR TITLE
Pull: compile MapOutput with a runner.

### DIFF
--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -262,4 +262,9 @@ class MemoryLeakSpec extends FunSuite {
       .constant(())
       .broadcastThrough(pipe)
   }
+
+  leakTest("eval + flatMap + map (2)") {
+    def unfold: Stream[IO, Unit] = Stream.eval(IO.unit).flatMap(_ => Stream.emits(Nil) ++ unfold)
+    unfold.map(x => x)
+  }
 }


### PR DESCRIPTION
The compilation of `MapOutput` is the only remaining `Pull` subclass that is compiled by "rewriting" the `MapOutput`, which is to say by reducing the `Pull` object to another `Pull` object, in the `innerMapOutput` auxiliary method.

To remove this last "rewrite" logic, we introduce a new `MapOutR`, a subclass of Runner for the MapOutput object. We remove the innterMapOutout rewrite method.

Add leak test for bug in typelevel#2569