### PR TITLE
Flush CharsetDecoder to produce final chunk

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -21,6 +21,7 @@
 
 package fs2
 
+import cats.ApplicativeThrow
 import java.nio.{Buffer, ByteBuffer, CharBuffer}
 import java.nio.charset.{
   CharacterCodingException,
@@ -250,8 +251,31 @@ object text {
               outBufferSize + (decoder.maxCharsPerByte() * nextAcc.size).toInt
             )
           )
-        else Pull.done // no more input, no more output
+        else flush(decoder, lastOutBuffer) // no more input, flush for final output
       }
+
+    def flush(
+        decoder: CharsetDecoder,
+        out: CharBuffer
+    ): Pull[F, String, Unit] = {
+      out.clear()
+      decoder.flush(out) match {
+        case res if res.isUnderflow =>
+          if (out.position() > 0) {
+            out.flip()
+            Pull.output1(out.toString) >> Pull.done
+          } else
+            Pull.done
+        case res if res.isOverflow =>
+          // Can't find any that output more than two chars. This
+          // oughtta do it.
+          val newSize = (out.capacity + decoder.maxCharsPerByte * 2).toInt
+          val bigger = CharBuffer.allocate(newSize)
+          flush(decoder, bigger)
+        case res =>
+          ApplicativeThrow[Pull[F, String, *]].catchNonFatal(res.throwException())
+      }
+    }
 
     { s =>
       Stream.suspend(Stream.emit(charset.newDecoder())).flatMap { decoder =>

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -262,7 +262,7 @@ object text {
       decoder.flush(out) match {
         case res if res.isUnderflow =>
           if (out.position() > 0) {
-            out.flip()
+            (out: Buffer).flip()
             Pull.output1(out.toString) >> Pull.done
           } else
             Pull.done


### PR DESCRIPTION
Only necessary in a handful of non-UTF-8 charsets.  Setting the last input flag on the final `decode` isn't sufficient: the decoder state must be flushed in a separate call.

Fixes #2664.