### PR TITLE
fsIO - realPath:  re-raise ENOENT javascript exceptions as NoSuchFileException

### DIFF
--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -321,7 +321,10 @@ private[fs2] trait FilesCompanionPlatform {
       readStream(path, chunkSize, Flags.Read)(_.setStart(start.toDouble).setEnd((end - 1).toDouble))
 
     def realPath(path: Path): F[Path] =
-      F.fromPromise(F.delay(fsPromisesMod.realpath(path.toString))).map(Path(_))
+      F.fromPromise(F.delay(fsPromisesMod.realpath(path.toString))).map(Path(_)).handleErrorWith {
+        case NoSuchFileException(e) =>
+          F.raiseError(e)
+      }
 
     override def setFileTimes(
         path: Path,

--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -321,9 +321,8 @@ private[fs2] trait FilesCompanionPlatform {
       readStream(path, chunkSize, Flags.Read)(_.setStart(start.toDouble).setEnd((end - 1).toDouble))
 
     def realPath(path: Path): F[Path] =
-      F.fromPromise(F.delay(fsPromisesMod.realpath(path.toString))).map(Path(_)).recoverWith {
-        case NoSuchFileException(e) =>
-          F.raiseError(e)
+      F.fromPromise(F.delay(fsPromisesMod.realpath(path.toString))).map(Path(_)).adaptError {
+        case NoSuchFileException(e) => e
       }
 
     override def setFileTimes(

--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -321,7 +321,7 @@ private[fs2] trait FilesCompanionPlatform {
       readStream(path, chunkSize, Flags.Read)(_.setStart(start.toDouble).setEnd((end - 1).toDouble))
 
     def realPath(path: Path): F[Path] =
-      F.fromPromise(F.delay(fsPromisesMod.realpath(path.toString))).map(Path(_)).handleErrorWith {
+      F.fromPromise(F.delay(fsPromisesMod.realpath(path.toString))).map(Path(_)).recoverWith {
         case NoSuchFileException(e) =>
           F.raiseError(e)
       }

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -728,4 +728,29 @@ class FilesSuite extends Fs2Suite with BaseFileSuite {
         .assertEquals(false)
     }
   }
+
+  group("realPath") {
+
+    test("doesn't fail if the path is for a file") {
+      tempFile
+        .use(Files[IO].realPath(_))
+        .void
+        .assert
+    }
+
+    test("doesn't fail if the path is for a directory") {
+      tempDirectory
+        .use(Files[IO].realPath(_))
+        .void
+        .assert
+    }
+
+    test("fails with NoSuchFileException if the path does not exist") {
+      tempDirectory
+        .map(_.resolve("non-existent-file"))
+        .use(Files[IO].realPath(_))
+        .intercept[NoSuchFileException]
+    }
+  }
+
 }


### PR DESCRIPTION
calls to `realPath` in nodejs throw an `ENOENT` exception if the path doesn't exist. In order to align the behaviour of `realPath` with what we have in JVM, those errors are re-raised as a `NoSuchFileException`.