### PR TITLE
Revert "Remove unnecessary delegate" for `fs2.io.compression`

### DIFF
--- a/io/jvm/src/main/scala/fs2/io/compressionplatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/compressionplatform.scala
@@ -22,4 +22,9 @@
 package fs2
 package io
 
-private[io] trait compressionplatform
+import cats.effect.kernel.Sync
+import fs2.compression.Compression
+
+private[io] trait compressionplatform {
+  implicit def fs2ioCompressionForSync[F[_]: Sync]: Compression[F] = Compression.forSync
+}


### PR DESCRIPTION
It turns out this was a good idea. The problem is that when this is empty for JVM, it becomes an unused import which is problematic with fatal warnings enabled.