### PR TITLE
Disable tracing in memory leak tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -203,7 +203,11 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
   .configs(IntegrationTest)
   .settings(Defaults.itSettings: _*)
   .settings(
-    inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings)
+    inConfig(IntegrationTest)(
+      org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings ++ List(
+        Test / javaOptions += "-Dcats.effect.tracing.mode=none"
+      )
+    )
   )
   .settings(
     name := "fs2-core",


### PR DESCRIPTION
@diesalbla spotted memory leak tests were failing here: https://github.com/typelevel/fs2/pull/2763#issuecomment-1000571690

A bisect showed it was due to the CE3 upgrade. This PR disables tracing which fixes the leak tests.