### PR TITLE
Add `userHome`, `currentWorkingDirectory` to `Files` API

### DIFF
--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -31,6 +31,7 @@ import fs2.internal.jsdeps.node.fsMod
 import fs2.internal.jsdeps.node.fsPromisesMod
 import fs2.internal.jsdeps.node.nodeStrings
 import fs2.internal.jsdeps.node.osMod
+import fs2.internal.jsdeps.node.processMod
 import fs2.io.file.Files.UnsealedFiles
 
 import scala.concurrent.duration._
@@ -132,6 +133,12 @@ private[fs2] trait FilesCompanionPlatform {
         F.fromPromise(F.delay(fsPromisesMod.rmdir(path.toString))),
         F.fromPromise(F.delay(fsPromisesMod.rm(path.toString)))
       ).adaptError { case IOException(ex) => ex }
+
+    def currentWorkingDirectory: F[Path] =
+      F.delay(Path(processMod.cwd()))
+
+    def userHome: F[Path] =
+      F.delay(Path(osMod.homedir()))
 
     override def delete(path: Path): F[Unit] =
       rmMaybeDir(path)

--- a/io/jvm/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -163,6 +163,12 @@ private[file] trait FilesCompanionPlatform {
           )
       }).map(Path.fromNioPath)
 
+    def currentWorkingDirectory: F[Path] =
+      Sync[F].delay(Path(Option(System.getProperty("user.dir")).get))
+
+    def userHome: F[Path] =
+      Sync[F].delay(Path(Option(System.getProperty("user.home")).get))
+
     def delete(path: Path): F[Unit] =
       Sync[F].blocking(JFiles.delete(path.toNioPath))
 

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -128,6 +128,9 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
       permissions: Option[Permissions]
   ): F[Path]
 
+  /** User's current working directory */
+  def currentWorkingDirectory: F[Path]
+
   /** Deletes the specified file or empty directory, failing if it does not exist. */
   def delete(path: Path): F[Unit]
 
@@ -349,6 +352,9 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
       prefix: String,
       permissions: Option[Permissions]
   ): Resource[F, Path]
+
+  /** User's home directory */
+  def userHome: F[Path]
 
   /** Creates a stream of paths contained in a given file tree. Depth is unlimited. */
   def walk(start: Path): Stream[F, Path] =


### PR DESCRIPTION
Not entirely sure if `Files` is the best place for these.

Maybe after https://github.com/typelevel/cats-effect/pull/2650 lands we can add a test that compares to env.