### PR TITLE
Issue-2598: Fix memory leaks and minimisations.

### DIFF
--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -271,4 +271,12 @@ class MemoryLeakSpec extends FunSuite {
   leakTest("flatMap(flatMap) then uncons") {
     Stream.constant(1).flatMap(s => Stream(s, s).flatMap(s => Stream(s))).drain
   }
+
+  leakTest("onFinalize + flatten + drain") {
+    Stream.constant(1).covary[IO].map(Stream(_).onFinalize(IO.unit)).flatten.drain
+  }
+
+  leakTest("merge + parJoinUnbounded") {
+    Stream(Stream.constant(1).covary[IO].merge(Stream())).parJoinUnbounded
+  }
 }

--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -267,4 +267,8 @@ class MemoryLeakSpec extends FunSuite {
     def unfold: Stream[IO, Unit] = Stream.eval(IO.unit).flatMap(_ => Stream.emits(Nil) ++ unfold)
     unfold.map(x => x)
   }
+
+  leakTest("flatMap(flatMap) then uncons") {
+    Stream.constant(1).flatMap(s => Stream(s, s).flatMap(s => Stream(s))).drain
+  }
 }

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -978,13 +978,13 @@ object Pull extends PullLowPriority {
           else {
             def go(idx: Int): Pull[G, X, Unit] =
               if (idx == chunk.size)
-                FlatMapOutput[G, Y, X](tail, fun)
+                flatMapOutput[G, G, Y, X](tail, fun)
               else {
                 try transformWith(fun(chunk(idx))) {
                   case Succeeded(_) => go(idx + 1)
                   case Fail(err)    => Fail(err)
                   case interruption @ Interrupted(_, _) =>
-                    FlatMapOutput[G, Y, X](interruptBoundary(tail, interruption), fun)
+                    flatMapOutput[G, G, Y, X](interruptBoundary(tail, interruption), fun)
                 } catch { case NonFatal(e) => Fail(e) }
               }
 

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -1187,7 +1187,7 @@ object Pull extends PullLowPriority {
               val v = view.asInstanceOf[Cont[Option[(Chunk[y], Pull[G, y, Unit])], G, X]]
               // a Uncons is run on the same scope, without shifting.
               val runr = new BuildR[G, y, End]
-              go(scope, extendedTopLevelScope, translation, runr, u.stream).attempt
+              F.unit >> go(scope, extendedTopLevelScope, translation, runr, u.stream).attempt
                 .flatMap(_.fold(goErr(_, view), _.apply(new UnconsRunR(v))))
 
             case s0: StepLeg[g, y] =>


### PR DESCRIPTION
From https://github.com/typelevel/fs2/issues/2598, we add a leak test for pure streams, one with flatMap and uncons, which does not involve parallelism.

We then make the changes in `pull` interpreter that would fix that specific leak test case.
