### PR TITLE
Fix microsite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           cd scalafix
           sbt testCI
 
-      - if: matrix.scala == '2.13.8' && matrix.project == 'rootJVM'
+      - if: matrix.scala == '2.13.8'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' microsite/mdoc
 
       - name: Make target directories

--- a/build.sbt
+++ b/build.sbt
@@ -355,7 +355,7 @@ lazy val microsite = project
 ThisBuild / githubWorkflowBuildPostamble ++= List(
   WorkflowStep.Sbt(
     List("microsite/mdoc"),
-    cond = Some(s"matrix.scala == '$NewScala' && matrix.project == 'rootJVM'")
+    cond = Some(s"matrix.scala == '$NewScala'") // && matrix.project == 'rootJVM'
   )
 )
 


### PR DESCRIPTION
This restores the microsite.

It vanished because currently the JVM and JS intermediate artifacts have the same name, so there is a race condition which overwrites the other. However, only the JVM artifacts contained the site. See:
- https://github.com/typelevel/sbt-typelevel/issues/74
- https://github.com/typelevel/sbt-typelevel/pull/98

As a temporary fix, now the site is also generated in the JS job, so regardless of which artifact overwrites the other there will always be a copy of the microsite provided to the gh-pages deploy step.