### PR TITLE
Fix #2679 - bug in Chunk.compactUntagged when used with empty or singleton chunks

### DIFF
--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -215,10 +215,4 @@ class ChunkSuite extends Fs2Suite {
   test("compactUntagged - regression #2679") {
     Chunk.Queue.singleton(Chunk.singleton(1)).traverse(x => Option(x))
   }
-
-  test("compactBoxed soundness") {
-    assertEquals(Chunk(1, 2, 3).compactBoxed.compact.values.toList, List(1, 2, 3))
-    assertEquals(Chunk(1, 2, 3).compactBoxed.toList, List(1, 2, 3))
-    assertEquals(Chunk(1, 2, 3).compactBoxed.map((_: Int) + 1).toList, List(2, 3, 4))
-  }
 }


### PR DESCRIPTION
There are three commits here, each with a different approach:
- f1b7ee3 deprecates `compactUntagged` without replacement and removes use of it internally
- ef20563 introduces a new `BoxedArraySlice` subtype of `Chunk` which stores elements in an `Array[Any]` internally, then introduces a `compactBoxed` operation which uses `BoxedArraySlice`
- 3a92d1a removes `BoxedArraySlice` in favor of implementing `compactBoxed` with `Chunk.BufferChunk` -- `BufferChunk` is backed by a `scala.collection.mutable.ArrayBuffer`, which essentially does the same trick as `BoxedArraySlice`.