### PR TITLE
Make Compiler.Target extend MonadCancelThrow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,7 +145,13 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.Pull.mapOutput"),
   ProblemFilters.exclude[NewMixinForwarderProblem]("fs2.compression.Compression.gzip*"),
   ProblemFilters.exclude[NewMixinForwarderProblem]("fs2.compression.Compression.gunzip*"),
-  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.compression.Compression.$init$")
+  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.compression.Compression.$init$"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.Compiler#Target.F"),
+  ProblemFilters.exclude[MissingTypesProblem]("fs2.Compiler$Target$ConcurrentTarget"),
+  ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.Compiler#Target#ConcurrentTarget.F"),
+  ProblemFilters.exclude[MissingClassProblem]("fs2.Compiler$TargetLowPriority$MonadCancelTarget"),
+  ProblemFilters.exclude[MissingClassProblem]("fs2.Compiler$TargetLowPriority$MonadErrorTarget"),
+  ProblemFilters.exclude[MissingTypesProblem]("fs2.Compiler$TargetLowPriority$SyncTarget")
 )
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,8 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[NewMixinForwarderProblem]("fs2.io.net.Network.*"),
   ProblemFilters.exclude[NewMixinForwarderProblem]("fs2.io.net.tls.TLSContext.*"),
   ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.io.net.tls.TLSContext.*"),
+  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.Compiler#Target.*"),
+  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.Compiler#TargetLowPriority#MonadErrorTarget.*"),
   // end #2453
   ProblemFilters.exclude[NewMixinForwarderProblem]("fs2.io.file.Files.*"),
   ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.io.file.Files.*"),

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,9 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[NewMixinForwarderProblem]("fs2.io.net.tls.TLSContext.*"),
   ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.io.net.tls.TLSContext.*"),
   ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.Compiler#Target.*"),
-  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.Compiler#TargetLowPriority#MonadErrorTarget.*"),
+  ProblemFilters.exclude[InheritedNewAbstractMethodProblem](
+    "fs2.Compiler#TargetLowPriority#MonadErrorTarget.*"
+  ),
   // end #2453
   ProblemFilters.exclude[NewMixinForwarderProblem]("fs2.io.file.Files.*"),
   ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.io.file.Files.*"),


### PR DESCRIPTION
This is intended to facilitate using `Target` as a context bound when you need `MonadCancelThrow` but don't specifically need either `Sync` or `Concurrent`.