### PR TITLE
Added `spaced` function, similar to `metered` but waiting

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -675,6 +675,30 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   def meteredStartImmediately[F2[x] >: F[x]: Temporal](rate: FiniteDuration): Stream[F2, O] =
     (Stream.emit(()) ++ Stream.fixedRate[F2](rate)).zipRight(this)
 
+  /** Waits the specified `delay` between each event.
+    *
+    * The resulting stream emits the same elements from `this` stream,
+    * but split into singleton chunks. Between each chunk (element) it
+    * adds a pause of a fixed `delay` duration.
+    *
+    * This method differs in the timing of elements from [[metered]].
+    * The [[metered]] combinator takes a "schedule" for elements to be released,
+    * and before each element introduces just the necessary delay to hit that time.
+    * To do so, it deducts from the pause any delay caused by other effects
+    * in the stream, or the pauses the stream consumer takes while pulling.
+    * This method, instead, simply introduced a fixed sleep time between elements,
+    * irrespective of other pauses in the stream or the consumer.
+    *
+    * Starts immediately, same as [[meteredStartImmediately]]
+    * unless parameter `startImmediately` is set to false.
+    */
+  def spaced[F2[x] >: F[x]: Temporal](
+      delay: FiniteDuration,
+      startImmediately: Boolean = true
+  ): Stream[F2, O] =
+    ((if (startImmediately) Stream.emit(()) else Stream.empty) ++ Stream.fixedDelay[F2](delay))
+      .zipRight(this)
+
   /** Logs the elements of this stream as they are pulled.
     *
     * By default, `toString` is called on each element and the result is printed


### PR DESCRIPTION
While working with the library I was kind of expecting `metered` to behave like the function I add in this PR. 
In short, the difference between `spaced` and `metered` is analogous to the one between `fixedDelay` and `fixedRate`. I also think having both makes more clear what `metered` does. 
Also decided not to have two versions of it (like `metered` and `meteredStartsImmediately`) but that's just an opinion.
I can add documentation as well. What do you think?