### PR TITLE
ioJS: handle NoSuchFileException in isDirectory, isFile and isSymbolicLink

### DIFF
--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -217,7 +217,7 @@ private[fs2] trait FilesCompanionPlatform {
       getPosixFileAttributes(path, followLinks).map(_.permissions)
 
     override def isDirectory(path: Path, followLinks: Boolean): F[Boolean] =
-      stat(path, followLinks).map(_.isDirectory())
+      stat(path, followLinks).map(_.isDirectory()).recover { case _: NoSuchFileException => false }
 
     override def isExecutable(path: Path): F[Boolean] =
       access(path, fsMod.constants.X_OK)
@@ -234,10 +234,10 @@ private[fs2] trait FilesCompanionPlatform {
       access(path, fsMod.constants.R_OK)
 
     override def isRegularFile(path: Path, followLinks: Boolean): F[Boolean] =
-      stat(path, followLinks).map(_.isFile())
+      stat(path, followLinks).map(_.isFile()).recover { case _: NoSuchFileException => false }
 
     override def isSymbolicLink(path: Path): F[Boolean] =
-      stat(path).map(_.isSymbolicLink())
+      stat(path).map(_.isSymbolicLink()).recover { case _: NoSuchFileException => false }
 
     override def isWritable(path: Path): F[Boolean] =
       access(path, fsMod.constants.W_OK)

--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -222,12 +222,9 @@ private[fs2] trait FilesCompanionPlatform {
     override def isExecutable(path: Path): F[Boolean] =
       access(path, fsMod.constants.X_OK)
 
-    private val HiddenPattern = raw"/(^|\/)\.[^\/\.]/g".r
     override def isHidden(path: Path): F[Boolean] = F.pure {
-      path.toString match {
-        case HiddenPattern() => true
-        case _               => false
-      }
+      val fileName = path.fileName.toString
+      fileName.length >= 2 && fileName(0) == '.' && fileName(1) != '.'
     }
 
     override def isReadable(path: Path): F[Boolean] =

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -23,7 +23,7 @@ package fs2
 package io
 package file
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.kernel.Order
 import cats.syntax.all._
 
@@ -637,7 +637,20 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
   }
 
   group("isSymbolicLink") {
-    // TODO test the true-case with an actual symlink
+
+    test("returns true if the path is for a symbolic link") {
+      val symLink = for {
+        dir <- tempDirectory
+        file <- tempFile
+        symLinkPath = dir.resolve("temp-sym-link")
+        _ <- Resource.make(Files[IO].createSymbolicLink(symLinkPath, file)) { _ =>
+          Files[IO].deleteIfExists(symLinkPath).void
+        }
+      } yield symLinkPath
+      symLink
+        .use(Files[IO].isSymbolicLink(_))
+        .assertEquals(true)
+    }
 
     test("returns false if the path is for a directory") {
       tempDirectory

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -541,6 +541,13 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
         .use(Files[IO].isDirectory(_))
         .assertEquals(true)
     }
+
+    test("returns false if the path does not exist") {
+      tempDirectory
+        .map(_.resolve("non-existent-file"))
+        .use(Files[IO].isDirectory(_))
+        .assertEquals(false)
+    }
   }
 
   group("isFile") {
@@ -553,6 +560,95 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
     test("returns false if the path is for a directory") {
       tempDirectory
         .use(Files[IO].isRegularFile(_))
+        .assertEquals(false)
+    }
+
+    test("returns false if the path does not exist") {
+      tempDirectory
+        .map(_.resolve("non-existent-file"))
+        .use(Files[IO].isRegularFile(_))
+        .assertEquals(false)
+    }
+  }
+
+  group("isReadable") {
+    test("returns true if the path is for a readable file") {
+      tempFile
+        .use(Files[IO].isReadable(_))
+        .assertEquals(true)
+    }
+
+    test("returns true if the path is for a directory") {
+      tempDirectory
+        .use(Files[IO].isReadable(_))
+        .assertEquals(true)
+    }
+
+    test("returns false if the path does not exist") {
+      tempDirectory
+        .map(_.resolve("non-existent-file"))
+        .use(Files[IO].isReadable(_))
+        .assertEquals(false)
+    }
+  }
+
+  group("isWritable") {
+    test("returns true if the path is for a readable file") {
+      tempFile
+        .use(Files[IO].isWritable(_))
+        .assertEquals(true)
+    }
+
+    test("returns true if the path is for a directory") {
+      tempDirectory
+        .use(Files[IO].isWritable(_))
+        .assertEquals(true)
+    }
+
+    test("returns false if the path does not exist") {
+      tempDirectory
+        .map(_.resolve("non-existent-file"))
+        .use(Files[IO].isWritable(_))
+        .assertEquals(false)
+    }
+  }
+
+  group("isHidden") {
+    // TODO test the true-case
+
+    test("returns false if the path is for a readable file") {
+      tempFile
+        .use(Files[IO].isHidden(_))
+        .assertEquals(false)
+    }
+
+    test("returns false if the path is for a directory") {
+      tempDirectory
+        .use(Files[IO].isHidden(_))
+        .assertEquals(false)
+    }
+
+    test("returns false if the path does not exist") {
+      tempDirectory
+        .map(_.resolve("non-existent-file"))
+        .use(Files[IO].isWritable(_))
+        .assertEquals(false)
+    }
+  }
+
+  group("isSymbolicLink") {
+    // TODO test the true-case with an actual symlink
+
+    test("returns false if the path is for a directory") {
+      tempDirectory
+        .use(Files[IO].isSymbolicLink(_))
+        .assertEquals(false)
+    }
+
+    test("returns false if the path does not exist") {
+      tempDirectory
+        .map(_.resolve("non-existent-file"))
+        .use(Files[IO].isSymbolicLink(_))
         .assertEquals(false)
     }
   }


### PR DESCRIPTION
In nodejs, calling `stat` throws an exception if the path does not exist, thus making `isDirectory`, `isFile` and `isSymbolicLink` fail as well. In jvm, on the other hand, the underlying calls do not throw and return `false` when the path does not exist.

This is an attempt to make the behaviour of these functions more aligned across platforms.

---

~There's a couple of TODOs in the tests, not sure how important these are:~
* ~not sure how to easily create a symlink for tests~
* ~not sure how to create a "hidden" file for tests~