### PR TITLE
Do not withhold emission in `pauseWhen`

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2196,6 +2196,10 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     def waitToResume =
       pauseWhenTrue.discrete.dropWhile(_ == true).take(1).compile.drain
 
+    // The logic can be expressed entirely with `waitToResume`, but
+    // `Signal.get` is lighter than `Signal.discrete`, so the preliminary
+    // check with `get` in `pauseIfNeeded` acts as an optimisation, since
+    // we expect a stream to generally not be in a paused state.
     def pauseIfNeeded = Stream.exec {
       pauseWhenTrue.get.flatMap(paused => waitToResume.whenA(paused))
     }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2201,7 +2201,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     }
 
     pauseIfNeeded ++ chunks.flatMap { chunk =>
-      pauseIfNeeded ++ Stream.chunk(chunk)
+      Stream.chunk(chunk) ++ pauseIfNeeded
     }
   }
 


### PR DESCRIPTION
pauseWhen should emit elements as soon as it wakes up, instead of checking for the need to pause again.

The difference in behaviour came up when I was implementing this (very complex) combinator for a user, which alternates between two streams upon a timeout.
```scala
def switchRepeat[A](
    every: FiniteDuration,
    to: Stream[IO, A]
): Pipe[IO, A, A] = { in =>
  Stream.eval(SignallingRef.of[IO, Boolean](true)).flatMap { paused =>
    val pause = Pull.eval(paused.set(true))
    val unpause = Pull.eval(paused.set(false))

    def go(p: Pull.Timed[IO, A]): Pull[IO, A, Unit] =
      p.timeout(every) >> p.uncons.flatMap {
        case Some((Right(elems), next)) =>
          pause >> Pull.output(elems) >> go(next)
        case Some((Left(_), next)) =>
          unpause >> go(next)
        case None =>
          Pull.done
      }

    val foreground = in.pull.timed(go).stream
    val background = to.through(pauseWhen(paused))

    foreground.mergeHaltL(background)
  }
}
```

Given how complex the example is, and how hard it is to engineer alternative code that would trigger a difference in behaviour between the new and old implementation of `pauseWhen`, I haven't added a test covering my change. Let me know if you want me to try harder finding a minimised test