### PR TITLE
Remove unnecessary indexing in Chunk combinators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,8 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.Pull.mapOutput"),
   ProblemFilters.exclude[NewMixinForwarderProblem]("fs2.compression.Compression.gzip*"),
   ProblemFilters.exclude[NewMixinForwarderProblem]("fs2.compression.Compression.gunzip*"),
-  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.compression.Compression.$init$")
+  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.compression.Compression.$init$"),
+  ProblemFilters.exclude[MissingClassProblem]("fs2.Chunk$VectorChunk")
 )
 
 lazy val root = project

--- a/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
@@ -79,7 +79,7 @@ private[fs2] trait ChunkCompanionPlatform { self: Chunk.type =>
     new IArraySlice(arr, offset, length)
 
   case class IArraySlice[O](values: IArray[O], offset: Int, length: Int)(implicit ct: ClassTag[O])
-      extends IndexedChunk[O] {
+      extends Chunk[O] {
     require(
       offset >= 0 && offset <= values.size && length >= 0 && length <= values.size && offset + length <= values.size
     )

--- a/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
@@ -79,7 +79,7 @@ private[fs2] trait ChunkCompanionPlatform { self: Chunk.type =>
     new IArraySlice(arr, offset, length)
 
   case class IArraySlice[O](values: IArray[O], offset: Int, length: Int)(implicit ct: ClassTag[O])
-      extends Chunk[O] {
+      extends IndexedChunk[O] {
     require(
       offset >= 0 && offset <= values.size && length >= 0 && length <= values.size && offset + length <= values.size
     )

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -924,7 +924,7 @@ object Chunk
       compacted.asInstanceOf[ArraySlice[O2]]
     }
 
-    def foreach(f: O => Unit): Unit = 
+    def foreach(f: O => Unit): Unit =
       chunks.foreach(_.foreach(f))
 
     def foreachWithIndex(f: (O, Int) => Unit): Unit = {
@@ -1134,6 +1134,7 @@ object Chunk
 }
 
 abstract class IndexedChunk[+O] extends Chunk[O] { self =>
+
   /** Invokes the supplied function for each element of this chunk. */
   def foreach(f: O => Unit): Unit = {
     var i = 0

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -454,6 +454,10 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * Chunks from the source stream are split as necessary.
     * If `allowFewer` is true, the last chunk that is emitted may have less than `n` elements.
     *
+    * Note: the emitted chunk may be a composite chunk (i.e., an instance of `Chunk.Queue`) and
+    * hence may not have O(1) lookup by index. Consider calling `.map(_.compact)` if indexed
+    * lookup is important.
+    *
     * @example {{{
     * scala> Stream(1,2,3).repeat.chunkN(2).take(5).toList
     * res0: List[Chunk[Int]] = List(Chunk(1, 2), Chunk(3, 1), Chunk(2, 3), Chunk(1, 2), Chunk(3, 1))
@@ -4079,9 +4083,13 @@ object Stream extends StreamLowPriority {
       }
     }
 
-    /** Like [[uncons]], but returns a chunk of exactly `n` elements, splitting chunk as necessary.
+    /** Like [[uncons]] but returns a chunk of exactly `n` elements, concatenating and splitting as necessary.
       *
       * `Pull.pure(None)` is returned if the end of the source stream is reached.
+      *
+      * Note: the emitted chunk may be a composite chunk (i.e., an instance of `Chunk.Queue`) and
+      * hence may not have O(1) lookup by index. Consider calling `.map(_.compact)` if indexed
+      * lookup is important.
       */
     def unconsN(
         n: Int,


### PR DESCRIPTION
Fixes #2603 and #2627. Also addresses the issue described here: https://github.com/circe/circe-fs2/issues/273 (cc @samspills)

The `Chunk.Queue` type provides the ability to efficiently create a single chunk out of any number of individual chunks. In 2.x, `Chunk.Queue` was not itself a subtype of `Chunk`. After various individual chunks had been accumulated in to a `Chunk.Queue`, the queue had to be converted to a single chunk via `toChunk`. This operation returned a single array backed chunk. Unfortunately, this relied on reflection and various tricks to build the array backed chunk without access to a `ClassTag` at the call site and ultimately was unsound. We fixed this in https://github.com/typelevel/fs2/pull/2181.

One of the main changes in #2181 was making `Chunk.Queue` a subtype of `Chunk`. Doing so meant that `Chunk` could no longer guarantee O(1) lookup by index -- rather, it was now O(number of chunks in chunk queue). When a chunk queue consists only of singleton chunks, that becomes O(n). We added a `Chunk#compact` operation which built a chunk backed by an array, potentially primitive array.

As a result of #2181, the various combinators that used to call `Chunk.Queue#toChunk` no longer had to, resulting in a significant performance improvement as they no longer had to copy all the accumulated elements to a new array backed chunk. This tradeoff normally pays off, though not in the case where the O(n) lookup ends up dominating. The performance regressions reported in #2603 and #2627 are examples of such cases.

So why not add a call to `.compact` in the implementation of operations like `chunkN`? In short, we can't. We don't have a `ClassTag[O]` in those cases so we can't create primitive arrays. This gets us right back to the initial issue #2181 was addressing -- unsoundness as a result of too clever reflection.

This PR takes a different approach. We maintain the worst case O(n) lookup and we leave `chunkN`/`unconsN` as-is. Instead, we reimplement all the combinators on `Chunk` to avoid indexed lookup. If a user wants O(1) indexed lookup, they must call `compact`.

This PR also adds a new `compactUntagged` operation which stores the elements in an `Array[Any]` (boxed).