### PR TITLE
Update docs for 3.1.1 + improve formatting on API reference page

### DIFF
--- a/site/api-reference.md
+++ b/site/api-reference.md
@@ -1,14 +1,14 @@
 # API Reference
 
-### FS2 3.1.0 (Cats Effect 3)
+### FS2 3.1.1 (Cats Effect 3)
 
 * [fs2-core][core-api-v3]
 * [fs2-io][io-api-v3]
 * [fs2-reactive-streams][rx-api-v3]
 
-[core-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.13/3.1.0/fs2-core_2.13-3.1.0-javadoc.jar/!/fs2/index.html
-[io-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.13/3.1.0/fs2-io_2.13-3.1.0-javadoc.jar/!/fs2/io/index.html
-[rx-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.13/3.1.0/fs2-reactive-streams_2.13-3.1.0-javadoc.jar/!/fs2/interop/reactivestreams/index.html
+[core-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.13/3.1.1/fs2-core_2.13-3.1.1-javadoc.jar/!/fs2/index.html
+[io-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.13/3.1.1/fs2-io_2.13-3.1.1-javadoc.jar/!/fs2/io/index.html
+[rx-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.13/3.1.1/fs2-reactive-streams_2.13-3.1.1-javadoc.jar/!/fs2/interop/reactivestreams/index.html
 
 ### FS2 2.5.9 (Cats Effect 2)
 

--- a/site/api-reference.md
+++ b/site/api-reference.md
@@ -1,20 +1,21 @@
 # API Reference
 
-###Cats Effect 3:
+### FS2 3.1.0 (Cats Effect 3)
 
 * [fs2-core][core-api-v3]
 * [fs2-io][io-api-v3]
 * [fs2-reactive-streams][rx-api-v3]
 
-###Cats Effect 2:
+[core-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.13/3.1.0/fs2-core_2.13-3.1.0-javadoc.jar/!/fs2/index.html
+[io-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.13/3.1.0/fs2-io_2.13-3.1.0-javadoc.jar/!/fs2/io/index.html
+[rx-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.13/3.1.0/fs2-reactive-streams_2.13-3.1.0-javadoc.jar/!/fs2/interop/reactivestreams/index.html
+
+### FS2 2.5.9 (Cats Effect 2)
 
 * [fs2-core][core-api-v2]
 * [fs2-io][io-api-v2]
 * [fs2-reactive-streams][rx-api-v2]
 
-[core-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.13/3.1.0/fs2-core_2.13-3.1.0-javadoc.jar/!/fs2/index.html
-[io-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.13/3.1.0/fs2-io_2.13-3.1.0-javadoc.jar/!/fs2/io/index.html
-[rx-api-v3]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.13/3.1.0/fs2-reactive-streams_2.13-3.1.0-javadoc.jar/!/fs2/interop/reactivestreams/index.html
 [core-api-v2]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.13/2.5.9/fs2-core_2.13-2.5.9-javadoc.jar/!/fs2/index.html
 [io-api-v2]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.13/2.5.9/fs2-io_2.13-2.5.9-javadoc.jar/!/fs2/io/index.html
 [rx-api-v2]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.13/2.5.9/fs2-reactive-streams_2.13-2.5.9-javadoc.jar/!/fs2/interop/reactivestreams/index.html

--- a/site/getstarted/install.md
+++ b/site/getstarted/install.md
@@ -1,6 +1,6 @@
 # Install
 
-The latest version for Cats Effect 3 is `3.1.0`, which supports Cats Effect 3 and is cross built for Scala 2.12, 2.13, and 3.0.
+The latest version for Cats Effect 3 is `3.1.1`, which supports Cats Effect 3 and is cross built for Scala 2.12, 2.13, and 3.0.
 
 The latest version for Cats Effect 2 is `2.5.9`, which supports Cats Effect 2 and is similarly cross built for various Scala versions.
 


### PR DESCRIPTION
This patch improves the formatting on the API reference page and updates links and references for FS2 3.1.1.

| Current | Proposed |
| - | - |
| <img width="385" alt="image" src="https://user-images.githubusercontent.com/4206232/131611572-caaf4414-dc14-4b80-bb12-a3b52f573c7e.png"> | <img width="385" alt="image" src="https://user-images.githubusercontent.com/4206232/131611511-1fb82251-f1b0-45c2-8268-5e5c12d686c7.png">

