### PR TITLE
Use sbt-typelevel-site plugin to build/publish microsite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,16 +84,13 @@ jobs:
           cd scalafix
           sbt testCI
 
-      - if: matrix.scala == '2.13.8' && matrix.project == 'rootJVM'
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' microsite/mdoc
-
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/2.5.x')
-        run: mkdir -p target node/js/target protocols/js/target .js/target core/js/target core/jvm/target .jvm/target .native/target scodec/jvm/target scodec/js/target io/js/target reactive-streams/target io/jvm/target protocols/jvm/target benchmark/target project/target
+        run: mkdir -p target node/js/target protocols/js/target .js/target core/js/target mdoc/target core/jvm/target .jvm/target .native/target scodec/jvm/target scodec/js/target io/js/target reactive-streams/target io/jvm/target protocols/jvm/target benchmark/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/2.5.x')
-        run: tar cf targets.tar target node/js/target protocols/js/target .js/target core/js/target core/jvm/target .jvm/target .native/target scodec/jvm/target scodec/js/target io/js/target reactive-streams/target io/jvm/target protocols/jvm/target benchmark/target project/target
+        run: tar cf targets.tar target node/js/target protocols/js/target .js/target core/js/target mdoc/target core/jvm/target .jvm/target .native/target scodec/jvm/target scodec/js/target io/js/target reactive-streams/target io/jvm/target protocols/jvm/target benchmark/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/2.5.x')
@@ -212,9 +209,7 @@ jobs:
         run: sbt '++${{ matrix.scala }}' tlRelease
 
   site:
-    name: Deploy site
-    needs: [publish]
-    if: always() && needs.build.result == 'success' && (needs.publish.result == 'success' && github.ref == 'refs/heads/main')
+    name: Generate Site
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -222,68 +217,37 @@ jobs:
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Download target directories (3.1.1, rootJS)
-        uses: actions/download-artifact@v2
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.1-rootJS
+          fetch-depth: 0
 
-      - name: Inflate target directories (3.1.1, rootJS)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3.1.1, rootJVM)
-        uses: actions/download-artifact@v2
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.1-rootJVM
+          distribution: temurin
+          java-version: 17
 
-      - name: Inflate target directories (3.1.1, rootJVM)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.12.15, rootJS)
-        uses: actions/download-artifact@v2
+      - name: Cache sbt
+        uses: actions/cache@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15-rootJS
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Inflate target directories (2.12.15, rootJS)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
+      - name: Generate site
+        run: sbt '++${{ matrix.scala }}' microsite/tlSite
 
-      - name: Download target directories (2.12.15, rootJVM)
-        uses: actions/download-artifact@v2
+      - name: Publish site
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3.8.0
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15-rootJVM
-
-      - name: Inflate target directories (2.12.15, rootJVM)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.13.8, rootJS)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-rootJS
-
-      - name: Inflate target directories (2.13.8, rootJS)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.13.8, rootJVM)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-rootJVM
-
-      - name: Inflate target directories (2.13.8, rootJVM)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Deploy site
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          publish_dir: ./target/website
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: mdoc/target/docs/site
+          publish_branch: gh-pages

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.3")
+val sbtTypelevelVersion = "0.4.3"
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % sbtTypelevelVersion)
+addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % sbtTypelevelVersion)
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.8.0")
 addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.9.9")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")

--- a/site/getstarted/install.md
+++ b/site/getstarted/install.md
@@ -1,6 +1,6 @@
 # Install
 
-The latest version for Cats Effect 3 is `3.2.0`, which supports Cats Effect 3 and is cross built for Scala 2.12, 2.13, and 3.0.
+The latest version for Cats Effect 3 is `@VERSION@`, which supports Cats Effect 3 and is cross built for Scala 2.12, 2.13, and 3.0.
 
 The latest version for Cats Effect 2 is `2.5.10`, which supports Cats Effect 2 and is similarly cross built for various Scala versions.
 
@@ -8,24 +8,24 @@ The latest version for Cats Effect 2 is `2.5.10`, which supports Cats Effect 2 a
 
 ```
 // available for 2.12, 2.13, 3.0
-libraryDependencies += "co.fs2" %% "fs2-core" % "<version>"
+libraryDependencies += "co.fs2" %% "fs2-core" % "@VERSION@"
 
 // optional I/O library
-libraryDependencies += "co.fs2" %% "fs2-io" % "<version>"
+libraryDependencies += "co.fs2" %% "fs2-io" % "@VERSION@"
 
 // optional reactive streams interop
-libraryDependencies += "co.fs2" %% "fs2-reactive-streams" % "<version>"
+libraryDependencies += "co.fs2" %% "fs2-reactive-streams" % "@VERSION@"
 
 // optional scodec interop
-libraryDependencies += "co.fs2" %% "fs2-scodec" % "<version>"
+libraryDependencies += "co.fs2" %% "fs2-scodec" % "@VERSION@"
 ```
 
 The fs2-core as well as fs2-io and fs2-scodec libraries are also supported on Scala.js:
 
 ```
-libraryDependencies += "co.fs2" %%% "fs2-core" % "<version>"
-libraryDependencies += "co.fs2" %%% "fs2-io" % "<version>" // Node.js only
-libraryDependencies += "co.fs2" %%% "fs2-scodec" % "<version>"
+libraryDependencies += "co.fs2" %%% "fs2-core" % "@VERSION@"
+libraryDependencies += "co.fs2" %%% "fs2-io" % "@VERSION@" // Node.js only
+libraryDependencies += "co.fs2" %%% "fs2-scodec" % "@VERSION@"
 ```
 
 Release notes for each release are available on [Github](https://github.com/typelevel/fs2/releases/).


### PR DESCRIPTION
Following up on https://github.com/typelevel/fs2/pull/2818#discussion_r801882521.

Uses a minor bit of hackery to override Laika, but saves a lot of boilerplate and gets you the latest fs2 version injected into the site for free.

A notable difference from the existing setup is that the site is now deployed in parallel to the snapshot publish (rather than afterwards) and thus does not wait for that to succeed.