### PR TITLE
Fix Collector.supportsFactory

### DIFF
--- a/core/shared/src/main/scala-2.13/fs2/CollectorPlatform.scala
+++ b/core/shared/src/main/scala-2.13/fs2/CollectorPlatform.scala
@@ -26,9 +26,11 @@ import scala.collection.{Factory, IterableFactory, MapFactory}
 import scala.reflect.ClassTag
 
 private[fs2] trait CollectorPlatform { self: Collector.type =>
-  implicit def supportsFactory[A, C[_], B](
-      f: Factory[A, C[B]]
-  ): Collector.Aux[A, C[B]] = make(Builder.fromFactory(f))
+  implicit def supportsCollectionFactory[A, C](f: Factory[A, C]): Collector.Aux[A, C] =
+    make(Builder.fromCollectionFactory(f))
+
+  def supportsFactory[A, C[_], B](f: Factory[A, C[B]]): Collector.Aux[A, C[B]] =
+    make(Builder.fromFactory(f))
 
   implicit def supportsIterableFactory[A, C[_]](f: IterableFactory[C]): Collector.Aux[A, C[A]] =
     make(Builder.fromIterableFactory(f))
@@ -50,6 +52,9 @@ private[fs2] trait CollectorPlatform { self: Collector.type =>
   }
 
   private[fs2] trait BuilderPlatform { self: Collector.Builder.type =>
+    def fromCollectionFactory[A, C](f: Factory[A, C]): Builder[A, C] =
+      fromBuilder(f.newBuilder)
+
     def fromFactory[A, C[_], B](f: Factory[A, C[B]]): Builder[A, C[B]] =
       fromBuilder(f.newBuilder)
 

--- a/core/shared/src/main/scala-3/fs2/CollectorPlatform.scala
+++ b/core/shared/src/main/scala-3/fs2/CollectorPlatform.scala
@@ -26,9 +26,11 @@ import scala.collection.{Factory, IterableFactory, MapFactory}
 import scala.reflect.ClassTag
 
 private[fs2] trait CollectorPlatform { self: Collector.type =>
-  implicit def supportsFactory[A, C[_], B](
-      f: Factory[A, C[B]]
-  ): Collector.Aux[A, C[B]] = make(Builder.fromFactory(f))
+  implicit def supportsCollectionFactory[A, C](f: Factory[A, C]): Collector.Aux[A, C] =
+    make(Builder.fromCollectionFactory(f))
+
+  def supportsFactory[A, C[_], B](f: Factory[A, C[B]]): Collector.Aux[A, C[B]] =
+    make(Builder.fromFactory(f))
 
   implicit def supportsIterableFactory[A, C[_]](f: IterableFactory[C]): Collector.Aux[A, C[A]] =
     make(Builder.fromIterableFactory(f))
@@ -58,6 +60,9 @@ private[fs2] trait CollectorPlatform { self: Collector.type =>
   }
 
   private[fs2] trait BuilderPlatform { self: Collector.Builder.type =>
+    def fromCollectionFactory[A, C](f: Factory[A, C]): Builder[A, C] =
+      fromBuilder(f.newBuilder)
+
     def fromFactory[A, C[_], B](f: Factory[A, C[B]]): Builder[A, C[B]] =
       fromBuilder(f.newBuilder)
 

--- a/core/shared/src/main/scala/fs2/Collector.scala
+++ b/core/shared/src/main/scala/fs2/Collector.scala
@@ -83,12 +83,12 @@ object Collector extends CollectorPlatform {
     def array[A: ClassTag]: Builder[A, Array[A]] =
       Chunk.newBuilder.mapResult(_.toArray)
 
-    protected def fromBuilder[A, C[_], B](
-        builder: collection.mutable.Builder[A, C[B]]
-    ): Builder[A, C[B]] =
-      new Builder[A, C[B]] {
+    protected def fromBuilder[A, C](
+        builder: collection.mutable.Builder[A, C]
+    ): Builder[A, C] =
+      new Builder[A, C] {
         def +=(c: Chunk[A]): Unit = builder ++= c.iterator
-        def result: C[B] = builder.result()
+        def result: C = builder.result()
       }
 
     def string: Builder[String, String] =

--- a/core/shared/src/test/scala-2.13/fs2/BitSetCollectorSuite.scala
+++ b/core/shared/src/test/scala-2.13/fs2/BitSetCollectorSuite.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import scala.collection.immutable.BitSet
+
+final class BitSetCollectorSuite extends Fs2Suite {
+  test("work for Bitset") {
+    assertEquals(
+      // Ensure the right return type.
+      Stream(1, 3, 5).compile.to(BitSet): BitSet,
+      BitSet(1, 3, 5)
+    )
+  }
+}


### PR DESCRIPTION
AFAIK this is the best practice and allows types like `BitSet` to be properly used.
