### PR TITLE
Extend `broadcastThrough` documentation

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -202,7 +202,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     attempt ++ delays.flatMap(delay => Stream.sleep_(delay) ++ attempt)
 
   /** Feeds the values from this stream (source) to all the given pipes,
-    * which process them in parallel. and coordinates its progress.
+    * which process them in parallel, and coordinates their progress.
     *
     * The new stream has one instance of `this` stream (the source), from
     * which it pulls its outputs. To balance the progress amongst pipes and


### PR DESCRIPTION
Opened to address some of the inaccuracies discussed in #2600 

- Formulate the coordination condition as: "no pipe can pull and start processing any source chunk until after all pipes have pulled and started processing the previous chunk", which is a bit more accurate than "are done" 