### PR TITLE
Introduce `fs2.io.ClosedChannelException`

### DIFF
--- a/io/js/src/main/scala/fs2/io/IOException.scala
+++ b/io/js/src/main/scala/fs2/io/IOException.scala
@@ -38,3 +38,5 @@ object IOException {
       .orElse(FileSystemException.unapply(cause))
       .orElse(UnknownHostException.unapply(cause))
 }
+
+class ClosedChannelException extends IOException

--- a/io/jvm/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/ioplatform.scala
@@ -31,6 +31,7 @@ import fs2.io.internal.PipedStreamBuffer
 import java.io.{InputStream, OutputStream}
 
 private[fs2] trait ioplatform {
+  type ClosedChannelException = java.nio.channels.ClosedChannelException
 
   /** Pipe that converts a stream of bytes to a stream that will emit a single `java.io.InputStream`,
     * that is closed whenever the resulting stream terminates.

--- a/io/jvm/src/main/scala/fs2/io/net/AsynchronousDatagramSocketGroup.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/AsynchronousDatagramSocketGroup.scala
@@ -27,7 +27,6 @@ import java.net.InetSocketAddress
 import java.nio.{Buffer, ByteBuffer}
 import java.nio.channels.{
   CancelledKeyException,
-  ClosedChannelException,
   DatagramChannel,
   SelectionKey,
   Selector

--- a/io/jvm/src/main/scala/fs2/io/net/AsynchronousDatagramSocketGroup.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/AsynchronousDatagramSocketGroup.scala
@@ -25,12 +25,7 @@ package net
 
 import java.net.InetSocketAddress
 import java.nio.{Buffer, ByteBuffer}
-import java.nio.channels.{
-  CancelledKeyException,
-  DatagramChannel,
-  SelectionKey,
-  Selector
-}
+import java.nio.channels.{CancelledKeyException, DatagramChannel, SelectionKey, Selector}
 import java.util.ArrayDeque
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
 import java.util.concurrent.atomic.AtomicLong

--- a/io/jvm/src/main/scala/fs2/io/net/DatagramSocketGroupPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/DatagramSocketGroupPlatform.scala
@@ -24,7 +24,7 @@ package io
 package net
 
 import java.net.{InetSocketAddress, NetworkInterface}
-import java.nio.channels.{ClosedChannelException, DatagramChannel}
+import java.nio.channels.DatagramChannel
 
 import cats.effect.kernel.{Async, Resource}
 import cats.syntax.all._


### PR DESCRIPTION
This came up in https://github.com/http4s/http4s/pull/5065#issuecomment-908288405. cc @rossabaker 

Note that I have no idea what the equivalent error type is on Node.js, so this will never be thrown "natively" on JS. But, it is useful for throwing manually as is the case in http4s.