### PR TITLE
Build fs2 with JDK 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.0.2, 2.12.15, 2.13.6]
-        java: [adoptium@17]
+        java: [adoptium@8, adoptium@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.6]
-        java: [adoptium@17]
+        java: [adoptium@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -152,7 +152,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.6]
-        java: [adoptium@17]
+        java: [adoptium@8, adoptium@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Download target directories (3.0.2)

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val NewScala = "2.13.6"
 ThisBuild / crossScalaVersions := Seq("3.0.2", "2.12.15", NewScala)
 
 ThisBuild / githubWorkflowEnv += ("JABBA_INDEX" -> "https://github.com/typelevel/jdk-index/raw/main/index.json")
-ThisBuild / githubWorkflowJavaVersions := Seq("adoptium@17")
+ThisBuild / githubWorkflowJavaVersions := Seq("adoptium@8", "adoptium@17")
 
 ThisBuild / spiewakCiReleaseSnapshots := true
 

--- a/io/jvm/src/main/java/fs2/io/net/StandardSocketOptionsCompat.java
+++ b/io/jvm/src/main/java/fs2/io/net/StandardSocketOptionsCompat.java
@@ -23,7 +23,6 @@ package fs2.io.net;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 
 import javax.management.RuntimeErrorException;
@@ -34,17 +33,17 @@ final class StandardSocketOptionsCompat {
 
   private static MethodHandle initSoReusePortMethodHandle() {
     try {
-      return LOOKUP.findStaticGetter(StandardSocketOptions.class, "SO_REUSEPORT", SocketOption.class);
+      return LOOKUP.findStaticGetter(StandardSocketOptions.class, "SO_REUSEPORT", java.net.SocketOption.class);
     } catch (Throwable t) {
       throw new ExceptionInInitializerError(t);
     }
   }
 
-  static final SocketOption<Boolean> SO_REUSEPORT = initSoReusePort();
+  static final java.net.SocketOption<Boolean> SO_REUSEPORT = initSoReusePort();
 
-  private static SocketOption<Boolean> initSoReusePort() {
+  private static java.net.SocketOption<Boolean> initSoReusePort() {
     try {
-      return (SocketOption<Boolean>) SO_REUSEPORT_METHOD_HANDLE.invokeExact();
+      return (java.net.SocketOption<Boolean>) SO_REUSEPORT_METHOD_HANDLE.invokeExact();
     } catch (Throwable t) {
       throw new ExceptionInInitializerError(t);
     }

--- a/io/jvm/src/main/java/fs2/io/net/StandardSocketOptionsCompat.java
+++ b/io/jvm/src/main/java/fs2/io/net/StandardSocketOptionsCompat.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.io.net;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.net.SocketOption;
+import java.net.StandardSocketOptions;
+
+import javax.management.RuntimeErrorException;
+
+final class StandardSocketOptionsCompat {
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final MethodHandle SO_REUSEPORT_METHOD_HANDLE = initSoReusePortMethodHandle();
+
+  private static MethodHandle initSoReusePortMethodHandle() {
+    try {
+      return LOOKUP.findStaticGetter(StandardSocketOptions.class, "SO_REUSEPORT", SocketOption.class);
+    } catch (Throwable t) {
+      throw new ExceptionInInitializerError(t);
+    }
+  }
+
+  static final SocketOption<Boolean> SO_REUSEPORT = initSoReusePort();
+
+  private static SocketOption<Boolean> initSoReusePort() {
+    try {
+      return (SocketOption<Boolean>) SO_REUSEPORT_METHOD_HANDLE.invokeExact();
+    } catch (Throwable t) {
+      throw new ExceptionInInitializerError(t);
+    }
+  }
+}

--- a/io/jvm/src/main/java/fs2/io/net/tls/SSLParametersCompat.java
+++ b/io/jvm/src/main/java/fs2/io/net/tls/SSLParametersCompat.java
@@ -67,11 +67,11 @@ final class SSLParametersCompat extends SSLParameters {
   }
 
   void setEnableRetransmissionsCompat(boolean enableRetransmissions) throws Throwable {
-    SET_ENABLE_RETRANSMISSIONS_METHOD_HANDLE.invokeExact(enableRetransmissions);
+    SET_ENABLE_RETRANSMISSIONS_METHOD_HANDLE.invokeExact(this, enableRetransmissions);
   }
 
   void setMaximumPacketSizeCompat(int maximumPacketSize) throws Throwable {
-    SET_MAXIMUM_PACKET_SIZE_METHOD_HANDLE.invokeExact(maximumPacketSize);
+    SET_MAXIMUM_PACKET_SIZE_METHOD_HANDLE.invokeExact(this, maximumPacketSize);
   }
 
   private void fauxSetEnableRetransmissions(boolean setEnableRetransmissions) {

--- a/io/jvm/src/main/java/fs2/io/net/tls/SSLParametersCompat.java
+++ b/io/jvm/src/main/java/fs2/io/net/tls/SSLParametersCompat.java
@@ -32,6 +32,8 @@ final class SSLParametersCompat extends SSLParameters {
   private static final MethodType SET_ENABLE_RETRANSMISSIONS_METHOD_TYPE = MethodType.methodType(void.class,
       boolean.class);
   private static final MethodHandle SET_ENABLE_RETRANSMISSIONS_METHOD_HANDLE = initSetEnableRetransmissionsMethodHandle();
+  private static final MethodType SET_MAXIMUM_PACKET_SIZE_METHOD_TYPE = MethodType.methodType(void.class, int.class);
+  private static final MethodHandle SET_MAXIMUM_PACKET_SIZE_METHOD_HANDLE = initSetMaximumPacketSizeMethodHandle();
 
   private static MethodHandle initSetEnableRetransmissionsMethodHandle() {
     try {
@@ -49,10 +51,32 @@ final class SSLParametersCompat extends SSLParameters {
     }
   }
 
+  private static MethodHandle initSetMaximumPacketSizeMethodHandle() {
+    try {
+      return LOOKUP.findVirtual(SSLParametersCompat.class, "setMaximumPacketSize", SET_MAXIMUM_PACKET_SIZE_METHOD_TYPE);
+    } catch (NoSuchMethodException e) {
+      try {
+        return LOOKUP.findVirtual(SSLParametersCompat.class, "fauxSetMaximumPacketSize",
+            SET_MAXIMUM_PACKET_SIZE_METHOD_TYPE);
+      } catch (Throwable t) {
+        throw new ExceptionInInitializerError(t);
+      }
+    } catch (Throwable t) {
+      throw new ExceptionInInitializerError(t);
+    }
+  }
+
   void setEnableRetransmissionsCompat(boolean enableRetransmissions) throws Throwable {
     SET_ENABLE_RETRANSMISSIONS_METHOD_HANDLE.invokeExact(enableRetransmissions);
   }
 
+  void setMaximumPacketSizeCompat(int maximumPacketSize) throws Throwable {
+    SET_MAXIMUM_PACKET_SIZE_METHOD_HANDLE.invokeExact(maximumPacketSize);
+  }
+
   private void fauxSetEnableRetransmissions(boolean setEnableRetransmissions) {
+  }
+
+  private void fauxSetMaximumPacketSize(int maximumPacketSize) {
   }
 }

--- a/io/jvm/src/main/java/fs2/io/net/tls/SSLParametersCompat.java
+++ b/io/jvm/src/main/java/fs2/io/net/tls/SSLParametersCompat.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.io.net.tls;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import javax.net.ssl.SSLParameters;
+
+final class SSLParametersCompat extends SSLParameters {
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final MethodType SET_ENABLE_RETRANSMISSIONS_METHOD_TYPE = MethodType.methodType(void.class,
+      boolean.class);
+  private static final MethodHandle SET_ENABLE_RETRANSMISSIONS_METHOD_HANDLE = initSetEnableRetransmissionsMethodHandle();
+
+  private static MethodHandle initSetEnableRetransmissionsMethodHandle() {
+    try {
+      return LOOKUP.findVirtual(SSLParametersCompat.class, "setEnableRetransmissions",
+          SET_ENABLE_RETRANSMISSIONS_METHOD_TYPE);
+    } catch (NoSuchMethodException e) {
+      try {
+        return LOOKUP.findVirtual(SSLParametersCompat.class, "fauxSetEnableRetransmissions",
+            SET_ENABLE_RETRANSMISSIONS_METHOD_TYPE);
+      } catch (Throwable t) {
+        throw new ExceptionInInitializerError(t);
+      }
+    } catch (Throwable t) {
+      throw new ExceptionInInitializerError(t);
+    }
+  }
+
+  void setEnableRetransmissionsCompat(boolean enableRetransmissions) throws Throwable {
+    SET_ENABLE_RETRANSMISSIONS_METHOD_HANDLE.invokeExact(enableRetransmissions);
+  }
+
+  private void fauxSetEnableRetransmissions(boolean setEnableRetransmissions) {
+  }
+}

--- a/io/jvm/src/main/java/fs2/io/net/unixsocket/ServerSocketChannelCompat.java
+++ b/io/jvm/src/main/java/fs2/io/net/unixsocket/ServerSocketChannelCompat.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.io.net.unixsocket;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.ProtocolFamily;
+import java.nio.channels.ServerSocketChannel;
+
+final class ServerSocketChannelCompat {
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final MethodType OPEN_METHOD_TYPE = MethodType.methodType(ServerSocketChannel.class,
+      ProtocolFamily.class);
+  private static final MethodHandle OPEN_METHOD_HANDLE = initOpenMethodHandle();
+
+  private static MethodHandle initOpenMethodHandle() {
+    try {
+      return LOOKUP.findStatic(ServerSocketChannel.class, "open", OPEN_METHOD_TYPE);
+    } catch (Throwable t) {
+      throw new ExceptionInInitializerError(t);
+    }
+  }
+
+  static ServerSocketChannel open(ProtocolFamily family) throws Throwable {
+    return (ServerSocketChannel) OPEN_METHOD_HANDLE.invokeExact(family);
+  }
+}

--- a/io/jvm/src/main/java/fs2/io/net/unixsocket/SocketChannelCompat.java
+++ b/io/jvm/src/main/java/fs2/io/net/unixsocket/SocketChannelCompat.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.io.net.unixsocket;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.ProtocolFamily;
+import java.nio.channels.SocketChannel;
+
+final class SocketChannelCompat {
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final MethodType OPEN_METHOD_TYPE = MethodType.methodType(SocketChannel.class, ProtocolFamily.class);
+  private static final MethodHandle OPEN_METHOD_HANDLE = initOpenMethodHandle();
+
+  private static MethodHandle initOpenMethodHandle() {
+    try {
+      return LOOKUP.findStatic(SocketChannel.class, "open", OPEN_METHOD_TYPE);
+    } catch (Throwable t) {
+      throw new ExceptionInInitializerError(t);
+    }
+  }
+
+  static SocketChannel open(ProtocolFamily family) throws Throwable {
+    return (SocketChannel) OPEN_METHOD_HANDLE.invokeExact(family);
+  }
+}

--- a/io/jvm/src/main/java/fs2/io/net/unixsocket/StandardProtocolFamilyCompat.java
+++ b/io/jvm/src/main/java/fs2/io/net/unixsocket/StandardProtocolFamilyCompat.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.io.net.unixsocket;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.net.StandardProtocolFamily;
+
+final class StandardProtocolFamilyCompat {
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final MethodHandle UNIX_METHOD_HANDLE = initUnixMethodHandle();
+
+  private static MethodHandle initUnixMethodHandle() {
+    try {
+      return LOOKUP.findStaticGetter(StandardProtocolFamily.class, "UNIX", StandardProtocolFamily.class);
+    } catch (Throwable t) {
+      throw new ExceptionInInitializerError(t);
+    }
+  }
+
+  static final StandardProtocolFamily UNIX = initUnix();
+
+  private static StandardProtocolFamily initUnix() {
+    try {
+      return (StandardProtocolFamily) UNIX_METHOD_HANDLE.invokeExact();
+    } catch (Throwable t) {
+      throw new ExceptionInInitializerError(t);
+    }
+  }
+}

--- a/io/jvm/src/main/java/fs2/io/net/unixsocket/UnixDomainSocketAddressCompat.java
+++ b/io/jvm/src/main/java/fs2/io/net/unixsocket/UnixDomainSocketAddressCompat.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.io.net.unixsocket;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.SocketAddress;
+
+final class UnixDomainSocketAddressCompat {
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final Class<?> UNIX_DOMAIN_SOCKET_ADDRESS_CLASS = initUnixDomainSocketAddressClass();
+
+  private static final MethodType OF_METHOD_TYPE = MethodType.methodType(SocketAddress.class, String.class);
+  private static final MethodHandle OF_METHOD_HANDLE = initOfMethodHandle();
+
+  private static Class<?> initUnixDomainSocketAddressClass() {
+    try {
+      return Class.forName("java.net.UnixDomainSocketAddress");
+    } catch (ClassNotFoundException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static MethodHandle initOfMethodHandle() {
+    try {
+      return LOOKUP.findStatic(UNIX_DOMAIN_SOCKET_ADDRESS_CLASS, "of", OF_METHOD_TYPE);
+    } catch (Throwable t) {
+      throw new ExceptionInInitializerError(t);
+    }
+  }
+
+  static SocketAddress of(String pathname) throws Throwable {
+    return (SocketAddress) OF_METHOD_HANDLE.invoke(pathname);
+  }
+}

--- a/io/jvm/src/main/java/fs2/io/net/unixsocket/UnixDomainSocketAddressCompat.java
+++ b/io/jvm/src/main/java/fs2/io/net/unixsocket/UnixDomainSocketAddressCompat.java
@@ -30,7 +30,8 @@ final class UnixDomainSocketAddressCompat {
   private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
   private static final Class<?> UNIX_DOMAIN_SOCKET_ADDRESS_CLASS = initUnixDomainSocketAddressClass();
 
-  private static final MethodType OF_METHOD_TYPE = MethodType.methodType(SocketAddress.class, String.class);
+  private static final MethodType OF_METHOD_TYPE = MethodType.methodType(UNIX_DOMAIN_SOCKET_ADDRESS_CLASS,
+      String.class);
   private static final MethodHandle OF_METHOD_HANDLE = initOfMethodHandle();
 
   private static Class<?> initUnixDomainSocketAddressClass() {

--- a/io/jvm/src/main/scala/fs2/io/net/SocketOptionPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SocketOptionPlatform.scala
@@ -64,7 +64,7 @@ private[net] trait SocketOptionCompanionPlatform {
     boolean(StandardSocketOptions.SO_REUSEADDR, value)
 
   def reusePort(value: Boolean): SocketOption =
-    boolean(StandardSocketOptions.SO_REUSEPORT, value)
+    boolean(StandardSocketOptionsCompat.SO_REUSEPORT, value)
 
   def sendBufferSize(value: Int): SocketOption =
     integer(StandardSocketOptions.SO_SNDBUF, value)

--- a/io/jvm/src/main/scala/fs2/io/net/tls/TLSEngine.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/tls/TLSEngine.scala
@@ -221,7 +221,7 @@ private[tls] object TLSEngine {
                     )
                 }
             }
-          case SSLEngineResult.HandshakeStatus.NEED_UNWRAP_AGAIN =>
+          case _ /* SSLEngineResult.HandshakeStatus.NEED_UNWRAP_AGAIN */ =>
             unwrapHandshake
         }
 

--- a/io/jvm/src/main/scala/fs2/io/net/tls/TLSParameters.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/tls/TLSParameters.scala
@@ -61,7 +61,7 @@ sealed trait TLSParameters {
     cipherSuites.foreach(cs => p.setCipherSuites(cs.toArray))
     enableRetransmissions.foreach(p.setEnableRetransmissionsCompat)
     endpointIdentificationAlgorithm.foreach(p.setEndpointIdentificationAlgorithm)
-    maximumPacketSize.foreach(p.setMaximumPacketSize)
+    maximumPacketSize.foreach(p.setMaximumPacketSizeCompat)
     protocols.foreach(ps => p.setProtocols(ps.toArray))
     serverNames.foreach(sn => p.setServerNames(sn.asJava))
     sniMatchers.foreach(sm => p.setSNIMatchers(sm.asJava))

--- a/io/jvm/src/main/scala/fs2/io/net/tls/TLSParameters.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/tls/TLSParameters.scala
@@ -55,11 +55,11 @@ sealed trait TLSParameters {
     * `needClientAuth` and `wantClientAuth` are mutually exclusive on `SSLParameters`. If both set on this `TLSParameters`, then `needClientAuth` takes precedence.
     */
   def toSSLParameters: SSLParameters = {
-    val p = new SSLParameters()
+    val p = new SSLParametersCompat()
     algorithmConstraints.foreach(p.setAlgorithmConstraints)
     applicationProtocols.foreach(ap => p.setApplicationProtocols(ap.toArray))
     cipherSuites.foreach(cs => p.setCipherSuites(cs.toArray))
-    enableRetransmissions.foreach(p.setEnableRetransmissions)
+    enableRetransmissions.foreach(p.setEnableRetransmissionsCompat)
     endpointIdentificationAlgorithm.foreach(p.setEndpointIdentificationAlgorithm)
     maximumPacketSize.foreach(p.setMaximumPacketSize)
     protocols.foreach(ps => p.setProtocols(ps.toArray))

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/JdkUnixSockets.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/JdkUnixSockets.scala
@@ -22,8 +22,7 @@
 package fs2.io.net.unixsocket
 
 import cats.effect.kernel.Async
-import java.net.{StandardProtocolFamily, UnixDomainSocketAddress}
-import java.nio.channels.{ServerSocketChannel, SocketChannel}
+import java.net.StandardProtocolFamily
 
 object JdkUnixSockets {
 
@@ -36,15 +35,15 @@ object JdkUnixSockets {
 private[unixsocket] class JdkUnixSocketsImpl[F[_]](implicit F: Async[F])
     extends UnixSockets.AsyncUnixSockets[F] {
   protected def openChannel(address: UnixSocketAddress) = F.delay {
-    val ch = SocketChannel.open(StandardProtocolFamily.UNIX)
-    ch.connect(UnixDomainSocketAddress.of(address.path))
+    val ch = SocketChannelCompat.open(StandardProtocolFamilyCompat.UNIX)
+    ch.connect(UnixDomainSocketAddressCompat.of(address.path))
     ch
   }
 
   protected def openServerChannel(address: UnixSocketAddress) = F.blocking {
-    val serverChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+    val serverChannel = ServerSocketChannelCompat.open(StandardProtocolFamilyCompat.UNIX)
     serverChannel.configureBlocking(false)
-    serverChannel.bind(UnixDomainSocketAddress.of(address.path))
+    serverChannel.bind(UnixDomainSocketAddressCompat.of(address.path))
     (F.blocking(serverChannel.accept()), F.blocking(serverChannel.close()))
   }
 }

--- a/io/jvm/src/test/scala/fs2/io/net/tcp/SocketSuitePlatform.scala
+++ b/io/jvm/src/test/scala/fs2/io/net/tcp/SocketSuitePlatform.scala
@@ -25,12 +25,17 @@ import fs2.io.net.SocketOption
 
 trait SocketSuitePlatform {
 
+  private val modernJDKs = Set("11", "17")
+
   val setupOptionsPlatform = List(SocketOption.sendBufferSize(10000))
   val optionsPlatform = List(
     SocketOption.receiveBufferSize(1024),
     SocketOption.reuseAddress(true),
-    SocketOption.reusePort(true),
     SocketOption.sendBufferSize(1024)
-  )
+  ) ++ {
+    if (modernJDKs.contains(System.getProperty("java.version").substring(0, 2)))
+      List(SocketOption.reusePort(true))
+    else Nil
+  }
 
 }

--- a/io/jvm/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -104,12 +104,21 @@ class TLSSocketSuite extends TLSSuite {
             .catchNonFatal(SSLContext.getInstance(protocol))
             .isRight
 
+        val modernJDKs = Set("11", "17")
+
         val enabled: Boolean =
           Either
             .catchNonFatal {
               val disabledAlgorithms = Security.getProperty("jdk.tls.disabledAlgorithms")
               !disabledAlgorithms.contains(protocol)
             }
+            .filterOrElse(
+              { _ =>
+                val version = System.getProperty("java.version")
+                protocol != "TLSv1.3" || modernJDKs.contains(version.substring(0, 2))
+              },
+              false
+            )
             .getOrElse(false)
 
         if (!supportedByPlatform)


### PR DESCRIPTION
This PR shows how to use `java.lang.MethodHandle` to essentially do reflection, just without the bad APIs. If initialized (lazily), these MethodHandles will try to find the appropriate methods that are available only on JDK16+ (mainly for Unix sockets) and link to them. This linking only happens once, so any further calls will be directly linked and are subject to optimizations by the JIT (unlike reflection).

This allows the project to be built using JDK 8, and be sure that JDK 8 platform specification is respected when linking against some problematic APIs like byte buffers (which is not exactly the same as building with a newer JDK and targeting an old one). How highly this feature is desired, is another debate.

Usage of new APIs works and it is tested in the CI.