### PR TITLE
`PipedStreamBuffer` circular copying overflow fix

### DIFF
--- a/io/jvm/src/main/scala/fs2/io/internal/PipedStreamBuffer.scala
+++ b/io/jvm/src/main/scala/fs2/io/internal/PipedStreamBuffer.scala
@@ -66,7 +66,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         self.synchronized {
           if (head != tail) {
             // There is at least one byte to read.
-            val byte = buffer(head % capacity) & 0xff
+            val byte = buffer(modulus(head, capacity)) & 0xff
             // The byte is marked as read by advancing the head of the
             // circular buffer.
             head += 1
@@ -211,7 +211,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         dstPos: Int,
         length: Int
     ): Unit = {
-      val srcOffset = srcPos % srcCap
+      val srcOffset = modulus(srcPos, srcCap)
       if (srcOffset + length >= srcCap) {
         val batch1 = srcCap - srcOffset
         val batch2 = length - batch1
@@ -237,7 +237,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         self.synchronized {
           if (tail - head < capacity) {
             // There is capacity for at least one byte to be written.
-            buffer(tail % capacity) = (b & 0xff).toByte
+            buffer(modulus(tail, capacity)) = (b & 0xff).toByte
             // The byte is marked as written by advancing the tail of the
             // circular buffer.
             tail += 1
@@ -364,15 +364,35 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         dstCap: Int,
         length: Int
     ): Unit = {
-      val dstOffset = dstPos % dstCap
+      val dstOffset = modulus(dstPos, dstCap)
       if (dstOffset + length >= dstCap) {
         val batch1 = dstCap - dstOffset
         val batch2 = length - batch1
         System.arraycopy(src, srcPos, dst, dstOffset, batch1)
         System.arraycopy(src, srcPos + batch1, dst, 0, batch2)
       } else {
-        System.arraycopy(src, srcPos, dst, dstOffset, length)
+        try System.arraycopy(src, srcPos, dst, dstOffset, length)
+        catch {
+          case e: ArrayIndexOutOfBoundsException =>
+            println(
+              s"srcPos = $srcPos, dstPos = $dstPos, dstCap = $dstCap, length = $length, dstOffset = $dstOffset, dstOffset + length = ${dstOffset + length}"
+            )
+            throw e
+        }
       }
     }
+  }
+
+  /** Calculates `n` modulo `m`. This is different from the JVMs built in `%`
+    * remainder operator which can return a negative result for negative
+    * numbers. This method always returns a non-negative result.
+    *
+    * @param n the divident
+    * @param m the divisor
+    * @return the result of `n` modulo `m`
+    */
+  private[this] def modulus(n: Int, m: Int): Int = {
+    val r = n % m
+    if (r < 0) r + m else r
   }
 }

--- a/io/jvm/src/main/scala/fs2/io/internal/PipedStreamBuffer.scala
+++ b/io/jvm/src/main/scala/fs2/io/internal/PipedStreamBuffer.scala
@@ -371,14 +371,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         System.arraycopy(src, srcPos, dst, dstOffset, batch1)
         System.arraycopy(src, srcPos + batch1, dst, 0, batch2)
       } else {
-        try System.arraycopy(src, srcPos, dst, dstOffset, length)
-        catch {
-          case e: ArrayIndexOutOfBoundsException =>
-            println(
-              s"srcPos = $srcPos, dstPos = $dstPos, dstCap = $dstCap, length = $length, dstOffset = $dstOffset, dstOffset + length = ${dstOffset + length}"
-            )
-            throw e
-        }
+        System.arraycopy(src, srcPos, dst, dstOffset, length)
       }
     }
   }

--- a/io/jvm/src/main/scala/fs2/io/internal/PipedStreamBuffer.scala
+++ b/io/jvm/src/main/scala/fs2/io/internal/PipedStreamBuffer.scala
@@ -66,7 +66,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         self.synchronized {
           if (head != tail) {
             // There is at least one byte to read.
-            val byte = buffer(modulus(head, capacity)) & 0xff
+            val byte = buffer(Integer.remainderUnsigned(head, capacity)) & 0xff
             // The byte is marked as read by advancing the head of the
             // circular buffer.
             head += 1
@@ -211,7 +211,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         dstPos: Int,
         length: Int
     ): Unit = {
-      val srcOffset = modulus(srcPos, srcCap)
+      val srcOffset = Integer.remainderUnsigned(srcPos, srcCap)
       if (srcOffset + length >= srcCap) {
         val batch1 = srcCap - srcOffset
         val batch2 = length - batch1
@@ -237,7 +237,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         self.synchronized {
           if (tail - head < capacity) {
             // There is capacity for at least one byte to be written.
-            buffer(modulus(tail, capacity)) = (b & 0xff).toByte
+            buffer(Integer.remainderUnsigned(tail, capacity)) = (b & 0xff).toByte
             // The byte is marked as written by advancing the tail of the
             // circular buffer.
             tail += 1
@@ -364,7 +364,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         dstCap: Int,
         length: Int
     ): Unit = {
-      val dstOffset = modulus(dstPos, dstCap)
+      val dstOffset = Integer.remainderUnsigned(dstPos, dstCap)
       if (dstOffset + length >= dstCap) {
         val batch1 = dstCap - dstOffset
         val batch2 = length - batch1
@@ -381,18 +381,5 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         }
       }
     }
-  }
-
-  /** Calculates `n` modulo `m`. This is different from the JVMs built in `%`
-    * remainder operator which can return a negative result for negative
-    * numbers. This method always returns a non-negative result.
-    *
-    * @param n the divident
-    * @param m the divisor
-    * @return the result of `n` modulo `m`
-    */
-  private[this] def modulus(n: Int, m: Int): Int = {
-    val r = n % m
-    if (r < 0) r + m else r
   }
 }

--- a/io/jvm/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -29,12 +29,16 @@ import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalacheck.effect.PropF.forAllF
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.Executors
 
 class IoPlatformSuite extends Fs2Suite {
+
+  // This suite runs for a long time, this avoids timeouts in CI.
+  override def munitTimeout: Duration = 1.minute
 
   group("readOutputStream") {
     test("writes data and terminates when `f` returns") {


### PR DESCRIPTION
Resolves #2637.

The built in `%` remainder operator can return a negative result. We're actually interested in the modulus operation which returns a non-negative result.
