### PR TITLE
Fix #2709

### DIFF
--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -114,9 +114,6 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
         }
       )
 
-    def readChunk(buff: ByteBuffer): F[Int] =
-      F.blocking(ch.read(buff))
-
     def write(bytes: Chunk[Byte]): F[Unit] = {
       def go(buff: ByteBuffer): F[Unit] =
         F.blocking(ch.write(buff)) >> {


### PR DESCRIPTION
This PR aims to fix #2709. The idea is to let `SocketCompanionPlatform.BufferedReads` carry around a mutex reference of previously-read data instead of a raw `ByteBuffer`, given that NIO channel's `read` is not really cancellable.

The change more or less complicates the code, so please point out if you spot any simplification or potential bugs.