### PR TITLE
Fix #2762 - eval after zip may cause interruption

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/Scope.scala
+++ b/core/shared/src/main/scala/fs2/internal/Scope.scala
@@ -442,7 +442,7 @@ private[fs2] final class Scope[F[_]] private (
     * that caused the interruption is returned so that it can be handled.
     */
   private[fs2] def interruptibleEval[A](f: F[A]): F[Either[InterruptionOutcome, A]] =
-    interruptible match {
+    openScope.map(_.interruptible).flatMap {
       case None =>
         f.attempt.map(_.leftMap(t => Outcome.Errored(t)))
       case Some(iCtx) =>


### PR DESCRIPTION
In the fix for #2717, we discovered that sometimes after zipping, a closed scope is used for evaluation. We fixed #2717 by ensuring that manual interruption checks occur on the nearest open scope in the case the current scope has been closed already. We needed a similar check for effect evaluation, which checks interruption inside `interruptibleEval`.