### PR TITLE
`PipedStreamBuffer` circular copying overflow fix backport

### DIFF
--- a/io/src/main/scala/fs2/io/internal/PipedStreamBuffer.scala
+++ b/io/src/main/scala/fs2/io/internal/PipedStreamBuffer.scala
@@ -66,7 +66,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         self.synchronized {
           if (head != tail) {
             // There is at least one byte to read.
-            val byte = buffer(head % capacity) & 0xff
+            val byte = buffer(Integer.remainderUnsigned(head, capacity)) & 0xff
             // The byte is marked as read by advancing the head of the
             // circular buffer.
             head += 1
@@ -211,7 +211,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         dstPos: Int,
         length: Int
     ): Unit = {
-      val srcOffset = srcPos % srcCap
+      val srcOffset = Integer.remainderUnsigned(srcPos, srcCap)
       if (srcOffset + length >= srcCap) {
         val batch1 = srcCap - srcOffset
         val batch2 = length - batch1
@@ -237,7 +237,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         self.synchronized {
           if (tail - head < capacity) {
             // There is capacity for at least one byte to be written.
-            buffer(tail % capacity) = (b & 0xff).toByte
+            buffer(Integer.remainderUnsigned(tail, capacity)) = (b & 0xff).toByte
             // The byte is marked as written by advancing the tail of the
             // circular buffer.
             tail += 1
@@ -364,7 +364,7 @@ private[io] final class PipedStreamBuffer(private[this] val capacity: Int) { sel
         dstCap: Int,
         length: Int
     ): Unit = {
-      val dstOffset = dstPos % dstCap
+      val dstOffset = Integer.remainderUnsigned(dstPos, dstCap)
       if (dstOffset + length >= dstCap) {
         val batch1 = dstCap - dstOffset
         val batch2 = length - batch1

--- a/io/src/test/scala/fs2/io/IoSuite.scala
+++ b/io/src/test/scala/fs2/io/IoSuite.scala
@@ -22,13 +22,16 @@
 package fs2
 package io
 
-import java.io.{ByteArrayInputStream, InputStream, OutputStream}
-import java.util.concurrent.Executors
 import cats.effect.{Blocker, IO, Resource}
 import fs2.Fs2Suite
-import scala.concurrent.ExecutionContext
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalacheck.effect.PropF.forAllF
+
+import scala.concurrent.ExecutionContext
+
+import java.io.{ByteArrayInputStream, InputStream, OutputStream}
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.Executors
 
 class IoSuite extends Fs2Suite {
   group("readInputStream") {
@@ -203,6 +206,31 @@ class IoSuite extends Fs2Suite {
             .compile
             .drain
         }
+      }
+    }
+
+    test("can copy more than Int.MaxValue bytes") {
+      // Unit test adapted from the original issue reproduction at https://github.com/mrdziuban/fs2-writeOutputStream.
+
+      val byteStream =
+        Stream
+          .chunk[IO, Byte](Chunk.array(("foobar" * 50000).getBytes(StandardCharsets.UTF_8)))
+          .repeatN(7200L) // 6 * 50,000 * 7,200 == 2,160,000,000 > 2,147,483,647 == Int.MaxValue
+
+      def writeToOutputStream(out: OutputStream, blocker: Blocker): IO[Unit] =
+        byteStream
+          .through(writeOutputStream(IO.pure(out), blocker))
+          .compile
+          .drain
+
+      Blocker[IO].use { blocker =>
+        readOutputStream[IO](blocker, 1024 * 8)(writeToOutputStream(_, blocker))
+          .chunkN(6 * 50000)
+          .map(c => new String(c.toArray[Byte], StandardCharsets.UTF_8))
+          .evalMap(str => IO.pure(str).assertEquals("foobar" * 50000))
+          .drain
+          .compile
+          .drain
       }
     }
   }

--- a/io/src/test/scala/fs2/io/IoSuite.scala
+++ b/io/src/test/scala/fs2/io/IoSuite.scala
@@ -28,12 +28,17 @@ import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalacheck.effect.PropF.forAllF
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 import java.io.{ByteArrayInputStream, InputStream, OutputStream}
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.Executors
 
 class IoSuite extends Fs2Suite {
+
+  // This suite runs for a long time, this avoids timeouts in CI.
+  override def munitTimeout: Duration = 1.minute
+
   group("readInputStream") {
     test("non-buffered") {
       forAllF { (bytes: Array[Byte], chunkSize0: Int) =>


### PR DESCRIPTION
Resolves #2637 for `series/2.5.x`.