### PR TITLE
Files walk order

### DIFF
--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -448,13 +448,9 @@ object Files extends FilesCompanionPlatform {
           else
             Stream.eval(getBasicFileAttributes(start, followLinks = false)).flatMap { attr =>
               if (attr.isDirectory)
-                list(start)
-                  .flatMap { path =>
-                    go(path, maxDepth - 1, attr.fileKey.toRight(start) :: ancestry)
-                  }
-                  .recoverWith { case _ =>
-                    Stream.empty
-                  }
+                list(start).flatMap { path =>
+                  go(path, maxDepth - 1, attr.fileKey.toRight(start) :: ancestry)
+                }.mask
               else if (attr.isSymbolicLink && followLinks)
                 Stream.eval(getBasicFileAttributes(start, followLinks = true)).flatMap { attr =>
                   val fileKey = attr.fileKey
@@ -465,13 +461,9 @@ object Files extends FilesCompanionPlatform {
 
                   Stream.eval(isCycle).flatMap { isCycle =>
                     if (!isCycle)
-                      list(start)
-                        .flatMap { path =>
-                          go(path, maxDepth - 1, attr.fileKey.toRight(start) :: ancestry)
-                        }
-                        .recoverWith { case _ =>
-                          Stream.empty
-                        }
+                      list(start).flatMap { path =>
+                        go(path, maxDepth - 1, attr.fileKey.toRight(start) :: ancestry)
+                      }.mask
                     else
                       Stream.raiseError(new FileSystemLoopException(start.toString))
                   }

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -511,7 +511,6 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
         .assertEquals(31) // the root + 5 children + 5 files per child directory
     }
 
-
   }
 
   test("writeRotate") {

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -228,8 +228,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
     }
 
     test("recursive copy in a streaming fashion") {
-      (tempFilesHierarchy, tempDirectory)
-        .tupled
+      (tempFilesHierarchy, tempDirectory).tupled
         .use { case (from, to) =>
           Files[IO]
             .walk(from)
@@ -242,7 +241,9 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
                   Files[IO].createDirectory(dest),
                   Files[IO].copy(source, dest)
                 ) >> Files[IO].exists(dest).assertEquals(true)
-            }.compile.drain
+            }
+            .compile
+            .drain
         }
     }
   }

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -227,7 +227,7 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
         .assertEquals(true)
     }
 
-    test("recursive copy in a streaming fashion".only) {
+    test("recursive copy in a streaming fashion") {
       (tempFilesHierarchy, tempDirectory)
         .tupled
         .use { case (from, to) =>

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -510,6 +510,8 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
         .foldMonoid
         .assertEquals(31) // the root + 5 children + 5 files per child directory
     }
+
+
   }
 
   test("writeRotate") {

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -26,7 +26,6 @@ package file
 import cats.effect.{IO, Resource}
 import cats.kernel.Order
 import cats.syntax.all._
-import cats.kernel.instances.order._
 
 import scala.concurrent.duration._
 
@@ -490,17 +489,6 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
         .compile
         .foldMonoid
         .assertEquals(31) // the root + 5 children + 5 files per child directory
-    }
-
-    test("returns files in order of traversal") {
-      Stream
-        .resource(tempFilesHierarchy)
-        .flatMap(topDir => Files[IO].walk(topDir))
-        .compile
-        .toList
-        .map { paths =>
-          assertEquals(paths, paths.sorted)
-        }
     }
   }
 

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -26,6 +26,7 @@ package file
 import cats.effect.{IO, Resource}
 import cats.kernel.Order
 import cats.syntax.all._
+import cats.kernel.instances.order._
 
 import scala.concurrent.duration._
 
@@ -489,6 +490,17 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
         .compile
         .foldMonoid
         .assertEquals(31) // the root + 5 children + 5 files per child directory
+    }
+
+    test("returns files in order of traversal") {
+      Stream
+        .resource(tempFilesHierarchy)
+        .flatMap(topDir => Files[IO].walk(topDir))
+        .compile
+        .toList
+        .map { paths =>
+          assertEquals(paths, paths.sorted)
+        }
     }
   }
 


### PR DESCRIPTION
Changes the behaviour of `walk` to emit files in the order it visits them, which in turn enables streaming copy since it lets you create folders before copying the files they contain, which is a prerequisite for `copy`.
The behaviour of `walk` in main is arguably a regression since it behaves differently from `NIO.walk`, which it used to wrap, so I'm targetting `main` with a straight change, rather than a new method or a flag.
