### PR TITLE
Re-working `readReadable` API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,7 +186,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel" %%% "cats-effect-laws" % "3.2.9" % Test,
       "org.typelevel" %%% "cats-effect-testkit" % "3.2.9" % Test,
       "org.scodec" %%% "scodec-bits" % "1.1.29",
-      "org.typelevel" %%% "scalacheck-effect-munit" % "1.0.2" % Test,
+      "org.typelevel" %%% "scalacheck-effect-munit" % "1.0.3" % Test,
       "org.typelevel" %%% "munit-cats-effect-3" % "1.0.6" % Test,
       "org.typelevel" %%% "discipline-munit" % "1.0.9" % Test
     ),

--- a/core/shared/src/test/scala/fs2/CompressionSuite.scala
+++ b/core/shared/src/test/scala/fs2/CompressionSuite.scala
@@ -111,7 +111,7 @@ abstract class CompressionSuite(implicit compression: Compression[IO]) extends F
     }
   }
 
-  test("inflate input") {
+  test("inflate input".ignore) { // TODO: This test hangs after upgrading to latest scalacheck-effect release, which fixed generators to increase sizes
     forAllF {
       (
           s: String,

--- a/core/shared/src/test/scala/fs2/CompressionSuite.scala
+++ b/core/shared/src/test/scala/fs2/CompressionSuite.scala
@@ -111,7 +111,7 @@ abstract class CompressionSuite(implicit compression: Compression[IO]) extends F
     }
   }
 
-  test("inflate input".ignore) { // TODO: This test hangs after upgrading to latest scalacheck-effect release, which fixed generators to increase sizes
+  test("inflate input") {
     forAllF {
       (
           s: String,

--- a/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -33,7 +33,7 @@ class IoPlatformSuite extends Fs2Suite {
       bytes
         .through(toReadable[IO])
         .flatMap { readable =>
-          readReadable(IO.pure(readable))
+          Stream.resource(readReadableResource(IO.pure(readable))).flatten
         }
         .compile
         .toVector
@@ -54,7 +54,9 @@ class IoPlatformSuite extends Fs2Suite {
       bytes1
         .through {
           toDuplexAndRead[IO] { duplex =>
-            readReadable[IO](IO.pure(duplex))
+            Stream
+              .resource(readReadableResource[IO](IO.pure(duplex)))
+              .flatten
               .merge(bytes2.covary[IO].through(writeWritable[IO](IO.pure(duplex))))
               .compile
               .toVector

--- a/io/js/src/test/scala/fs2/io/NodeJSCompressionSuite.scala
+++ b/io/js/src/test/scala/fs2/io/NodeJSCompressionSuite.scala
@@ -29,9 +29,6 @@ import fs2.io.internal.ByteChunkOps._
 
 class NodeJSCompressionSuite extends CompressionSuite {
 
-  override def scalaCheckTestParameters =
-    super.scalaCheckTestParameters.withMaxSize(10000)
-
   override def deflateStream(
       b: Array[Byte],
       level: Int,


### PR DESCRIPTION
So far this fixes the issue reported in https://github.com/typelevel/fs2/pull/2661, but I think the API for converting a Node.js [`Readable` stream](https://nodejs.org/api/stream.html#stream_readable_streams) is still unsafe. I have another idea I want to try.