### PR TITLE
`text.lines` enhancements

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -387,7 +387,7 @@ object text {
           maxLineLength match {
             case Some((max, raiseThrowable)) if stringBuilder.length > max =>
               Pull.raiseError[F](
-                new LineTooLongException(stringBuilder.length(), max)
+                new LineTooLongException(stringBuilder.length, max)
               )(raiseThrowable)
             case _ =>
               Pull.output(Chunk.indexedSeq(linesBuffer)) >> go(stream, stringBuilder, first = false)

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -387,9 +387,7 @@ object text {
           maxLineLength match {
             case Some((max, raiseThrowable)) if stringBuilder.length > max =>
               Pull.raiseError[F](
-                new IllegalStateException(
-                  s"Max line size is $max but ${stringBuilder.length} chars have been accumulated"
-                )
+                new LineTooLongException(stringBuilder.length(), max)
               )(raiseThrowable)
             case _ =>
               Pull.output(Chunk.buffer(linesBuffer)) >> go(stream, stringBuilder, first = false)
@@ -398,6 +396,11 @@ object text {
 
     s => Stream.suspend(go(s, new StringBuilder(), first = true).stream)
   }
+
+  class LineTooLongException(val length: Int, val max: Int)
+      extends RuntimeException(
+        s"Max line size is $max but $length chars have been accumulated"
+      )
 
   /** Functions for working with base 64. */
   object base64 {

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -385,10 +385,10 @@ object text {
           }
 
           maxLineLength match {
-            case Some((max, raiseThrowable)) if stringBuilder.length() > max =>
+            case Some((max, raiseThrowable)) if stringBuilder.length > max =>
               Pull.raiseError[F](
                 new IllegalStateException(
-                  s"Max line size is $max but ${stringBuilder.length()} chars have been accumulated"
+                  s"Max line size is $max but ${stringBuilder.length} chars have been accumulated"
                 )
               )(raiseThrowable)
             case _ =>

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -316,14 +316,24 @@ object text {
   def utf8EncodeC[F[_]]: Pipe[F, String, Chunk[Byte]] =
     utf8.encodeC
 
+
+  def linesFor[F[_]: RaiseThrowable](sizeLimit: Option[Int] = None, crsOnly: Boolean = false):Pipe[F, String, String] =
+    linesImpl[F](
+      maxLineSize = sizeLimit.map((_, implicitly[RaiseThrowable[F]])),
+      crsOnly = crsOnly
+    )
+
+  def lines[F[_]]:Pipe[F, String, String] = linesImpl[F]()
+
   /** Transforms a stream of `String` such that each emitted `String` is a line from the input. */
-  def lines[F[_]]: Pipe[F, String, String] = {
+  private def linesImpl[F[_]](maxLineSize: Option[(Int, RaiseThrowable[F])] = None, crsOnly: Boolean = false): Pipe[F, String, String] = {
     def fillBuffers(
         stringBuilder: StringBuilder,
         linesBuffer: ArrayBuffer[String],
         string: String
     ): Unit = {
       val l = stringBuilder.length
+
       var i =
         if (l > 0 && stringBuilder(l - 1) == '\r' && string.nonEmpty && string(0) == '\n') {
           stringBuilder.deleteCharAt(l - 1)
@@ -341,6 +351,9 @@ object text {
             linesBuffer += stringBuilder.result()
             stringBuilder.clear()
             i += 1
+          case '\r' if crsOnly =>
+            linesBuffer += stringBuilder.result()
+            stringBuilder.clear()
           case other =>
             stringBuilder.append(other)
         }
@@ -360,7 +373,14 @@ object text {
           chunk.foreach { string =>
             fillBuffers(stringBuilder, linesBuffer, string)
           }
-          Pull.output(Chunk.buffer(linesBuffer)) >> go(stream, stringBuilder, first = false)
+
+          maxLineSize match {
+            case Some((max, raiseThrowable)) if stringBuilder.length() > max =>
+              Pull.raiseError[F](new IllegalStateException(
+                s"Max line size is $max but ${stringBuilder.length()} chars have been accumulated"
+              ))(raiseThrowable)
+            case _ => Pull.output(Chunk.buffer(linesBuffer)) >> go(stream, stringBuilder, first = false)
+          }
       }
 
     s => Stream.suspend(go(s, new StringBuilder(), first = true).stream)

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -390,7 +390,7 @@ object text {
                 new LineTooLongException(stringBuilder.length(), max)
               )(raiseThrowable)
             case _ =>
-              Pull.output(Chunk.buffer(linesBuffer)) >> go(stream, stringBuilder, first = false)
+              Pull.output(Chunk.indexedSeq(linesBuffer)) >> go(stream, stringBuilder, first = false)
           }
       }
 

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -320,7 +320,7 @@ object text {
     * @param maxLineLength maximum size to accumulate a line to; throw an error if a line is larger
     */
   def linesLimited[F[_]: RaiseThrowable](maxLineLength: Int): Pipe[F, String, String] =
-    linesImpl[F](maxLineLength = Some(maxLineLength, implicitly[RaiseThrowable[F]]))
+    linesImpl[F](maxLineLength = Some((maxLineLength, implicitly[RaiseThrowable[F]])))
 
   /** Transforms a stream of `String` such that each emitted `String` is a line from the input. */
   def lines[F[_]]: Pipe[F, String, String] = linesImpl[F](None)

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -316,23 +316,27 @@ object text {
   def utf8EncodeC[F[_]]: Pipe[F, String, Chunk[Byte]] =
     utf8.encodeC
 
-
-  /**
-    * Transforms a stream of `String` such that each emitted `String` is a line from the input
+  /** Transforms a stream of `String` such that each emitted `String` is a line from the input
     * @param maxLineLength maximum size to accumulate a line to; throw an error if a line is larger
     * @param crsOnly separate lines that are delimited only by '\r'
     * @tparam F
     */
-  def linesFor[F[_]: RaiseThrowable](maxLineLength: Option[Int] = None, crsOnly: Boolean = false):Pipe[F, String, String] =
+  def linesFor[F[_]: RaiseThrowable](
+      maxLineLength: Option[Int] = None,
+      crsOnly: Boolean = false
+  ): Pipe[F, String, String] =
     linesImpl[F](
       maxLineLength = maxLineLength.map((_, implicitly[RaiseThrowable[F]])),
       crsOnly = crsOnly
     )
 
   /** Transforms a stream of `String` such that each emitted `String` is a line from the input. */
-  def lines[F[_]]:Pipe[F, String, String] = linesImpl[F]()
+  def lines[F[_]]: Pipe[F, String, String] = linesImpl[F]()
 
-  private def linesImpl[F[_]](maxLineLength: Option[(Int, RaiseThrowable[F])] = None, crsOnly: Boolean = false): Pipe[F, String, String] = {
+  private def linesImpl[F[_]](
+      maxLineLength: Option[(Int, RaiseThrowable[F])] = None,
+      crsOnly: Boolean = false
+  ): Pipe[F, String, String] = {
     def fillBuffers(
         stringBuilder: StringBuilder,
         linesBuffer: ArrayBuffer[String],
@@ -382,10 +386,13 @@ object text {
 
           maxLineLength match {
             case Some((max, raiseThrowable)) if stringBuilder.length() > max =>
-              Pull.raiseError[F](new IllegalStateException(
-                s"Max line size is $max but ${stringBuilder.length()} chars have been accumulated"
-              ))(raiseThrowable)
-            case _ => Pull.output(Chunk.buffer(linesBuffer)) >> go(stream, stringBuilder, first = false)
+              Pull.raiseError[F](
+                new IllegalStateException(
+                  s"Max line size is $max but ${stringBuilder.length()} chars have been accumulated"
+                )
+              )(raiseThrowable)
+            case _ =>
+              Pull.output(Chunk.buffer(linesBuffer)) >> go(stream, stringBuilder, first = false)
           }
       }
 

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -345,11 +345,18 @@ object text {
       val l = stringBuilder.length
 
       var i =
-        if (l > 0 && stringBuilder(l - 1) == '\r' && string.nonEmpty && string(0) == '\n') {
-          stringBuilder.deleteCharAt(l - 1)
-          linesBuffer += stringBuilder.result()
-          stringBuilder.clear()
-          1
+        if (l > 0 && stringBuilder(l - 1) == '\r') {
+          if (string.nonEmpty && string(0) == '\n') {
+            stringBuilder.deleteCharAt(l - 1)
+            linesBuffer += stringBuilder.result()
+            stringBuilder.clear()
+            1
+          } else if (crsOnly && stringBuilder(l - 1) == '\r') {
+            stringBuilder.deleteCharAt(l - 1)
+            linesBuffer += stringBuilder.result()
+            stringBuilder.clear()
+            0
+          } else 0
         } else 0
 
       while (i < string.size) {
@@ -361,7 +368,7 @@ object text {
             linesBuffer += stringBuilder.result()
             stringBuilder.clear()
             i += 1
-          case '\r' if crsOnly =>
+          case '\r' if crsOnly && i + 1 < string.size =>
             linesBuffer += stringBuilder.result()
             stringBuilder.clear()
           case other =>

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -290,7 +290,6 @@ class TextSuite extends Fs2Suite {
 
     property("linesFor with maxLineLength") {
       val line = "foo" * 100
-
       (1 to line.length).foreach { i =>
         val stream = Stream
           .emits(line.toCharArray)
@@ -299,16 +298,11 @@ class TextSuite extends Fs2Suite {
           .covary[Fallible]
 
         assert(stream.through(text.linesFor(maxLineLength = Some(10))).toList.isLeft)
-
         assertEquals(
           stream.through(text.linesFor(maxLineLength = Some(line.length))).toList,
           Right(List(line))
         )
-
       }
-
-
-
     }
   }
 

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -288,7 +288,7 @@ class TextSuite extends Fs2Suite {
       }
     }
 
-    property("linesFor with sizeLimit") {
+    property("linesFor with maxLineLength") {
       val line = "foo" * 100
 
       (1 to line.length).foreach { i =>
@@ -298,10 +298,10 @@ class TextSuite extends Fs2Suite {
           .map(c => new String(c.toArray))
           .covary[Fallible]
 
-        assert(stream.through(text.linesFor(sizeLimit = Some(10))).toList.isLeft)
+        assert(stream.through(text.linesFor(maxLineLength = Some(10))).toList.isLeft)
 
         assertEquals(
-          stream.through(text.linesFor(sizeLimit = Some(line.length))).toList,
+          stream.through(text.linesFor(maxLineLength = Some(line.length))).toList,
           Right(List(line))
         )
 

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -22,6 +22,7 @@
 package fs2
 
 import cats.syntax.all._
+
 import java.nio.charset.Charset
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Prop.forAll
@@ -275,6 +276,10 @@ class TextSuite extends Fs2Suite {
         if (lines.toList.nonEmpty) {
           val s = lines.intersperse("\r\n").toList.mkString
           assertEquals(Stream.emit(s).through(text.lines).toList, lines.toList)
+          assertEquals(
+            Stream.emit(s).covary[fs2.Fallible].through(text.linesFor(crsOnly = true)).toList,
+            Right(lines.toList)
+          )
         }
       }
     }
@@ -288,9 +293,24 @@ class TextSuite extends Fs2Suite {
         else {
           assertEquals(Stream.emits(s).through(text.lines).toList, lines.toList)
           assertEquals(
+            Stream.emits(s).covary[Fallible].through(text.linesFor(crsOnly = true)).toList,
+            Right(lines.toList)
+          )
+          assertEquals(
             Stream.emits(s).chunkLimit(1).unchunks.through(text.lines).toList,
             lines.toList
           )
+          assertEquals(
+            Stream
+              .emits(s)
+              .chunkLimit(1)
+              .unchunks
+              .covary[Fallible]
+              .through(text.linesFor(crsOnly = true))
+              .toList,
+            Right(lines.toList)
+          )
+
         }
       }
     }

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -256,9 +256,16 @@ class TextSuite extends Fs2Suite {
         val lines = lines0.map(escapeCrLf)
         assertEquals(lines.intersperse("\n").through(text.lines).toList, lines.toList)
         assertEquals(lines.intersperse("\r\n").through(text.lines).toList, lines.toList)
-        assertEquals(lines.intersperse("\r").covary[Fallible].through(
-          text.linesFor[Fallible](crsOnly = true)
-        ).toList, Right(lines.toList))
+        assertEquals(
+          lines
+            .intersperse("\r")
+            .covary[Fallible]
+            .through(
+              text.linesFor[Fallible](crsOnly = true)
+            )
+            .toList,
+          Right(lines.toList)
+        )
       }
     }
 


### PR DESCRIPTION
* add support for input with '\r'-only newlines, like from macos classic. yes, content like this still exists
* add support to throw an error when an accumulated line is over a certain size; good to prevent bad/malicious inputs from causing OOMs
