### PR TITLE
Pull - fix Translate bug.

### DIFF
--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -6,6 +6,7 @@ import scala.concurrent.duration._
 import java.lang.management.ManagementFactory
 import java.nio.file.{Files, Path}
 
+import cats.~>
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
@@ -270,6 +271,13 @@ class MemoryLeakSpec extends FunSuite {
 
   leakTest("flatMap(flatMap) then uncons") {
     Stream.constant(1).flatMap(s => Stream(s, s).flatMap(s => Stream(s))).drain
+  }
+
+  leakTest("map, flatMap, translate") {
+    val fk = new (Pure ~> IO) {
+      def apply[A](pa: Pure[A]): IO[A] = IO.pure(pa)
+    }
+    Stream.constant(1).translate(fk).flatMap(s => Stream(s, s).flatMap(s => Stream(s))).drain
   }
 
   leakTest("onFinalize + flatten + drain") {

--- a/core/shared/src/test/scala/fs2/StreamTranslateSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamTranslateSuite.scala
@@ -40,17 +40,18 @@ class StreamTranslateSuite extends Fs2Suite {
     }
   }
 
-  test("2") {
-    forAllF { (s: Stream[Pure, Int]) =>
-      val expected = s.toList
-      s.covary[Function0]
+  test("2 - Appending another stream after translation") {
+    forAllF { (s1: Stream[Pure, Int], s2: Stream[Pure, Int]) =>
+      val expected = (s1 ++ s2).toList
+      val translated: Stream[IO, Int] = s1
+        .covary[Function0]
         .flatMap(i => Stream.eval(() => i))
         .flatMap(i => Stream.eval(() => i))
         .translate(new (Function0 ~> IO) {
           def apply[A](thunk: Function0[A]) = IO(thunk())
         })
-        .compile
-        .toList
+
+      (translated ++ s2.covary[IO]).compile.toList
         .assertEquals(expected)
     }
   }


### PR DESCRIPTION
Looking at the translate method, I noticed that, strangely enough,  it was not using the `view` or continuation. This means that any stream after a Translate would be dropped. This was not detected because, in the `StreamTranslateSuite`, none of the unit/property tests was appending something after the translation. Along the way, we also add a leak test that uses translate, to cover that a little bit.

