### PR TITLE
fix socket leak for unresolvable domains

### DIFF
--- a/io/jvm/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -36,11 +36,11 @@ private[net] trait SocketCompanionPlatform {
   private[net] def forAsync[F[_]: Async](
       ch: AsynchronousSocketChannel
   ): Resource[F, Socket[F]] =
-    Resource.make {
+    Resource.eval {
       (Semaphore[F](1), Semaphore[F](1)).mapN { (readSemaphore, writeSemaphore) =>
         new AsyncSocket[F](ch, readSemaphore, writeSemaphore)
       }
-    }(_ => Async[F].delay(if (ch.isOpen) ch.close else ()))
+    }
 
   private[net] abstract class BufferedReads[F[_]](
       readSemaphore: Semaphore[F]


### PR DESCRIPTION
This PR fixes a socket / file descriptor leak when opening sockets to domains that dont resolve. eg Network[IO].client(SocketAddress(Host.fromString("nodomain.fs2.io").get, port"80"))

Fix for https://github.com/typelevel/fs2/issues/2643


Please review. The main change is just to `close` with `Resource.make` in `def client(..` rather than later in `Socket.forAsync`. Im not sure why it was in `Socket.forAsync`, the other usages I found in `fs2.io.net` seemed to be already closing. Im not sure if that instance could have been used elsewhere, it shouldnt because its private.

PS. Thanks for the excellent library 😊