### PR TITLE
parEvalMapUnordered performance

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ParEvalMapBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ParEvalMapBenchmark.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package benchmark
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.openjdk.jmh.annotations.{Benchmark, Param, Scope, State}
+
+@State(Scope.Thread)
+class ParEvalMapBenchmark {
+  @Param(Array("100", "10000"))
+  var size: Int = _
+
+  @Param(Array("10", "100"))
+  var chunkSize: Int = _
+
+  private def dummyLoad = IO.delay(())
+
+  @Benchmark
+  def evalMap(): Unit =
+    execute(getStream.evalMap(_ => dummyLoad))
+
+  @Benchmark
+  def parEvalMapUnordered10(): Unit =
+    execute(getStream.parEvalMapUnordered(10)(_ => dummyLoad))
+
+  private def getStream: Stream[IO, Unit] = Stream.constant((), chunkSize).take(size).covary[IO]
+  private def execute(s: Stream[IO, Unit]): Unit = s.compile.drain.unsafeRunSync()
+}

--- a/core/shared/src/main/scala/fs2/CompositeFailure.scala
+++ b/core/shared/src/main/scala/fs2/CompositeFailure.scala
@@ -59,6 +59,12 @@ object CompositeFailure {
     }
   }
 
+  def fromNel(errors: NonEmptyList[Throwable]): Throwable =
+    errors match {
+      case NonEmptyList(hd, Nil)               => hd
+      case NonEmptyList(first, second :: rest) => apply(first, second, rest)
+    }
+
   def fromList(errors: List[Throwable]): Option[Throwable] =
     errors match {
       case Nil                     => None

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1751,7 +1751,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   ]: Concurrent, O2](
       maxConcurrent: Int
   )(f: O => F2[O2]): Stream[F2, O2] =
-    map(o => Stream.eval(f(o))).parJoin(maxConcurrent)
+    parEvalMapUnordered[F2, O2](maxConcurrent)(f)
 
   /** Applies the specified pure function to each chunk in this stream.
     *


### PR DESCRIPTION
issue: https://github.com/typelevel/fs2/issues/2297

MR has three commits, the first one contains the implementation of parEvalMapUnordered
using queue. In the second one channel is used instead. Both show 4x performance boost in the benchmark.

Queue version can be backported to 2.x

<pre>
original
[info] Benchmark                                  (chunkSize)  (size)   Mode  Cnt      Score     Error  Units
[info] ParEvalMapBenchmark.evalMap                         10     100  thrpt    5  18371,696 ± 691,166  ops/s
[info] ParEvalMapBenchmark.evalMap                         10   10000  thrpt    5    268,572 ±  50,354  ops/s
[info] ParEvalMapBenchmark.evalMap                        100     100  thrpt    5  20519,182 ± 700,520  ops/s
[info] ParEvalMapBenchmark.evalMap                        100   10000  thrpt    5    327,894 ±  13,484  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10           10     100  thrpt    5    247,284 ±  13,961  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10           10   10000  thrpt    5      2,690 ±   0,216  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10          100     100  thrpt    5    243,230 ±  63,045  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10          100   10000  thrpt    5      2,514 ±   0,909  ops/s

queue
[info] Benchmark                                  (chunkSize)  (size)   Mode  Cnt      Score       Error  Units
[info] ParEvalMapBenchmark.evalMap                         10     100  thrpt    5  14941,125 ± 15793,397  ops/s
[info] ParEvalMapBenchmark.evalMap                         10   10000  thrpt    5    271,087 ±    32,569  ops/s
[info] ParEvalMapBenchmark.evalMap                        100     100  thrpt    5  21112,826 ±  1200,298  ops/s
[info] ParEvalMapBenchmark.evalMap                        100   10000  thrpt    5    333,532 ±    29,564  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10           10     100  thrpt    5    777,716 ±    51,634  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10           10   10000  thrpt    5      8,548 ±     1,527  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10          100     100  thrpt    5    751,344 ±   140,702  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10          100   10000  thrpt    5      8,680 ±     0,625  ops/s

channel
[info] Benchmark                                  (chunkSize)  (size)   Mode  Cnt      Score       Error  Units
[info] ParEvalMapBenchmark.evalMap                         10     100  thrpt    5  14737,644 ± 11934,801  ops/s
[info] ParEvalMapBenchmark.evalMap                         10   10000  thrpt    5    269,426 ±    27,346  ops/s
[info] ParEvalMapBenchmark.evalMap                        100     100  thrpt    5  20672,646 ±  3040,174  ops/s
[info] ParEvalMapBenchmark.evalMap                        100   10000  thrpt    5    326,514 ±    16,164  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10           10     100  thrpt    5    690,876 ±   103,356  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10           10   10000  thrpt    5      8,636 ±     2,096  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10          100     100  thrpt    5    798,570 ±    58,991  ops/s
[info] ParEvalMapBenchmark.parEvalMapUnordered10          100   10000  thrpt    5      8,620 ±     1,949  ops/s
</pre>