### PR TITLE
Add reproduction case of leak with merge+parJoinUnbounded

### DIFF
--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -268,7 +268,11 @@ class MemoryLeakSpec extends FunSuite {
     unfold.map(x => x)
   }
 
-  leakTest("merge + parJoinUnbounded".only) {
+  leakTest("merge + parJoinUnbounded") {
     Stream(Stream.constant(1).covary[IO].merge(Stream())).parJoinUnbounded
+  }
+
+  leakTest("flatMap(flatMap) then uncons".only) {
+    Stream.constant(1).flatMap(s => Stream(s, s).flatMap(s => Stream(s))).drain
   }
 }

--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -267,4 +267,8 @@ class MemoryLeakSpec extends FunSuite {
     def unfold: Stream[IO, Unit] = Stream.eval(IO.unit).flatMap(_ => Stream.emits(Nil) ++ unfold)
     unfold.map(x => x)
   }
+
+  leakTest("merge + parJoinUnbounded".only) {
+    Stream(Stream.constant(1).covary[IO].merge(Stream())).parJoinUnbounded
+  }
 }

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -978,13 +978,13 @@ object Pull extends PullLowPriority {
           else {
             def go(idx: Int): Pull[G, X, Unit] =
               if (idx == chunk.size)
-                FlatMapOutput[G, Y, X](tail, fun)
+                flatMapOutput[G, G, Y, X](tail, fun)
               else {
                 try transformWith(fun(chunk(idx))) {
                   case Succeeded(_) => go(idx + 1)
                   case Fail(err)    => Fail(err)
                   case interruption @ Interrupted(_, _) =>
-                    FlatMapOutput[G, Y, X](interruptBoundary(tail, interruption), fun)
+                    flatMapOutput[G, G, Y, X](interruptBoundary(tail, interruption), fun)
                 } catch { case NonFatal(e) => Fail(e) }
               }
 


### PR DESCRIPTION
Reproduction case for #2598.

Fails on 3.1.1 and 3.0.0 but passes on 2.5.9.