### PR TITLE
Handle trailing \r in `text.lines` consistently with other delimiters

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -376,11 +376,17 @@ object text {
     ): Pull[F, String, Unit] =
       stream.pull.uncons.flatMap {
         case None =>
-          if (first) Pull.done else {
+          if (first) Pull.done
+          else {
             val result = stringBuilder.result()
-            if (result.nonEmpty && result.last == '\r') Pull.output(Chunk(
-              result.dropRight(1), ""
-            )) else Pull.output1(result)
+            if (result.nonEmpty && result.last == '\r')
+              Pull.output(
+                Chunk(
+                  result.dropRight(1),
+                  ""
+                )
+              )
+            else Pull.output1(result)
           }
         case Some((chunk, stream)) =>
           val linesBuffer = ArrayBuffer.empty[String]

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -375,7 +375,13 @@ object text {
         first: Boolean
     ): Pull[F, String, Unit] =
       stream.pull.uncons.flatMap {
-        case None => if (first) Pull.done else Pull.output1(stringBuilder.result())
+        case None =>
+          if (first) Pull.done else {
+            val result = stringBuilder.result()
+            if (result.nonEmpty && result.last == '\r') Pull.output(Chunk(
+              result.dropRight(1), ""
+            )) else Pull.output1(result)
+          }
         case Some((chunk, stream)) =>
           val linesBuffer = ArrayBuffer.empty[String]
           chunk.foreach { string =>

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -271,6 +271,13 @@ class TextSuite extends Fs2Suite {
       }
     }
 
+    property("EOF") {
+      List("\n", "\r\n", "\r").foreach { delimiter =>
+        val s = s"a$delimiter"
+        assertEquals(Stream.emit(s).through(lines).toList, List("a", ""))
+      }
+    }
+
     property("grouped in 3 character chunks") {
       forAll { (lines0: Stream[Pure, String]) =>
         val lines = lines0.map(escapeCrLf)


### PR DESCRIPTION
Don't like the additional special cases here but I can't see an obviously better way to do it.