### PR TITLE
Deprecate Chunk.buffer, add Chunk.to(Collection)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,8 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[MissingClassProblem](
     "fs2.io.net.SocketCompanionPlatform$IntCallbackHandler"
-  )
+  ),
+  ProblemFilters.exclude[MissingClassProblem]("fs2.Chunk$BufferChunk")
 )
 
 lazy val root = project


### PR DESCRIPTION
This PR replaces all remaining internal uses of `collection.mutable.Buffer` with `Array` - not sure how I missed these all the first time around. :)

It also adds the `Chunk.to` method, allowing usage like `Chunk.to(Set)`.