### PR TITLE
Fix socket close regression

### DIFF
--- a/io/jvm/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -36,11 +36,11 @@ private[net] trait SocketCompanionPlatform {
   private[net] def forAsync[F[_]: Async](
       ch: AsynchronousSocketChannel
   ): Resource[F, Socket[F]] =
-    Resource.eval {
+    Resource.make {
       (Semaphore[F](1), Semaphore[F](1)).mapN { (readSemaphore, writeSemaphore) =>
         new AsyncSocket[F](ch, readSemaphore, writeSemaphore)
       }
-    }
+    }(_ => Async[F].delay(if (ch.isOpen) ch.close else ()))
 
   private[net] abstract class BufferedReads[F[_]](
       readSemaphore: Semaphore[F]


### PR DESCRIPTION
This partially reverts #2644 to fix the socket close bug that came up in https://github.com/http4s/http4s/pull/5316#issuecomment-933920782 while preserving the fix for #2643. Not sure what caused the regression, or why this fixes it.