### PR TITLE
Fix decodeCWithCharset with JDK8

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -258,7 +258,7 @@ object text {
         decoder: CharsetDecoder,
         out: CharBuffer
     ): Pull[F, String, Unit] = {
-      out.clear()
+      (out: Buffer).clear()
       decoder.flush(out) match {
         case res if res.isUnderflow =>
           if (out.position() > 0) {


### PR DESCRIPTION
I broke this in #2667.  It results in a fatal error that hangs decoding non-UTF-8 streams.  

Dagnabbit.