### PR TITLE
Opt-in for FHCRC in gzip compression

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,20 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[MissingClassProblem]("fs2.Compiler$TargetLowPriority$MonadCancelTarget"),
   ProblemFilters.exclude[MissingClassProblem]("fs2.Compiler$TargetLowPriority$MonadErrorTarget"),
   ProblemFilters.exclude[MissingTypesProblem]("fs2.Compiler$TargetLowPriority$SyncTarget"),
-  ProblemFilters.exclude[MissingClassProblem]("fs2.Chunk$VectorChunk")
+  ProblemFilters.exclude[MissingClassProblem]("fs2.Chunk$VectorChunk"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "fs2.compression.DeflateParams.fhCrcEnabled"
+  ),
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "fs2.compression.DeflateParams#DeflateParamsImpl.copy"
+  ),
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "fs2.compression.DeflateParams#DeflateParamsImpl.this"
+  ),
+  ProblemFilters.exclude[MissingTypesProblem]("fs2.compression.DeflateParams$DeflateParamsImpl$"),
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "fs2.compression.DeflateParams#DeflateParamsImpl.apply"
+  )
 )
 
 lazy val root = project

--- a/core/jvm/src/test/scala/fs2/JvmCompressionSuite.scala
+++ b/core/jvm/src/test/scala/fs2/JvmCompressionSuite.scala
@@ -271,7 +271,7 @@ class JvmCompressionSuite extends CompressionSuite {
       .map { compressed =>
         val headerBytes = ByteVector(compressed.take(10))
         val crc32 = crc.crc32(headerBytes.toBitVector).toByteArray
-        val expectedCrc16 = crc32.drop(2).take(2).reverse.toVector
+        val expectedCrc16 = crc32.reverse.take(2).toVector
         val actualCrc16 = compressed.drop(10).take(2)
         assertEquals(actualCrc16, expectedCrc16)
       }

--- a/core/shared/src/main/scala/fs2/compression/DeflateParams.scala
+++ b/core/shared/src/main/scala/fs2/compression/DeflateParams.scala
@@ -46,7 +46,7 @@ sealed trait DeflateParams {
   val flushMode: DeflateParams.FlushMode
 
   /** A [[Boolean]] indicating whether the `FLG.FHCRC` bit is set. Default is `false`.
-    *  This is provided so that the client can opt-in and enable the CRC16 check for the gzip header.
+    *  This is provided so that the compressor can be configured to have the CRC16 check enabled.
     *  Why opt-in and not opt-out? It turned out not all clients implemented that right.
     *  More context [[https://github.com/http4s/http4s/issues/5417 in this issue]].
     */

--- a/core/shared/src/main/scala/fs2/compression/DeflateParams.scala
+++ b/core/shared/src/main/scala/fs2/compression/DeflateParams.scala
@@ -45,6 +45,13 @@ sealed trait DeflateParams {
     */
   val flushMode: DeflateParams.FlushMode
 
+  /** A [[Boolean]] indicating whether the `FLG.FHCRC` bit is set. Default is `false`.
+    *  This is provided so that the client can opt-in and enable the CRC16 check for the gzip header.
+    *  Why opt-in and not opt-out? It turned out not all clients implemented that right.
+    *  More context [[https://github.com/http4s/http4s/issues/5417 in this issue]].
+    */
+  val fhCrcEnabled: Boolean
+
   private[fs2] val bufferSizeOrMinimum: Int = bufferSize.max(128)
 }
 
@@ -57,14 +64,25 @@ object DeflateParams {
       strategy: DeflateParams.Strategy = DeflateParams.Strategy.DEFAULT,
       flushMode: DeflateParams.FlushMode = DeflateParams.FlushMode.DEFAULT
   ): DeflateParams =
-    DeflateParamsImpl(bufferSize, header, level, strategy, flushMode)
+    DeflateParamsImpl(bufferSize, header, level, strategy, flushMode, false)
+
+  def apply(
+      bufferSize: Int,
+      header: ZLibParams.Header,
+      level: DeflateParams.Level,
+      strategy: DeflateParams.Strategy,
+      flushMode: DeflateParams.FlushMode,
+      fhCrcEnabled: Boolean
+  ): DeflateParams =
+    DeflateParamsImpl(bufferSize, header, level, strategy, flushMode, fhCrcEnabled)
 
   private case class DeflateParamsImpl(
       bufferSize: Int,
       header: ZLibParams.Header,
       level: DeflateParams.Level,
       strategy: DeflateParams.Strategy,
-      flushMode: DeflateParams.FlushMode
+      flushMode: DeflateParams.FlushMode,
+      fhCrcEnabled: Boolean
   ) extends DeflateParams
 
   sealed abstract class Level(private[fs2] val juzDeflaterLevel: Int)


### PR DESCRIPTION
Context here: https://github.com/http4s/http4s/issues/5417

## TL;DR:

This FHCRC flag is an optional feature that fs2 is opting-in to (with an implementation that looks good BTW), but unfortunately, many clients have/had a bugged implementation (e.g. https://github.com/netty/netty/pull/11805) of it or perhaps don't even support it at all (and that's fine, as soon as they don't break 😄 ).

This PR is making it configurable, restoring a default of `0` (no FHCRC). 
The client can choose to opt-in by specifying the `fhCrcEnabled` property in `DeflateParams`.

Ideally, we should backport this to 2.x (for supporting http4s 0.22 as well).

Hopefully, I preserved the binary compatibility. 