### PR TITLE
Channel perf

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ChannelBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChannelBenchmark.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package benchmark
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.openjdk.jmh.annotations.{Benchmark, Param, Scope, Setup, State}
+import cats.syntax.all._
+import fs2.concurrent.Channel
+
+@State(Scope.Thread)
+class ChannelBenchmark {
+  @Param(Array("16", "256", "4096"))
+  var size: Int = _
+
+  var list: List[Unit] = _
+
+  @Setup
+  def setup() {
+    list = List.fill(size)(())
+  }
+
+  @Benchmark
+  def sendPull(): Unit =
+    Channel
+      .bounded[IO, Unit](size)
+      .flatMap { channel =>
+        list.traverse_(_ => channel.send(())) *> channel.close *> channel.stream.compile.drain
+      }
+      .unsafeRunSync()
+}

--- a/core/shared/src/main/scala/fs2/concurrent/Channel.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Channel.scala
@@ -201,7 +201,7 @@ object Channel {
                       producers.foreach { case (value, producer) =>
                         size += 1
                         allValues = value :: allValues
-                        unblock = unblock >> producer.complete(()).void
+                        unblock = unblock <* producer.complete(())
                       }
 
                       val toEmit = makeChunk(allValues, size)


### PR DESCRIPTION
`benchmark/ jmh:run -i 10 -wi 6 -f1 -t4 -gc true -jvmArgs "-XX:MaxRecursiveInlineLevel=3 -XX:MaxInlineSize=50 -Dcats.effect.tracing.mode=none" fs2.benchmark.ChannelBenchmark`

`channel-perf`
```
[info] Benchmark                              (size)   Mode  Cnt      Score     Error  Units
[info] ChannelBenchmark.sendPull                  64  thrpt   10  70315,735 ± 990,801  ops/s
[info] ChannelBenchmark.sendPull                1024  thrpt   10   8489,787 ± 220,705  ops/s
[info] ChannelBenchmark.sendPull               16384  thrpt   10    586,689 ±  14,841  ops/s
[info] ChannelBenchmark.sendPullPar8              64  thrpt   10  48603,532 ± 755,156  ops/s
[info] ChannelBenchmark.sendPullPar8            1024  thrpt   10  10497,909 ± 444,052  ops/s
[info] ChannelBenchmark.sendPullPar8           16384  thrpt   10    650,486 ±  36,143  ops/s
[info] ChannelBenchmark.sendPullParUnlimited      64  thrpt   10  46336,865 ± 640,137  ops/s
[info] ChannelBenchmark.sendPullParUnlimited    1024  thrpt   10   3421,420 ± 268,378  ops/s
[info] ChannelBenchmark.sendPullParUnlimited   16384  thrpt   10    162,638 ±   9,527  ops/s
```


`main`
```
[info] Benchmark                              (size)   Mode  Cnt      Score      Error  Units
[info] ChannelBenchmark.sendPull                  64  thrpt   10  65333,103 ± 4694,045  ops/s
[info] ChannelBenchmark.sendPull                1024  thrpt   10   7288,803 ±  309,856  ops/s
[info] ChannelBenchmark.sendPull               16384  thrpt   10    487,553 ±   28,040  ops/s
[info] ChannelBenchmark.sendPullPar8              64  thrpt   10  45527,449 ± 2153,177  ops/s
[info] ChannelBenchmark.sendPullPar8            1024  thrpt   10   8268,452 ±  320,778  ops/s
[info] ChannelBenchmark.sendPullPar8           16384  thrpt   10    490,139 ±   25,620  ops/s
[info] ChannelBenchmark.sendPullParUnlimited      64  thrpt   10  36154,018 ± 2300,873  ops/s
[info] ChannelBenchmark.sendPullParUnlimited    1024  thrpt   10   2891,059 ±  219,453  ops/s
[info] ChannelBenchmark.sendPullParUnlimited   16384  thrpt   10    143,254 ±   10,190  ops/s
```

New versions differs from the one from the main in two aspects. Firstly, it replaces `Vector` with `List` in the `State`. I don’t think that this change is responsible for the observed performance change. ~Yet, currently fs2.Chunk doesn’t have a vector-specialized implementation, therefore it’ll anyway be converted to Array.~ A more specialized implementation reduces the amount of computations required. 
The second change reduces critical section in the CAS loop. Previously, not only the next state was computed in the loop, but also the old state was transformed into the output. Updated version splits this action into two distinct pieces of work. While we compute new state in CAS, the conversion of the previous state to the emitted chunk is done after the CAS. It reduces contention and eliminates duplicated emitted chunk preparations.

```
                                  method   channel-perf          main ratio
               ChannelBenchmark.sendPull      70315,735     65333,103 1,076
               ChannelBenchmark.sendPull       8489,787      7288,803 1,165
               ChannelBenchmark.sendPull        586,689       487,553 1,203
           ChannelBenchmark.sendPullPar8      48603,532     45527,449 1,068
           ChannelBenchmark.sendPullPar8      10497,909      8268,452 1,270
           ChannelBenchmark.sendPullPar8        650,486       490,139 1,327
   ChannelBenchmark.sendPullParUnlimited      46336,865     36154,018 1,282
   ChannelBenchmark.sendPullParUnlimited       3421,420      2891,059 1,183
   ChannelBenchmark.sendPullParUnlimited        162,638       143,254 1,135
```