### PR TITLE
Minimal fix of observe termination logic

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3824,8 +3824,7 @@ object Stream extends StreamLowPriority {
         val sinkOut: Stream[F, O] = {
           def go(s: Stream[F, Chunk[O]]): Pull[F, O, Unit] =
             s.pull.uncons1.flatMap {
-              case None =>
-                Pull.eval(outChan.close.void)
+              case None => Pull.done
               case Some((ch, rest)) =>
                 Pull.output(ch) >> Pull.eval(outChan.send(ch)) >> go(rest)
             }


### PR DESCRIPTION
This is a minimal fix for #2757.

While this works, there are a few things that I'm unsure of.

 - I'm not sure why we need both the `sinkChan` and `outChan` channels. A single channel seems to suffice.
 - I'm not sure why we're using `++ Stream.exec(outChan.close.void)` to close the channel instead of `onFinalize`. Is this because we only want the channel to close on success?

   I've created an alternative implementation in [a separate branch](https://github.com/typelevel/fs2/compare/main...zainab-ali:observe-reworked) that uses a single channel and finalizers, but this is a bit of a rehaul. Let me know if you'd prefer that PRed instead.

