### PR TITLE
Improve memory efficiency of Chunk.filter and replace internal use of mutable.Buffer with mutable.ArrayBuilder

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
@@ -32,9 +32,8 @@ class ChunkBenchmark {
   var ints: Chunk[Int] = _
 
   @Setup
-  def setup() = {
+  def setup() =
     ints = Chunk.seq((0 until chunkSize).map(_ + 1000)).compact
-  }
 
   @Benchmark
   def map(): Unit = {

--- a/benchmark/src/main/scala/fs2/benchmark/ChunksBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChunksBenchmark.scala
@@ -24,27 +24,46 @@ package benchmark
 
 import org.openjdk.jmh.annotations.{Benchmark, Param, Scope, Setup, State}
 
+import cats.syntax.all._
+
 @State(Scope.Thread)
-class ChunkBenchmark {
+class ChunksBenchmark {
   @Param(Array("16", "256", "4096"))
   var chunkSize: Int = _
 
-  var ints: Chunk[Int] = _
+  @Param(Array("1", "20", "50", "100"))
+  var chunkCount: Int = _
+
+  case class Obj(dummy: Boolean)
+  object Obj {
+    def create: Obj = Obj(true)
+  }
+
+  var chunkSeq: Seq[Chunk[Obj]] = _
+  var flattened: Chunk[Obj] = _
+  var sizeHint: Int = _
 
   @Setup
   def setup() = {
-    ints = Chunk.seq((0 until chunkSize).map(_ + 1000)).compact
+    chunkSeq = Seq.range(0, chunkCount).map(_ => Chunk.seq(Seq.fill(chunkSize)(Obj.create)))
+    sizeHint = chunkSeq.foldLeft(0)(_ + _.size)
+    flattened = Chunk.seq(chunkSeq).flatten
   }
 
   @Benchmark
-  def map(): Unit = {
-    ints.map(_ + 1)
+  def concat(): Unit = {
+    Chunk.concat(chunkSeq, sizeHint)
     ()
   }
 
   @Benchmark
-  def filter(): Unit = {
-    ints.filter(_ % 3 == 0)
-    ()
+  def traverse(): Boolean = {
+    val fn: () => Chunk[Boolean] =
+      flattened.traverse { obj =>
+        if (obj.dummy) { () => true }
+        else { () => false }
+      }
+
+    fn().isEmpty
   }
 }

--- a/core/shared/src/main/scala-2.12/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-2.12/fs2/ChunkPlatform.scala
@@ -21,10 +21,13 @@
 
 package fs2
 
-import scala.collection.mutable.WrappedArray
+import scala.collection.mutable.{ArrayBuilder, WrappedArray}
 import scala.reflect.ClassTag
 
-private[fs2] trait ChunkPlatform[+O] { self: Chunk[O] => }
+private[fs2] trait ChunkPlatform[+O] { self: Chunk[O] =>
+  protected def makeArrayBuilder[A](implicit ct: ClassTag[A]): ArrayBuilder[A] =
+    ArrayBuilder.make()(ct)
+}
 
 private[fs2] trait ChunkCompanionPlatform { self: Chunk.type =>
 

--- a/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
@@ -23,9 +23,13 @@ package fs2
 
 import scala.collection.immutable.ArraySeq
 import scala.collection.immutable
+import scala.collection.mutable.ArrayBuilder
 import scala.reflect.ClassTag
 
 private[fs2] trait ChunkPlatform[+O] { self: Chunk[O] =>
+
+  protected def makeArrayBuilder[A](implicit ct: ClassTag[A]): ArrayBuilder[A] =
+    ArrayBuilder.make(ct)
 
   def toArraySeq[O2 >: O: ClassTag]: ArraySeq[O2] = {
     val array: Array[O2] = new Array[O2](size)

--- a/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
@@ -23,9 +23,13 @@ package fs2
 
 import scala.collection.immutable.ArraySeq
 import scala.collection.immutable
+import scala.collection.mutable.ArrayBuilder
 import scala.reflect.ClassTag
 
 private[fs2] trait ChunkPlatform[+O] { self: Chunk[O] =>
+
+  protected def makeArrayBuilder[A](implicit ct: ClassTag[A]): ArrayBuilder[A] =
+    ArrayBuilder.make(ct)
 
   def toArraySeq[O2 >: O: ClassTag]: ArraySeq[O2] = {
     val array: Array[O2] = new Array[O2](size)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -112,7 +112,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
 
   /** Returns a chunk that has only the elements that satisfy the supplied predicate. */
   def filter(p: O => Boolean): Chunk[O] = {
-    val b = collection.mutable.ArrayBuilder.make(thisClassTag)
+    val b = makeArrayBuilder(thisClassTag)
     b.sizeHint(size)
     foreach(e => if (p(e)) b += e)
     Chunk.array(b.result()).asInstanceOf[Chunk[O]]
@@ -187,7 +187,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
 
   /** Creates a new chunk by applying `f` to each element in this chunk. */
   def map[O2](f: O => O2): Chunk[O2] = {
-    val b = collection.mutable.ArrayBuilder.make[Any]
+    val b = makeArrayBuilder[Any]
     b.sizeHint(size)
     foreach(e => b += f(e))
     Chunk.array(b.result()).asInstanceOf[Chunk[O2]]
@@ -198,7 +198,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
     * the output state of the previous invocation.
     */
   def mapAccumulate[S, O2](init: S)(f: (S, O) => (S, O2)): (S, Chunk[O2]) = {
-    val b = collection.mutable.ArrayBuilder.make[Any]
+    val b = makeArrayBuilder[Any]
     b.sizeHint(size)
     var s = init
     foreach { o =>
@@ -211,7 +211,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
 
   /** Maps the supplied function over each element and returns a chunk of just the defined results. */
   def mapFilter[O2](f: O => Option[O2]): Chunk[O2] = {
-    val b = collection.mutable.ArrayBuilder.make[Any]
+    val b = makeArrayBuilder[Any]
     b.sizeHint(size)
     foreach { o =>
       val o2 = f(o)
@@ -326,7 +326,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
     */
   def toIndexedChunk: Chunk[O] = this match {
     case _: Chunk.Queue[_] =>
-      val b = collection.mutable.ArrayBuilder.make[Any]
+      val b = makeArrayBuilder[Any]
       b.sizeHint(size)
       foreach(o => b += o)
       Chunk.array(b.result()).asInstanceOf[Chunk[O]]

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -187,10 +187,9 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
 
   /** Creates a new chunk by applying `f` to each element in this chunk. */
   def map[O2](f: O => O2): Chunk[O2] = {
-    val b = makeArrayBuilder[Any]
-    b.sizeHint(size)
-    foreach(e => b += f(e))
-    Chunk.array(b.result()).asInstanceOf[Chunk[O2]]
+    val arr = new Array[Any](size)
+    foreachWithIndex((e, i) => arr(i) = f(e))
+    Chunk.array(arr).asInstanceOf[Chunk[O2]]
   }
 
   /** Maps the supplied stateful function over each element, outputting the final state and the accumulated outputs.
@@ -198,15 +197,14 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
     * the output state of the previous invocation.
     */
   def mapAccumulate[S, O2](init: S)(f: (S, O) => (S, O2)): (S, Chunk[O2]) = {
-    val b = makeArrayBuilder[Any]
-    b.sizeHint(size)
+    val arr = new Array[Any](size)
     var s = init
-    foreach { o =>
+    foreachWithIndex { (o, i) =>
       val (s2, o2) = f(s, o)
-      b += o2
+      arr(i) = o2
       s = s2
     }
-    s -> Chunk.array(b.result()).asInstanceOf[Chunk[O2]]
+    s -> Chunk.array(arr).asInstanceOf[Chunk[O2]]
   }
 
   /** Maps the supplied function over each element and returns a chunk of just the defined results. */

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -32,7 +32,8 @@ import cats.{Alternative, Applicative, Eq, Eval, Monad, Monoid, Traverse, Traver
 import cats.data.{Chain, NonEmptyList}
 import cats.syntax.all._
 
-/** Strict, finite sequence of values that allows index-based random access of elements.
+/** Immutable, strict, finite sequence of values that supports efficient index-based random access of elements,
+  * is memory efficient for all sizes, and avoids unnecessary copying.
   *
   * `Chunk`s can be created from a variety of collection types using methods on the `Chunk` companion
   * (e.g., `Chunk.array`, `Chunk.seq`, `Chunk.vector`).
@@ -107,12 +108,14 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
   /** Drops the right-most `n` elements of this chunk queue in a way that preserves chunk structure. */
   def dropRight(n: Int): Chunk[O] = if (n <= 0) this else take(size - n)
 
+  protected def thisClassTag: ClassTag[Any] = implicitly[ClassTag[Any]]
+
   /** Returns a chunk that has only the elements that satisfy the supplied predicate. */
   def filter(p: O => Boolean): Chunk[O] = {
-    val b = collection.mutable.Buffer.newBuilder[O]
+    val b = collection.mutable.ArrayBuilder.make(thisClassTag)
     b.sizeHint(size)
     foreach(e => if (p(e)) b += e)
-    Chunk.buffer(b.result())
+    Chunk.array(b.result()).asInstanceOf[Chunk[O]]
   }
 
   /** Returns the first element for which the predicate returns true or `None` if no elements satisfy the predicate. */
@@ -184,9 +187,10 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
 
   /** Creates a new chunk by applying `f` to each element in this chunk. */
   def map[O2](f: O => O2): Chunk[O2] = {
-    val arr = new Array[Any](size)
-    foreachWithIndex((o, i) => arr(i) = f(o))
-    Chunk.array(arr).asInstanceOf[Chunk[O2]]
+    val b = collection.mutable.ArrayBuilder.make[Any]
+    b.sizeHint(size)
+    foreach(e => b += f(e))
+    Chunk.array(b.result()).asInstanceOf[Chunk[O2]]
   }
 
   /** Maps the supplied stateful function over each element, outputting the final state and the accumulated outputs.
@@ -194,25 +198,26 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
     * the output state of the previous invocation.
     */
   def mapAccumulate[S, O2](init: S)(f: (S, O) => (S, O2)): (S, Chunk[O2]) = {
-    val arr = new Array[Any](size)
+    val b = collection.mutable.ArrayBuilder.make[Any]
+    b.sizeHint(size)
     var s = init
-    foreachWithIndex { (o, i) =>
+    foreach { o =>
       val (s2, o2) = f(s, o)
-      arr(i) = o2
+      b += o2
       s = s2
     }
-    s -> Chunk.array(arr).asInstanceOf[Chunk[O2]]
+    s -> Chunk.array(b.result()).asInstanceOf[Chunk[O2]]
   }
 
   /** Maps the supplied function over each element and returns a chunk of just the defined results. */
   def mapFilter[O2](f: O => Option[O2]): Chunk[O2] = {
-    val b = collection.mutable.Buffer.newBuilder[O2]
+    val b = collection.mutable.ArrayBuilder.make[Any]
     b.sizeHint(size)
     foreach { o =>
       val o2 = f(o)
       if (o2.isDefined) b += o2.get
     }
-    Chunk.buffer(b.result())
+    Chunk.array(b.result()).asInstanceOf[Chunk[O2]]
   }
 
   /** False if size is zero, true otherwise. */
@@ -321,10 +326,10 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
     */
   def toIndexedChunk: Chunk[O] = this match {
     case _: Chunk.Queue[_] =>
-      val b = collection.mutable.Buffer.newBuilder[O]
+      val b = collection.mutable.ArrayBuilder.make[Any]
       b.sizeHint(size)
       foreach(o => b += o)
-      Chunk.buffer(b.result())
+      Chunk.array(b.result()).asInstanceOf[Chunk[O]]
     case other => other
   }
 
@@ -683,9 +688,12 @@ object Chunk
 
   case class ArraySlice[O](values: Array[O], offset: Int, length: Int)(implicit ct: ClassTag[O])
       extends Chunk[O] {
+
     require(
       offset >= 0 && offset <= values.size && length >= 0 && length <= values.size && offset + length <= values.size
     )
+
+    override protected def thisClassTag: ClassTag[Any] = ct.asInstanceOf[ClassTag[Any]]
 
     def size = length
     def apply(i: Int) = values(offset + i)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -188,7 +188,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
   /** Creates a new chunk by applying `f` to each element in this chunk. */
   def map[O2](f: O => O2): Chunk[O2] = {
     val arr = new Array[Any](size)
-    foreachWithIndex((e, i) => arr(i) = f(e))
+    foreachWithIndex((o, i) => arr(i) = f(o))
     Chunk.array(arr).asInstanceOf[Chunk[O2]]
   }
 


### PR DESCRIPTION
This PR:
- replaces uses of mutable.Buffer with mutable.ArrayBuilder
- allocates primitive arrays when possible (e.g. filter)

```
# Map

## new Array(size)
[info] ChunkBenchmark.map           16  thrpt    5  20039615.265 ± 492279.237  ops/s
[info] ChunkBenchmark.map          256  thrpt    5   1278011.968 ±  42407.622  ops/s
[info] ChunkBenchmark.map         4096  thrpt    5     46243.164 ±    295.401  ops/s

## ArrayBuilder
[info] ChunkBenchmark.map           16  thrpt    5  43344785.011 ± 665760.099  ops/s
[info] ChunkBenchmark.map          256  thrpt    5   3551895.914 ±  12759.777  ops/s
[info] ChunkBenchmark.map         4096  thrpt    5     69298.960 ±   4435.243  ops/s

# Filter

## ArrayBuilder
[info] ChunkBenchmark.filter           16  thrpt    5  30132296.897 ± 378366.725  ops/s
[info] ChunkBenchmark.filter          256  thrpt    5   2326540.853 ±   7729.015  ops/s
[info] ChunkBenchmark.filter         4096  thrpt    5     66920.922 ±   1146.317  ops/s

## mutable.Buffer
[info] ChunkBenchmark.filter           16  thrpt    5  15843176.346 ± 109023.863  ops/s
[info] ChunkBenchmark.filter          256  thrpt    5   1031608.241 ±   3938.483  ops/s
[info] ChunkBenchmark.filter         4096  thrpt    5     55229.486 ±   4883.909  ops/s
```