### PR TITLE
Change Socket#read to disallow a read after a timeout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,9 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[MissingTypesProblem]("fs2.compression.DeflateParams$DeflateParamsImpl$"),
   ProblemFilters.exclude[DirectMissingMethodProblem](
     "fs2.compression.DeflateParams#DeflateParamsImpl.apply"
+  ),
+  ProblemFilters.exclude[MissingClassProblem](
+    "fs2.io.net.SocketCompanionPlatform$IntCallbackHandler"
   )
 )
 

--- a/io/jvm/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -54,7 +54,7 @@ private[net] trait SocketCompanionPlatform {
       F.uncancelable { p =>
         p(readSemaphore.acquire) *>
           p(fa)
-            .onCancel(F.delay(this.readBuffer = null))
+            .onCancel(F.delay(this.readBuffer = null) *> endOfInput)
             .guarantee(readSemaphore.release)
       }
 

--- a/io/jvm/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -92,7 +92,7 @@ private[net] trait SocketCompanionPlatform {
 
     def read(max: Int): F[Option[Chunk[Byte]]] =
       withReadBuffer(max) { buffer =>
-        readChunk(buffer).flatMap[Option[Chunk[Byte]]] { read =>
+        readChunk(buffer).flatMap { read =>
           if (read < 0) F.pure(None)
           else releaseBuffer(buffer).map(Some(_))
         }

--- a/io/jvm/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -66,8 +66,8 @@ class TLSSocketSuite extends TLSSuite {
               Stream(googleDotCom)
                 .covary[IO]
                 .through(text.utf8.encode)
-                .through(tlsSocket.writes) ++
-                Stream.exec(tlsSocket.endOfOutput) ++
+                .through(tlsSocket.writes)
+                .onFinalize(tlsSocket.endOfOutput) ++
                 tlsSocket.reads
                   .through(text.utf8.decode)
                   .through(text.lines)
@@ -141,7 +141,7 @@ class TLSSocketSuite extends TLSSuite {
           }.parJoinUnbounded
 
           val client =
-            Stream.exec(clientSocket.write(msg)) ++
+            Stream.exec(clientSocket.write(msg)).onFinalize(clientSocket.endOfOutput) ++
               clientSocket.reads.take(msg.size.toLong)
 
           client.concurrently(echoServer)
@@ -169,7 +169,7 @@ class TLSSocketSuite extends TLSSuite {
           }.parJoinUnbounded
 
           val client =
-            Stream.exec(clientSocket.write(msg)) ++
+            Stream.exec(clientSocket.write(msg)).onFinalize(clientSocket.endOfOutput) ++
               clientSocket.reads.take(msg.size.toLong)
 
           client.concurrently(echoServer)
@@ -207,7 +207,7 @@ class TLSSocketSuite extends TLSSuite {
           }.parJoinUnbounded
 
           val client =
-            Stream.exec(clientSocket.write(msg)) ++
+            Stream.exec(clientSocket.write(msg)).onFinalize(clientSocket.endOfOutput) ++
               clientSocket.reads.take(msg.size.toLong)
 
           client.concurrently(echoServer)

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -238,11 +238,11 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
               client.write(msg) *>
               client
                 .readN(msg.size)
-                .timeout(100.millis)
+                .timeout(1000.millis)
                 .attempt
                 .map { res =>
                   if (isJVM) assert(res.merge.isInstanceOf[IllegalStateException])
-                  else assertEquals(res.merge, msg)
+                  else assertEquals(res, Right(msg))
                 }
           Stream.eval(prg).concurrently(echoServer)
         }

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -238,7 +238,6 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
               client.write(msg) *>
               client
                 .readN(msg.size)
-                .timeout(1000.millis)
                 .attempt
                 .map { res =>
                   if (isJVM) assert(res.merge.isInstanceOf[IllegalStateException])

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -227,7 +227,7 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
       Stream
         .resource(setup)
         .flatMap { case (server, client) =>
-          val echoServer = server.flatMap(c => c.reads.through(c.writes))
+          val echoServer = server.flatMap(c => c.writes(c.reads).attempt)
           val msg = Chunk.array("Hello!".getBytes)
           val prg =
             client.write(msg) *>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,6 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.4")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24")
 addSbtPlugin("org.scalablytyped.converter" % "sbt-converter" % "1.0.0-beta36")
+
+// Needed until sjs 1.8 due to https://github.com/scala-js/scala-js-js-envs/issues/12
+libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.2.1"


### PR DESCRIPTION
Fixes https://github.com/typelevel/fs2/issues/2709

We explored four solutions here:
1) Making reads uncancellable
2) Allow read to be canceled and then any subsequent reads hang
3) Improving the error message when reading from a socket that's had a canceled read
4) Making reads after a canceled read behave like a closed socket

## Making reads uncancellable

The JVM's async channel read does not support cancelation. Hence, the simplest approach is wrapping the channel read with an `F.uncancellable`. We modified `readChunk` and wrapped the `F.async_` call with `F.uncancellable(_ => F.async_(...))`. Unfortunately, this resulted in stream hangs any time a read was pending at the time of shutdown. For example:

```scala
val server = Network[IO].server(...)
doStuff.concurrently(server)
```

When `doStuff` completes, the `server` stream is interrupted. However, if there are any accepted sockets which are waiting on a `read`, shutdown hangs until those reads complete -- either due to receiving data or due to the socket getting closed somehow.

Hence, we abandoned this solution.

## Allow read to be canceled and then any subsequent reads hang

The next approach allowed cancelation of read but made any subsequent reads hang (i.e. never complete). This also intentionally leaks the channel read upon cancelation - at most one of these pending reads per socket though, so no memory / resource concerns. This was implemented in ea596c2 by modifying the `readSemaphore` management such that the semaphore was not released in the event of cancelation. Hence any subsequent reads would wait forever for the `readSemaphore`. This worked but seemed confusing from an API perspective.

## Improving the error message when reading from a socket that's had a canceled read

We tried simply improving the error message in the case where a read is performed after a canceled read. The downside of this approach is that the leaked read could eventually succeed and then the next user land read would subsequently succeed.

## Making reads after a canceled read behave like a closed socket

We settled on making a canceled read shutdown the socket for future channel reads. Any user land calls to `read` or `readN` return the same result as if the socket was manually closed for reading (via `endOfInput`).

Note: the Node.js implementation doesn't suffer from this same limitation.