### PR TITLE
Scope - Small tweak to isInterrupted

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/Scope.scala
+++ b/core/shared/src/main/scala/fs2/internal/Scope.scala
@@ -425,9 +425,11 @@ private[fs2] final class Scope[F[_]] private (
     * to evaluate
     */
   def isInterrupted: F[Option[InterruptionOutcome]] =
-    openScope.map(_.interruptible).flatMap {
-      case None       => F.pure(None)
-      case Some(iCtx) => iCtx.ref.get
+    openScope.flatMap { scope =>
+      scope.interruptible match {
+        case None       => F.pure(None)
+        case Some(iCtx) => iCtx.ref.get
+      }
     }
 
   /** When the stream is evaluated, there may be `Eval` that needs to be cancelled early,


### PR DESCRIPTION
Modifies `isInterrupted` to join `map` and `flatMap` into single step. Since the `isInterrupted` is called often in the stream processing, one less F action in here may help performance a little bit.
