### PR TITLE
Fix #2717

### DIFF
--- a/core/shared/src/test/scala/fs2/StreamZipSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamZipSuite.scala
@@ -416,5 +416,15 @@ class StreamZipSuite extends Fs2Suite {
         .compile
         .drain
     }
+
+    test("#2717 - unexpected behavior of Pull") {
+      val stream = Stream(1).as(1).scope ++ Stream(2)
+      val zippedPull =
+        stream.pull.uncons1.flatMap { case Some((_, s)) =>
+          s.zipWith(Stream(3))((_, _)).pull.echo
+        }
+      val actual = zippedPull.stream.map(identity).covary[IO].compile.toList
+      actual.assertEquals(List((2, 3)))
+    }
   }
 }


### PR DESCRIPTION
Fixes #2717 by ensuring we only consider interruption status of open scopes. It might be nicer to ensure the interpreter only ever evaluates with open scopes, but that's a bigger change (I tried).