### PR TITLE
Set `tlJdkRelease := 8` for all modules but `io`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,6 +196,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test,
       "org.typelevel" %%% "discipline-munit" % "1.0.9" % Test
     ),
+    tlJdkRelease := Some(8),
     Compile / doc / scalacOptions ++= (if (scalaVersion.value.startsWith("2.")) Seq("-nowarn")
                                        else Nil)
   )
@@ -282,7 +283,8 @@ lazy val scodec = crossProject(JVMPlatform, JSPlatform)
                                                              )
                                                                "1.11.9"
                                                              else "2.1.0"),
-    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "3.2.0").toMap
+    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "3.2.0").toMap,
+    tlJdkRelease := Some(8),
   )
   .jsSettings(
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
@@ -293,7 +295,8 @@ lazy val protocols = crossProject(JVMPlatform, JSPlatform)
   .in(file("protocols"))
   .settings(
     name := "fs2-protocols",
-    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "3.2.0").toMap
+    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "3.2.0").toMap,
+    tlJdkRelease := Some(8),
   )
   .jsSettings(
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
@@ -309,6 +312,7 @@ lazy val reactiveStreams = project
       "org.reactivestreams" % "reactive-streams-tck" % "1.0.3" % "test",
       "org.scalatestplus" %% "testng-6-7" % "3.2.10.0" % "test"
     ),
+    tlJdkRelease := Some(8),
     Test / fork := true // Otherwise SubscriberStabilitySpec fails
   )
   .dependsOn(coreJVM % "compile->compile;test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -196,18 +196,6 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test,
       "org.typelevel" %%% "discipline-munit" % "1.0.9" % Test
     ),
-    Compile / unmanagedSourceDirectories ++= {
-      val major = if (scalaVersion.value.startsWith("3")) "-3" else "-2"
-      List(CrossType.Pure, CrossType.Full).flatMap(
-        _.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + major))
-      )
-    },
-    Test / unmanagedSourceDirectories ++= {
-      val major = if (scalaVersion.value.startsWith("3")) "-3" else "-2"
-      List(CrossType.Pure, CrossType.Full).flatMap(
-        _.sharedSrcDir(baseDirectory.value, "test").toList.map(f => file(f.getPath + major))
-      )
-    },
     Compile / doc / scalacOptions ++= (if (scalaVersion.value.startsWith("2.")) Seq("-nowarn")
                                        else Nil)
   )

--- a/build.sbt
+++ b/build.sbt
@@ -284,7 +284,7 @@ lazy val scodec = crossProject(JVMPlatform, JSPlatform)
                                                                "1.11.9"
                                                              else "2.1.0"),
     tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "3.2.0").toMap,
-    tlJdkRelease := Some(8),
+    tlJdkRelease := Some(8)
   )
   .jsSettings(
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
@@ -296,7 +296,7 @@ lazy val protocols = crossProject(JVMPlatform, JSPlatform)
   .settings(
     name := "fs2-protocols",
     tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "3.2.0").toMap,
-    tlJdkRelease := Some(8),
+    tlJdkRelease := Some(8)
   )
   .jsSettings(
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -209,7 +209,7 @@ object text {
         }
 
         val isLast = r.isEmpty
-        (lastOutBuffer: Buffer).clear()
+        lastOutBuffer.clear()
 
         val outBufferSize = (decoder.averageCharsPerByte() * toDecode.size).toInt
 
@@ -220,7 +220,7 @@ object text {
 
         val inBuffer = toDecode.toByteBuffer
         val result = decoder.decode(inBuffer, out, isLast)
-        (out: Buffer).flip()
+        out.flip()
 
         val nextAcc =
           if (inBuffer.remaining() > 0) Chunk.byteBuffer(inBuffer.slice) else Chunk.empty
@@ -258,11 +258,11 @@ object text {
         decoder: CharsetDecoder,
         out: CharBuffer
     ): Pull[F, String, Unit] = {
-      (out: Buffer).clear()
+      out.clear()
       decoder.flush(out) match {
         case res if res.isUnderflow =>
           if (out.position() > 0) {
-            (out: Buffer).flip()
+            out.flip()
             Pull.output1(out.toString) >> Pull.done
           } else
             Pull.done
@@ -568,7 +568,7 @@ object text {
             .append(alphabet.toChar(fourth))
           idx = idx + 3
         }
-        (bldr: Buffer).flip()
+        bldr.flip()
         val out = bldr.toString
         if (mod == 0)
           (out, ByteVector.empty)
@@ -662,7 +662,7 @@ object text {
             }
           idx += 1
         }
-        (bldr: Buffer).flip()
+        bldr.flip()
         (Chunk.byteVector(ByteVector(bldr)), hi, midByte)
       }
       def dropPrefix(s: Stream[F, String], acc: String): Pull[F, Byte, Unit] =

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -22,7 +22,7 @@
 package fs2
 
 import cats.ApplicativeThrow
-import java.nio.{Buffer, ByteBuffer, CharBuffer}
+import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.charset.{
   CharacterCodingException,
   Charset,

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -22,7 +22,7 @@
 package fs2
 
 import cats.ApplicativeThrow
-import java.nio.{ByteBuffer, CharBuffer}
+import java.nio.{Buffer, ByteBuffer, CharBuffer}
 import java.nio.charset.{
   CharacterCodingException,
   Charset,

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -209,7 +209,7 @@ object text {
         }
 
         val isLast = r.isEmpty
-        lastOutBuffer.clear()
+        (lastOutBuffer: Buffer).clear()
 
         val outBufferSize = (decoder.averageCharsPerByte() * toDecode.size).toInt
 
@@ -220,7 +220,7 @@ object text {
 
         val inBuffer = toDecode.toByteBuffer
         val result = decoder.decode(inBuffer, out, isLast)
-        out.flip()
+        (out: Buffer).flip()
 
         val nextAcc =
           if (inBuffer.remaining() > 0) Chunk.byteBuffer(inBuffer.slice) else Chunk.empty
@@ -258,11 +258,11 @@ object text {
         decoder: CharsetDecoder,
         out: CharBuffer
     ): Pull[F, String, Unit] = {
-      out.clear()
+      (out: Buffer).clear()
       decoder.flush(out) match {
         case res if res.isUnderflow =>
           if (out.position() > 0) {
-            out.flip()
+            (out: Buffer).flip()
             Pull.output1(out.toString) >> Pull.done
           } else
             Pull.done
@@ -568,7 +568,7 @@ object text {
             .append(alphabet.toChar(fourth))
           idx = idx + 3
         }
-        bldr.flip()
+        (bldr: Buffer).flip()
         val out = bldr.toString
         if (mod == 0)
           (out, ByteVector.empty)
@@ -662,7 +662,7 @@ object text {
             }
           idx += 1
         }
-        bldr.flip()
+        (bldr: Buffer).flip()
         (Chunk.byteVector(ByteVector(bldr)), hi, midByte)
       }
       def dropPrefix(s: Stream[F, String], acc: String): Pull[F, Byte, Unit] =


### PR DESCRIPTION
Although @vasilmkd's release flag idea doesn't work for the io module, there's no reason we shouldn't apply it for all the other modules.