### PR TITLE
Special case for `parEvalMap` with max concurrency of 1

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2014,38 +2014,40 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     */
   def parEvalMap[F2[x] >: F[x], O2](
       maxConcurrent: Int
-  )(f: O => F2[O2])(implicit F: Concurrent[F2]): Stream[F2, O2] = {
-    val fstream: F2[Stream[F2, O2]] = for {
-      chan <- Channel.bounded[F2, F2[Either[Throwable, O2]]](maxConcurrent)
-      chanReadDone <- F.deferred[Unit]
-    } yield {
-      def forkOnElem(o: O): F2[Stream[F2, Unit]] =
-        for {
-          value <- F.deferred[Either[Throwable, O2]]
-          send = chan.send(value.get).as {
-            Stream.eval(f(o).attempt.flatMap(value.complete(_).void))
+  )(f: O => F2[O2])(implicit F: Concurrent[F2]): Stream[F2, O2] =
+    if (maxConcurrent === 1) evalMap(f)
+    else {
+      val fstream: F2[Stream[F2, O2]] = for {
+        chan <- Channel.bounded[F2, F2[Either[Throwable, O2]]](maxConcurrent)
+        chanReadDone <- F.deferred[Unit]
+      } yield {
+        def forkOnElem(o: O): F2[Stream[F2, Unit]] =
+          for {
+            value <- F.deferred[Either[Throwable, O2]]
+            send = chan.send(value.get).as {
+              Stream.eval(f(o).attempt.flatMap(value.complete(_).void))
+            }
+            eit <- chanReadDone.get.race(send)
+          } yield eit match {
+            case Left(())      => Stream.empty
+            case Right(stream) => stream
           }
-          eit <- chanReadDone.get.race(send)
-        } yield eit match {
-          case Left(())      => Stream.empty
-          case Right(stream) => stream
-        }
 
-      val background = this
-        .evalMap(forkOnElem)
-        .parJoin(maxConcurrent)
-        .onFinalize(chanReadDone.get.race(chan.close).void)
+        val background = this
+          .evalMap(forkOnElem)
+          .parJoin(maxConcurrent)
+          .onFinalize(chanReadDone.get.race(chan.close).void)
 
-      val foreground =
-        chan.stream
-          .evalMap(identity)
-          .rethrow
-          .onFinalize(chanReadDone.complete(()).void)
+        val foreground =
+          chan.stream
+            .evalMap(identity)
+            .rethrow
+            .onFinalize(chanReadDone.complete(()).void)
 
-      foreground.concurrently(background)
+        foreground.concurrently(background)
+      }
+      Stream.eval(fstream).flatten
     }
-    Stream.eval(fstream).flatten
-  }
 
   /** Like [[Stream#evalMap]], but will evaluate effects in parallel, emitting the results
     * downstream. The number of concurrent effects is limited by the `maxConcurrent` parameter.


### PR DESCRIPTION
This avoids the penalty of using the combinator if there is no
concurrency. Analogous to #2557 which did the same for `parJoin`.
