### PR TITLE
Improve IO exceptions on Node.js

### DIFF
--- a/io/js/src/main/scala/fs2/io/file/FileSystemException.scala
+++ b/io/js/src/main/scala/fs2/io/file/FileSystemException.scala
@@ -40,42 +40,45 @@ object FileSystemException {
 
 class AccessDeniedException(message: String = null, cause: Throwable = null)
     extends FileSystemException(message, cause)
-private class JavaScriptAccessDeniedException(cause: js.JavaScriptException)
-    extends AccessDeniedException(cause = cause)
+private class JavaScriptAccessDeniedException(file: String, cause: js.JavaScriptException)
+    extends AccessDeniedException(file, cause)
     with NoStackTrace
 object AccessDeniedException {
   private[file] def unapply(cause: js.JavaScriptException): Option[AccessDeniedException] =
-    cause match {
-      case js.JavaScriptException(error: js.Error) if error.message.contains("EACCES") =>
-        Some(new JavaScriptAccessDeniedException(cause))
+    cause.exception match {
+      case error: js.Error if error.message.contains("EACCES") =>
+        val file = error.message.split('\'').toList.lastOption.getOrElse("<unknown>")
+        Some(new JavaScriptAccessDeniedException(file, cause))
       case _ => None
     }
 }
 
 class DirectoryNotEmptyException(message: String = null, cause: Throwable = null)
     extends FileSystemException(message, cause)
-private class JavaScriptDirectoryNotEmptyException(cause: js.JavaScriptException)
-    extends DirectoryNotEmptyException(cause = cause)
+private class JavaScriptDirectoryNotEmptyException(file: String, cause: js.JavaScriptException)
+    extends DirectoryNotEmptyException(file, cause)
     with NoStackTrace
 object DirectoryNotEmptyException {
   private[file] def unapply(cause: js.JavaScriptException): Option[DirectoryNotEmptyException] =
-    cause match {
-      case js.JavaScriptException(error: js.Error) if error.message.contains("ENOTEMPTY") =>
-        Some(new JavaScriptDirectoryNotEmptyException(cause))
+    cause.exception match {
+      case error: js.Error if error.message.contains("ENOTEMPTY") =>
+        val file = error.message.split('\'').toList.lastOption.getOrElse("<unknown>")
+        Some(new JavaScriptDirectoryNotEmptyException(file, cause))
       case _ => None
     }
 }
 
 class FileAlreadyExistsException(message: String = null, cause: Throwable = null)
     extends FileSystemException(message, cause)
-private class JavaScriptFileAlreadyExistsException(cause: js.JavaScriptException)
-    extends FileAlreadyExistsException(cause = cause)
+private class JavaScriptFileAlreadyExistsException(file: String, cause: js.JavaScriptException)
+    extends FileAlreadyExistsException(file, cause)
     with NoStackTrace
 object FileAlreadyExistsException {
   private[file] def unapply(cause: js.JavaScriptException): Option[FileAlreadyExistsException] =
-    cause match {
-      case js.JavaScriptException(error: js.Error) if error.message.contains("EEXIST") =>
-        Some(new JavaScriptFileAlreadyExistsException(cause))
+    cause.exception match {
+      case error: js.Error if error.message.contains("EEXIST") =>
+        val file = error.message.split('\'').toList.lastOption.getOrElse("<unknown>")
+        Some(new JavaScriptFileAlreadyExistsException(file, cause))
       case _ => None
     }
 }
@@ -84,28 +87,30 @@ class FileSystemLoopException(file: String) extends FileSystemException(file)
 
 class NoSuchFileException(message: String = null, cause: Throwable = null)
     extends FileSystemException(message, cause)
-private class JavaScriptNoSuchFileException(cause: js.JavaScriptException)
-    extends NoSuchFileException(cause = cause)
+private class JavaScriptNoSuchFileException(file: String, cause: js.JavaScriptException)
+    extends NoSuchFileException(file, cause)
     with NoStackTrace
 object NoSuchFileException {
   private[file] def unapply(cause: js.JavaScriptException): Option[NoSuchFileException] =
-    cause match {
-      case js.JavaScriptException(error: js.Error) if error.message.contains("ENOENT") =>
-        Some(new JavaScriptNoSuchFileException(cause))
+    cause.exception match {
+      case error: js.Error if error.message.contains("ENOENT") =>
+        val file = error.message.split('\'').toList.lastOption.getOrElse("<unknown>")
+        Some(new JavaScriptNoSuchFileException(file, cause))
       case _ => None
     }
 }
 
 class NotDirectoryException(message: String = null, cause: Throwable = null)
     extends FileSystemException(message, cause)
-private class JavaScriptNotDirectoryException(cause: js.JavaScriptException)
-    extends NotDirectoryException(cause = cause)
+private class JavaScriptNotDirectoryException(file: String, cause: js.JavaScriptException)
+    extends NotDirectoryException(file, cause)
     with NoStackTrace
 object NotDirectoryException {
   private[file] def unapply(cause: js.JavaScriptException): Option[NotDirectoryException] =
-    cause match {
-      case js.JavaScriptException(error: js.Error) if error.message.contains("ENOTDIR") =>
-        Some(new JavaScriptNotDirectoryException(cause))
+    cause.exception match {
+      case error: js.Error if error.message.contains("ENOTDIR") =>
+        val file = error.message.split('\'').toList.lastOption.getOrElse("<unknown>")
+        Some(new JavaScriptNotDirectoryException(file, cause))
       case _ => None
     }
 }

--- a/io/js/src/main/scala/fs2/io/net/NetException.scala
+++ b/io/js/src/main/scala/fs2/io/net/NetException.scala
@@ -33,14 +33,14 @@ import scala.util.matching.Regex
 
 class SocketException(message: String = null, cause: Throwable = null)
     extends IOException(message, cause)
-private class JavaScriptSocketException(cause: js.JavaScriptException)
-    extends SocketException("Connection reset", cause)
+private class JavaScriptSocketException(message: String, cause: js.JavaScriptException)
+    extends SocketException(message, cause)
     with NoStackTrace
 object SocketException {
   private[io] def unapply(cause: js.JavaScriptException): Option[SocketException] =
     cause.exception match {
       case error: js.Error if error.message.contains("ECONNRESET") =>
-        Some(new JavaScriptSocketException(cause))
+        Some(new JavaScriptSocketException("Connection reset by peer", cause))
       case _ => BindException.unapply(cause).orElse(ConnectException.unapply(cause))
     }
 }

--- a/io/js/src/main/scala/fs2/io/net/NetException.scala
+++ b/io/js/src/main/scala/fs2/io/net/NetException.scala
@@ -25,6 +25,7 @@ package net
 
 import com.comcast.ip4s.Host
 import com.comcast.ip4s.SocketAddress
+import fs2.internal.jsdeps.node.osMod
 
 import scala.scalajs.js
 import scala.util.control.NoStackTrace
@@ -89,7 +90,7 @@ object SocketTimeoutException {
 class UnknownHostException(message: String = null, cause: Throwable = null)
     extends IOException(message, cause)
 private class JavaScriptUnknownHostException(host: String, cause: js.JavaScriptException)
-    extends UnknownHostException(s"$host: nodename nor servname provided, or not known", cause)
+    extends UnknownHostException(s"$host: ${UnknownHostException.message}", cause)
     with NoStackTrace
 object UnknownHostException {
   private[io] def unapply(cause: js.JavaScriptException): Option[UnknownHostException] =
@@ -107,4 +108,8 @@ object UnknownHostException {
       case _ => None
     }
   private[this] val pattern = raw"(?:ENOTFOUND|EAI_AGAIN)(?: (\S+))?".r
+  private[net] val message = osMod.`type`() match {
+    case "Darwin" => "nodename nor servname provided, or not known"
+    case _        => "Name or service not known"
+  }
 }

--- a/io/js/src/main/scala/fs2/io/net/NetException.scala
+++ b/io/js/src/main/scala/fs2/io/net/NetException.scala
@@ -31,6 +31,9 @@ import scala.scalajs.js
 import scala.util.control.NoStackTrace
 import scala.util.matching.Regex
 
+class ProtocolException(message: String = null, cause: Throwable = null)
+    extends IOException(message, cause)
+
 class SocketException(message: String = null, cause: Throwable = null)
     extends IOException(message, cause)
 private class JavaScriptSocketException(message: String, cause: js.JavaScriptException)

--- a/io/js/src/main/scala/fs2/io/net/NetException.scala
+++ b/io/js/src/main/scala/fs2/io/net/NetException.scala
@@ -34,7 +34,7 @@ import scala.util.matching.Regex
 class SocketException(message: String = null, cause: Throwable = null)
     extends IOException(message, cause)
 private class JavaScriptSocketException(cause: js.JavaScriptException)
-    extends SocketException(cause = cause)
+    extends SocketException("Connection reset", cause)
     with NoStackTrace
 object SocketException {
   private[io] def unapply(cause: js.JavaScriptException): Option[SocketException] =
@@ -74,9 +74,9 @@ object ConnectException {
 }
 
 class SocketTimeoutException(message: String = null, cause: Throwable = null)
-    extends IOException(message, cause)
+    extends InterruptedIOException(message, cause)
 private class JavaScriptSocketTimeoutException(cause: js.JavaScriptException)
-    extends SocketTimeoutException(cause = cause)
+    extends SocketTimeoutException("Connection timed out", cause)
     with NoStackTrace
 object SocketTimeoutException {
   private[io] def unapply(cause: js.JavaScriptException): Option[SocketTimeoutException] =

--- a/io/js/src/main/scala/fs2/io/net/NetException.scala
+++ b/io/js/src/main/scala/fs2/io/net/NetException.scala
@@ -23,8 +23,12 @@ package fs2
 package io
 package net
 
+import com.comcast.ip4s.Host
+import com.comcast.ip4s.SocketAddress
+
 import scala.scalajs.js
 import scala.util.control.NoStackTrace
+import scala.util.matching.Regex
 
 class SocketException(message: String = null, cause: Throwable = null)
     extends IOException(message, cause)
@@ -32,37 +36,40 @@ private class JavaScriptSocketException(cause: js.JavaScriptException)
     extends SocketException(cause = cause)
     with NoStackTrace
 object SocketException {
-  private[io] def unapply(cause: js.JavaScriptException): Option[SocketException] = cause match {
-    case js.JavaScriptException(error: js.Error) if error.message.contains("ECONNRESET") =>
-      Some(new JavaScriptSocketException(cause))
-    case _ => BindException.unapply(cause).orElse(ConnectException.unapply(cause))
-  }
+  private[io] def unapply(cause: js.JavaScriptException): Option[SocketException] =
+    cause.exception match {
+      case error: js.Error if error.message.contains("ECONNRESET") =>
+        Some(new JavaScriptSocketException(cause))
+      case _ => BindException.unapply(cause).orElse(ConnectException.unapply(cause))
+    }
 }
 
 class BindException(message: String = null, cause: Throwable = null)
     extends SocketException(message, cause)
 private class JavaScriptBindException(cause: js.JavaScriptException)
-    extends BindException(cause = cause)
+    extends BindException("Address already in use", cause)
     with NoStackTrace
 object BindException {
-  private[net] def unapply(cause: js.JavaScriptException): Option[BindException] = cause match {
-    case js.JavaScriptException(error: js.Error) if error.message.contains("EADDRINUSE") =>
-      Some(new JavaScriptBindException(cause))
-    case _ => None
-  }
+  private[net] def unapply(cause: js.JavaScriptException): Option[BindException] =
+    cause.exception match {
+      case error: js.Error if error.message.contains("EADDRINUSE") =>
+        Some(new JavaScriptBindException(cause))
+      case _ => None
+    }
 }
 
 class ConnectException(message: String = null, cause: Throwable = null)
     extends SocketException(message, cause)
 private class JavaScriptConnectException(cause: js.JavaScriptException)
-    extends ConnectException(cause = cause)
+    extends ConnectException("Connection refused", cause)
     with NoStackTrace
 object ConnectException {
-  private[net] def unapply(cause: js.JavaScriptException): Option[ConnectException] = cause match {
-    case js.JavaScriptException(error: js.Error) if error.message.contains("ECONNREFUSED") =>
-      Some(new JavaScriptConnectException(cause))
-    case _ => None
-  }
+  private[net] def unapply(cause: js.JavaScriptException): Option[ConnectException] =
+    cause.exception match {
+      case error: js.Error if error.message.contains("ECONNREFUSED") =>
+        Some(new JavaScriptConnectException(cause))
+      case _ => None
+    }
 }
 
 class SocketTimeoutException(message: String = null, cause: Throwable = null)
@@ -72,8 +79,8 @@ private class JavaScriptSocketTimeoutException(cause: js.JavaScriptException)
     with NoStackTrace
 object SocketTimeoutException {
   private[io] def unapply(cause: js.JavaScriptException): Option[SocketTimeoutException] =
-    cause match {
-      case js.JavaScriptException(error: js.Error) if error.message.contains("ETIMEDOUT") =>
+    cause.exception match {
+      case error: js.Error if error.message.contains("ETIMEDOUT") =>
         Some(new JavaScriptSocketTimeoutException(cause))
       case _ => None
     }
@@ -81,15 +88,23 @@ object SocketTimeoutException {
 
 class UnknownHostException(message: String = null, cause: Throwable = null)
     extends IOException(message, cause)
-private class JavaScriptUnknownException(cause: js.JavaScriptException)
-    extends UnknownHostException(cause = cause)
+private class JavaScriptUnknownHostException(host: String, cause: js.JavaScriptException)
+    extends UnknownHostException(s"$host: nodename nor servname provided, or not known", cause)
     with NoStackTrace
 object UnknownHostException {
   private[io] def unapply(cause: js.JavaScriptException): Option[UnknownHostException] =
-    cause match {
-      case js.JavaScriptException(error: js.Error)
-          if error.message.contains("ENOTFOUND") || error.message.contains("EAI_AGAIN") =>
-        Some(new JavaScriptUnknownException(cause))
+    cause.exception match {
+      case error: js.Error =>
+        pattern.findFirstMatchIn(error.message).collect { case Regex.Groups(addr) =>
+          val host =
+            Option(addr)
+              .flatMap { addr =>
+                SocketAddress.fromString(addr).map(_.host).orElse(Host.fromString(addr))
+              }
+              .fold("<unknown>")(_.toString)
+          new JavaScriptUnknownHostException(host, cause)
+        }
       case _ => None
     }
+  private[this] val pattern = raw"(?:ENOTFOUND|EAI_AGAIN)(?: (\S+))?".r
 }

--- a/io/jvm/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/ioplatform.scala
@@ -31,6 +31,7 @@ import fs2.io.internal.PipedStreamBuffer
 import java.io.{InputStream, OutputStream}
 
 private[fs2] trait ioplatform {
+  type InterruptedIOException = java.io.InterruptedIOException
   type ClosedChannelException = java.nio.channels.ClosedChannelException
 
   /** Pipe that converts a stream of bytes to a stream that will emit a single `java.io.InputStream`,

--- a/io/jvm/src/main/scala/fs2/io/net/net.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/net.scala
@@ -23,6 +23,7 @@ package fs2.io
 
 /** Provides support for doing network I/O -- TCP, UDP, and TLS. */
 package object net {
+  type ProtocolException = java.net.ProtocolException
   type SocketException = java.net.SocketException
   type BindException = java.net.BindException
   type ConnectException = java.net.ConnectException

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -177,9 +177,8 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
       } yield ()).use_ >> (for {
         _ <- Network[IO].client(SocketAddress.fromString("not.example.com:80").get).use_.recover {
           case ex: UnknownHostException =>
-            assertEquals(
-              ex.getMessage,
-              "not.example.com: nodename nor servname provided, or not known"
+            assert(
+              ex.getMessage == "not.example.com: Name or service not known" || ex.getMessage == "not.example.com: nodename nor servname provided, or not known"
             )
         }
       } yield ())

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -25,6 +25,7 @@ package net
 package tcp
 
 import cats.effect.IO
+import cats.syntax.all._
 import com.comcast.ip4s._
 
 import scala.concurrent.duration._
@@ -162,13 +163,26 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
     test("errors - should be captured in the effect") {
       (for {
         bindAddress <- Network[IO].serverResource(Some(ip"127.0.0.1")).use(s => IO.pure(s._1))
-        _ <- Network[IO].client(bindAddress).use(_ => IO.unit)
-      } yield ()).intercept[ConnectException] >> (for {
+        _ <- Network[IO].client(bindAddress).use(_ => IO.unit).recover {
+          case ex: ConnectException => assertEquals(ex.getMessage, "Connection refused")
+        }
+      } yield ()) >> (for {
         bindAddress <- Network[IO].serverResource(Some(ip"127.0.0.1")).map(_._1)
-        _ <- Network[IO].serverResource(Some(bindAddress.host), Some(bindAddress.port))
-      } yield ()).use_.intercept[BindException] >> (for {
-        _ <- Network[IO].client(SocketAddress.fromString("not.example.com:80").get).use_
-      } yield ()).intercept[UnknownHostException]
+        _ <- Network[IO]
+          .serverResource(Some(bindAddress.host), Some(bindAddress.port))
+          .void
+          .recover { case ex: BindException =>
+            assertEquals(ex.getMessage, "Address already in use")
+          }
+      } yield ()).use_ >> (for {
+        _ <- Network[IO].client(SocketAddress.fromString("not.example.com:80").get).use_.recover {
+          case ex: UnknownHostException =>
+            assertEquals(
+              ex.getMessage,
+              "not.example.com: nodename nor servname provided, or not known"
+            )
+        }
+      } yield ())
     }
 
     test("options - should work with socket options") {


### PR DESCRIPTION
This improves the consistency of IO exceptions on Node.js with their JVM counterparts by providing identical messages. This came up in https://github.com/http4s/http4s/pull/5290.