### PR TITLE
Initial prototype of outputting scope tree as DOT graph

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -1203,7 +1203,13 @@ object Pull extends PullLowPriority {
           go(scope, extendedTopLevelScope, translation, runner, getCont(Succeeded(scope)))
         case _: DebugScopes[_] =>
           initScope.snapshot.flatMap { snapshot =>
-            go(scope, extendedTopLevelScope, translation, runner, getCont(Succeeded(snapshot.activate(scope.id))))
+            go(
+              scope,
+              extendedTopLevelScope,
+              translation,
+              runner,
+              getCont(Succeeded(snapshot.activate(scope.id)))
+            )
           }
         case eval: Eval[G, r]       => goEval[r](eval, getCont[r, G, X])
         case acquire: Acquire[G, r] => goAcquire(acquire, getCont[r, G, X])
@@ -1293,11 +1299,11 @@ object Pull extends PullLowPriority {
   def getScopeSnapshot[F[_]]: Pull[F, Nothing, ScopeSnapshot] = DebugScopes()
 
   def debugScopes[F[_]](
-    formatter: ScopeSnapshot => String = _.toDot,
-    logger: String => Unit = println(_)
+      formatter: ScopeSnapshot => String = _.toDot(),
+      logger: String => Unit = println(_)
   ): Pull[F, Nothing, Unit] =
     getScopeSnapshot.map(s => logger(formatter(s)))
- 
+
   private[this] def transformWith[F[_], O, R, S](p: Pull[F, O, R])(
       f: Terminal[R] => Pull[F, O, S]
   ): Pull[F, O, S] =

--- a/core/shared/src/main/scala/fs2/ScopeSnapshot.scala
+++ b/core/shared/src/main/scala/fs2/ScopeSnapshot.scala
@@ -108,8 +108,8 @@ sealed trait ScopeSnapshot {
     val font = "Helvetica,Arial"
     val lines = Chain(
       "digraph {",
-      s"  node [shape=rectangle fontname=\"$font\"]",
-      s"  edge [fontname=\"$font\"]"
+      s"""  node [shape=rectangle fontname="$font"]""",
+      s"""  edge [fontname="$font"]"""
     ) ++ subgraph ++ Chain.one("}")
     lines.iterator.mkString("\n")
   }

--- a/core/shared/src/main/scala/fs2/ScopeSnapshot.scala
+++ b/core/shared/src/main/scala/fs2/ScopeSnapshot.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import cats.Id
+import cats.kernel.Monoid
+import cats.data.Chain
+import cats.effect.kernel.{Outcome, Unique}
+import cats.syntax.all._
+
+sealed trait ScopeSnapshot {
+  def id: Unique.Token
+  def open: Boolean
+  def active: Boolean
+  def children: Chain[ScopeSnapshot]
+  def resources: Chain[ResourceSnapshot]
+  def interruptible: Option[InterruptContextSnapshot]
+  def activate(id: Unique.Token): ScopeSnapshot
+
+  def withActive(active: Boolean): ScopeSnapshot
+  def withChildren(children: Chain[ScopeSnapshot]): ScopeSnapshot
+
+  def withSimpleResourceDetails: ScopeSnapshot
+  def withNoResourceDetails: ScopeSnapshot
+  def mapResources(f: Option[Any] => Option[Any]): ScopeSnapshot
+
+  def toDot: String = {
+    def id(t: Unique.Token): String = t.##.toString
+    def render(t: Unique.Token): String = t.##.toHexString
+    def renderOutcome(o: Outcome[Id, Throwable, Unique.Token]): String = o match {
+      case Outcome.Succeeded(_) => "Succeeded"
+      case Outcome.Errored(t) => s"Errored(${t.getMessage})"
+      case Outcome.Canceled() => "Canceled"
+    }
+    def escape(s: String): String = s.replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+    def table(rows: Option[String]*): String = {
+      val bldr = new collection.mutable.StringBuilder
+      bldr ++= """<table border="0" cellborder="0" cellspacing="1">"""
+      rows.flatten.foreach { s => 
+        bldr ++= "<tr><td>"
+        bldr ++= s
+        bldr ++= "</td></tr>"
+      }
+      bldr ++= """</table>"""
+      bldr.result()
+    }
+
+    val subgraph = ScopeSnapshot.walk { s =>
+      val node = {
+        val t = table(
+          Some(s"<b>Scope ${render(s.id)}</b>"),
+          s.interruptible.map(i => i.outcome match {
+            case Some(outcome) => s"Interruption outcome: ${renderOutcome(outcome)}"
+            case None => "Interruptible"
+          }),
+          Option("Closed").filterNot(_ => s.open),
+          Option("Active").filter(_ => s.active)
+        )
+        s"""  ${id(s.id)} [label=<$t> penwidth=${if (s.active) 2 else 1}]"""
+      }
+      val interruptionEdges = Chain.fromSeq(List(
+        s.interruptible.map(i => s"  ${id(s.id)} -> ${id(i.interruptRoot)} [style=dashed]"),
+        s.interruptible.flatMap(_.outcome.collect {
+          case Outcome.Succeeded(t) => s"  ${id(s.id)} -> ${id(t)} [style=dotted label=interrupt]"
+        })
+      ).flatten)
+      val edges =
+        interruptionEdges ++
+        s.resources.flatMap { r => 
+          val t = table(Some(s"<b>Resource ${render(r.id)}</b>"), r.resource.map(a => escape(a.toString)))
+          Chain(
+            s"  ${id(r.id)} [label=<$t>]",
+            s"  ${id(s.id)} -> ${id(r.id)}"
+          )
+        } ++
+          s.children.map(c => s"  ${id(s.id)} -> ${id(c.id)}")
+      node +: edges
+    }(this)
+    val lines = Chain("digraph {", "  node [shape=rectangle]") ++ subgraph ++ Chain.one("}")
+    lines.iterator.mkString("\n")
+  }
+}
+
+object ScopeSnapshot {
+  def apply(id0: Unique.Token, open0: Boolean, active0: Boolean, children0: Chain[ScopeSnapshot], resources0: Chain[ResourceSnapshot], interruptible0: Option[InterruptContextSnapshot]): ScopeSnapshot =
+    new ScopeSnapshot {
+      def id = id0
+      def open = open0
+      def active = active0
+      def children = children0
+      def resources = resources0
+      def interruptible = interruptible0
+
+      def activate(id: Unique.Token) =
+        if (this.id == id) withActive(true)
+        else withChildren(children.map(_.activate(id)))
+
+      def withActive(active0: Boolean) = apply(id, open, active0, children, resources, interruptible)
+      def withChildren(children0: Chain[ScopeSnapshot]) = apply(id, open, active, children0, resources, interruptible)
+
+      def withSimpleResourceDetails: ScopeSnapshot =
+        mapResources(_.map(simpleTypeName))
+
+      private def simpleTypeName(a: Any): String = a match {
+        case _: Function[_, _] | _: Function2[_, _, _] | _: Function3[_, _, _, _] | _: Function4[_, _, _, _, _] | _: Function5[_, _, _, _, _, _] => "<fn>"
+        case p: Product =>
+          val prefix = if (p.productPrefix.startsWith("Tuple")) "" else p.productPrefix
+          p.productIterator.map(simpleTypeName).mkString(prefix + "(", ",", ")")
+        case _ => a.getClass.getSimpleName
+      }
+
+      def withNoResourceDetails: ScopeSnapshot = 
+        mapResources(_ => None)
+
+      def mapResources(f: Option[Any] => Option[Any]): ScopeSnapshot = {
+        val resources0 = resources.map(_.mapResource(f))
+        apply(id, open, active, children.map(_.mapResources(f)), resources0, interruptible)
+      }
+    }
+
+  private def walk[A: Monoid](f: ScopeSnapshot => A)(scope: ScopeSnapshot): A =
+    f(scope) |+| scope.children.foldMap(walk(f))
+}
+
+sealed trait ResourceSnapshot {
+  def id: Unique.Token
+  def resource: Option[Any]
+  def mapResource(f: Option[Any] => Option[Any]): ResourceSnapshot
+}
+
+object ResourceSnapshot {
+  def apply(id0: Unique.Token, resource0: Option[Any]): ResourceSnapshot =
+    new ResourceSnapshot {
+      def id = id0
+      def resource = resource0
+      def mapResource(f: Option[Any] => Option[Any]) = apply(id, f(resource))
+    }
+}
+
+sealed trait InterruptContextSnapshot {
+  def interruptRoot: Unique.Token
+  def outcome: Option[Outcome[Id, Throwable, Unique.Token]]
+}
+
+object InterruptContextSnapshot {
+  def apply(interruptRoot0: Unique.Token, outcome0: Option[Outcome[Id, Throwable, Unique.Token]]): InterruptContextSnapshot =
+    new InterruptContextSnapshot {
+      def interruptRoot = interruptRoot0
+      def outcome = outcome0
+    }
+}

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -762,6 +762,16 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       Stream.chunk(os)
     }
 
+  def debugScopes(
+    formatter: ScopeSnapshot => String = _.toDot,
+    logger: String => Unit = println(_)
+  ): Stream[F, O] =
+    this.pull.uncons.flatMap {
+      case Some((hd, tl)) =>
+        Pull.debugScopes(formatter, logger) >> tl.cons(hd).pull.echo
+      case None => Pull.debugScopes(formatter, logger)
+    }.streamNoScope
+
   /** Returns a stream that when run, sleeps for duration `d` and then pulls from this stream.
     *
     * Alias for `sleep_[F](d) ++ this`.

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -763,8 +763,8 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     }
 
   def debugScopes(
-    formatter: ScopeSnapshot => String = _.toDot,
-    logger: String => Unit = println(_)
+      formatter: ScopeSnapshot => String = _.toDot(),
+      logger: String => Unit = println(_)
   ): Stream[F, O] =
     this.pull.uncons.flatMap {
       case Some((hd, tl)) =>

--- a/core/shared/src/main/scala/fs2/internal/Debug.scala
+++ b/core/shared/src/main/scala/fs2/internal/Debug.scala
@@ -1,0 +1,36 @@
+package fs2.internal
+
+import cats.effect.kernel.Unique
+
+private[fs2] object Debug {
+
+  def displayToken(t: Unique.Token): String = t.##.toHexString
+
+  def displayTypeName(a: Any): String = a match {
+    case IsFunction(_) => "<fn>"
+    case p: Product =>
+      val prefix = if (p.productPrefix.startsWith("Tuple")) "" else p.productPrefix
+      p.productIterator.map(displayTypeName).mkString(prefix + "(", ",", ")")
+    case _ => a.getClass.getSimpleName
+  }
+
+  def display(a: Any): String = a match {
+    case t: Unique.Token => displayToken(t)
+    case IsFunction(_)   => "<fn>"
+    case _               => a.toString
+  }
+
+  private object IsFunction {
+    def unapply(a: Any): Option[Any] = a match {
+      case _: Function[_, _] | _: Function2[_, _, _] | _: Function3[_, _, _, _] |
+          _: Function4[_, _, _, _, _] | _: Function5[_, _, _, _, _, _] |
+          _: Function6[_, _, _, _, _, _, _] | _: Function7[_, _, _, _, _, _, _, _] |
+          _: Function8[_, _, _, _, _, _, _, _, _] | _: Function9[_, _, _, _, _, _, _, _, _, _] |
+          _: Function10[_, _, _, _, _, _, _, _, _, _, _] |
+          _: Function11[_, _, _, _, _, _, _, _, _, _, _, _] |
+          _: Function12[_, _, _, _, _, _, _, _, _, _, _, _, _] =>
+        Some(a)
+      case _ => None
+    }
+  }
+}

--- a/core/shared/src/main/scala/fs2/internal/Debug.scala
+++ b/core/shared/src/main/scala/fs2/internal/Debug.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package fs2.internal
 
 import cats.effect.kernel.Unique

--- a/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
+++ b/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
@@ -26,6 +26,7 @@ import cats.effect.kernel.{Concurrent, Deferred, Fiber, Outcome, Ref, Unique}
 import cats.effect.kernel.implicits._
 import cats.syntax.all._
 import InterruptContext.InterruptionOutcome
+import fs2.InterruptContextSnapshot
 
 /** A context of interruption status. This is shared from the parent that was created as interruptible to all
   * its children. It assures consistent view of the interruption through the stack
@@ -93,6 +94,9 @@ final private[fs2] case class InterruptContext[F[_]](
           case Left(other)   => Left(other)
         }
     }
+
+  def snapshot: F[InterruptContextSnapshot] =
+    ref.get.map(InterruptContextSnapshot(interruptRoot, _))
 }
 
 private[fs2] object InterruptContext {

--- a/core/shared/src/main/scala/fs2/internal/Scope.scala
+++ b/core/shared/src/main/scala/fs2/internal/Scope.scala
@@ -483,14 +483,19 @@ private[fs2] final class Scope[F[_]] private (
   def snapshot: F[ScopeSnapshot] =
     state.get.flatMap {
       case Scope.State.Open(resources, children) =>
-        children.traverse(_.snapshot).flatMap(c => 
-          resources.traverse(_.snapshot).flatMap(r =>
-            interruptible.traverse(_.snapshot).map(i =>
-              ScopeSnapshot(id, true, false, c, r, i))))
+        children
+          .traverse(_.snapshot)
+          .flatMap(c =>
+            resources
+              .traverse(_.snapshot)
+              .flatMap(r =>
+                interruptible.traverse(_.snapshot).map(i => ScopeSnapshot(id, true, false, c, r, i))
+              )
+          )
       case Scope.State.Closed() =>
         ScopeSnapshot(id, false, false, Chain.empty, Chain.empty, None).pure[F]
     }
- 
+
   override def toString =
     s"Scope(id=$id,interruptible=${interruptible.nonEmpty})"
 }


### PR DESCRIPTION
Lots to do still but opening this as a draft for now. I'll update PR description as we get closer to something mergable.

The main idea right now is to drop a `Pull.debugScopes(..)` call anywhere you want to inspect the scope tree. Doing so will dump a DOT graph to standard out. There's some customizability of the graph -- e.g., `Pull.debugScopes(_.withSimpleResourceDetails.toDot)`.

For now, I've been copying the DOT output to my clipboard and then running `pbpaste | dot -Tpng | ~/bin/imgcat` in an iTerm2 window (where `imgcat` is from https://iterm2.com/utilities/imgcat).