### PR TITLE
Introduce aliases for parameterized `Pull` types

### DIFF
--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -156,7 +156,7 @@ class MemoryLeakSpec extends FunSuite {
 
   leakTest("repeatEval") {
     def id[F[_], A]: Pipe[F, A, A] = {
-      def go(s: Stream[F, A]): Pull[F, A, Unit] =
+      def go(s: Stream[F, A]): Pull.From[F, A] =
         s.pull.uncons1.flatMap {
           case Some((h, t)) => Pull.output1(h) >> go(t); case None => Pull.done
         }

--- a/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
+++ b/core/jvm/src/it/scala/fs2/MemoryLeakSpec.scala
@@ -156,7 +156,7 @@ class MemoryLeakSpec extends FunSuite {
 
   leakTest("repeatEval") {
     def id[F[_], A]: Pipe[F, A, A] = {
-      def go(s: Stream[F, A]): Pull.From[F, A] =
+      def go(s: Stream[F, A]): Pull.ToStream[F, A] =
         s.pull.uncons1.flatMap {
           case Some((h, t)) => Pull.output1(h) >> go(t); case None => Pull.done
         }

--- a/core/jvm/src/main/scala/fs2/compression/CompressionPlatform.scala
+++ b/core/jvm/src/main/scala/fs2/compression/CompressionPlatform.scala
@@ -904,13 +904,13 @@ private[compression] trait CompressionCompanionPlatform {
       private def unconsUntil[O: ClassTag](
           predicate: O => Boolean,
           softLimit: Int
-      ): Stream[F, O] => Pull[F, INothing, Option[(Chunk[O], Stream[F, O])]] =
+      ): Stream[F, O] => Pull.From[F, Option[(Chunk[O], Stream[F, O])]] =
         stream => {
           def go(
               acc: List[Chunk[O]],
               rest: Stream[F, O],
               size: Int = 0
-          ): Pull[F, INothing, Option[(Chunk[O], Stream[F, O])]] =
+          ): Pull.From[F, Option[(Chunk[O], Stream[F, O])]] =
             rest.pull.uncons.flatMap {
               case None =>
                 Pull.pure(None)

--- a/core/shared/src/main/scala/fs2/Compiler.scala
+++ b/core/shared/src/main/scala/fs2/Compiler.scala
@@ -97,7 +97,7 @@ private[fs2] trait CompilerLowPriority0 extends CompilerLowPriority1 {
   implicit val idInstance: Compiler[Id, Id] = new Compiler[Id, Id] {
     val target: Monad[Id] = implicitly
     def apply[O, B](
-        stream: Pull[Id, O, Unit],
+        stream: Pull.ToStream[Id, O],
         init: B
     )(foldChunk: (B, Chunk[O]) => B): B =
       Compiler
@@ -112,12 +112,12 @@ private[fs2] trait CompilerLowPriority extends CompilerLowPriority0 {
     new Compiler[Fallible, Either[Throwable, *]] {
       val target: Monad[Either[Throwable, *]] = implicitly
       def apply[O, B](
-          stream: Pull[Fallible, O, Unit],
+          stream: Pull.ToStream[Fallible, O],
           init: B
       )(foldChunk: (B, Chunk[O]) => B): Either[Throwable, B] =
         Compiler
           .target[SyncIO]
-          .apply(stream.asInstanceOf[Pull[SyncIO, O, Unit]], init)(foldChunk)
+          .apply(stream.asInstanceOf[Pull.ToStream[SyncIO, O]], init)(foldChunk)
           .attempt
           .unsafeRunSync()
     }
@@ -127,7 +127,7 @@ object Compiler extends CompilerLowPriority {
   implicit val pureInstance: Compiler[Pure, Id] = new Compiler[Pure, Id] {
     val target: Monad[Id] = implicitly
     def apply[O, B](
-        stream: Pull[Pure, O, Unit],
+        stream: Pull.ToStream[Pure, O],
         init: B
     )(foldChunk: (B, Chunk[O]) => B): B =
       Compiler

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -299,6 +299,10 @@ sealed abstract class Pull[+F[_], +O, +R] {
 
 object Pull extends PullLowPriority {
 
+  /** A [[Pull]] instance that has has no unprocessed resource and can be converted to
+   * a [[Stream[F, O]]] using [[StreamPullOps.stream]]
+   */ 
+  type ToStream[+F[_], +O] = Pull[F, O, Unit]
   implicit final class StreamPullOps[F[_], O](private val self: Pull[F, O, Unit]) extends AnyVal {
 
     /** Interprets this pull to produce a stream. This method introduces a resource

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -314,8 +314,9 @@ object Pull extends PullLowPriority {
     * may still have further elements from the source stream to process. Can be converted
     * to [[Pull.ToStream]] in three ways:
     *
-    * - processing the resource further via `flatMap
-    *    `
+    * - process the input stream further via `flatMap`
+    * - echo remaining elements using `echo`
+    * - drop remaining elements using `void`
     */
   type TransformStream[+F[_], +O] = Pull[F, O, Option[Stream[F, O]]]
 
@@ -344,7 +345,9 @@ object Pull extends PullLowPriority {
     def streamNoScope: Stream[F, O] = new Stream(self)
   }
 
-  implicit final class StreamingPullOps[F[_], O](private val self: Pull.TransformStream[F, O]) {
+  implicit final class StreamTransformPullOps[F[_], O](
+      private val self: Pull.TransformStream[F, O]
+  ) {
     /* Echoes the resource of this [[Pull]] to the output
      */
     def echo: Pull.ToStream[F, O] =

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -317,7 +317,7 @@ object Pull extends PullLowPriority {
     * - processing the resource further via `flatMap
     *    `
     */
-  type Streaming[+F[_], +O] = Pull[F, O, Option[Stream[F, O]]]
+  type TransformStream[+F[_], +O] = Pull[F, O, Option[Stream[F, O]]]
 
   implicit final class StreamPullOps[F[_], O](private val self: Pull.ToStream[F, O])
       extends AnyVal {
@@ -344,7 +344,7 @@ object Pull extends PullLowPriority {
     def streamNoScope: Stream[F, O] = new Stream(self)
   }
 
-  implicit final class StreamingPullOps[F[_], O](private val self: Pull.Streaming[F, O]) {
+  implicit final class StreamingPullOps[F[_], O](private val self: Pull.TransformStream[F, O]) {
     /* Echoes the resource of this [[Pull]] to the output
      */
     def echo: Pull.ToStream[F, O] =

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4286,7 +4286,7 @@ object Stream extends StreamLowPriority {
     def echo: Pull.ToStream[F, O] = self.underlying
 
     /** Reads a single element from the input and emits it to the output. */
-    def echo1: Pull.Streaming[F, O] =
+    def echo1: Pull.TransformStream[F, O] =
       uncons.flatMap {
         case None => Pull.pure(None)
         case Some((hd, tl)) =>
@@ -4295,7 +4295,7 @@ object Stream extends StreamLowPriority {
       }
 
     /** Reads the next available chunk from the input and emits it to the output. */
-    def echoChunk: Pull.Streaming[F, O] =
+    def echoChunk: Pull.TransformStream[F, O] =
       uncons.flatMap {
         case None           => Pull.pure(None)
         case Some((hd, tl)) => Pull.output(hd).as(Some(tl))
@@ -4425,7 +4425,7 @@ object Stream extends StreamLowPriority {
       }
 
     /** Emits the first `n` elements of the input. */
-    def take(n: Long): Pull.Streaming[F, O] =
+    def take(n: Long): Pull.TransformStream[F, O] =
       if (n <= 0) Pull.pure(None)
       else
         uncons.flatMap {
@@ -4453,20 +4453,20 @@ object Stream extends StreamLowPriority {
     }
 
     /** Like [[takeWhile]], but emits the first value which tests false. */
-    def takeThrough(p: O => Boolean): Pull.Streaming[F, O] =
+    def takeThrough(p: O => Boolean): Pull.TransformStream[F, O] =
       takeWhile_(p, true)
 
     /** Emits the elements of the stream until the predicate `p` fails,
       * and returns the remaining `Stream`. If non-empty, the returned stream will have
       * a first element `i` for which `p(i)` is `false`.
       */
-    def takeWhile(p: O => Boolean, takeFailure: Boolean = false): Pull.Streaming[F, O] =
+    def takeWhile(p: O => Boolean, takeFailure: Boolean = false): Pull.TransformStream[F, O] =
       takeWhile_(p, takeFailure)
 
     private def takeWhile_(
         p: O => Boolean,
         takeFailure: Boolean
-    ): Pull.Streaming[F, O] =
+    ): Pull.TransformStream[F, O] =
       uncons.flatMap {
         case None => Pull.pure(None)
         case Some((hd, tl)) =>

--- a/core/shared/src/main/scala/fs2/concurrent/Channel.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Channel.scala
@@ -183,7 +183,7 @@ object Channel {
 
         def stream = consumeLoop.stream
 
-        def consumeLoop: Pull[F, A, Unit] =
+        def consumeLoop: Pull.ToStream[F, A] =
           Pull.eval {
             F.deferred[Unit].flatMap { waiting =>
               state

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -130,7 +130,7 @@ object text {
         }
       }
 
-      def doPull(buf: Chunk[Byte], s: Stream[F, Chunk[Byte]]): Pull[F, String, Unit] =
+      def doPull(buf: Chunk[Byte], s: Stream[F, Chunk[Byte]]): Pull.ToStream[F, String] =
         s.pull.uncons.flatMap {
           case Some((byteChunks, tail)) =>
             // use local and private mutability here
@@ -153,7 +153,7 @@ object text {
       def processByteOrderMark(
           buffer: Chunk.Queue[Byte] /* or null which we use as an Optional type to avoid boxing */,
           s: Stream[F, Chunk[Byte]]
-      ): Pull[F, String, Unit] =
+      ): Pull.ToStream[F, String] =
         s.pull.uncons1.flatMap {
           case Some((hd, tl)) =>
             val newBuffer0 =
@@ -201,7 +201,7 @@ object text {
         acc: Chunk[Byte],
         s: Stream[F, Chunk[Byte]],
         lastOutBuffer: CharBuffer
-    ): Pull[F, String, Unit] =
+    ): Pull.ToStream[F, String] =
       s.pull.uncons1.flatMap { r =>
         val toDecode = r match {
           case Some((c, _)) => acc ++ c
@@ -257,7 +257,7 @@ object text {
     def flush(
         decoder: CharsetDecoder,
         out: CharBuffer
-    ): Pull[F, String, Unit] = {
+    ): Pull.ToStream[F, String] = {
       (out: Buffer).clear()
       decoder.flush(out) match {
         case res if res.isUnderflow =>
@@ -373,7 +373,7 @@ object text {
         stream: Stream[F, String],
         stringBuilder: StringBuilder,
         first: Boolean
-    ): Pull[F, String, Unit] =
+    ): Pull.ToStream[F, String] =
       stream.pull.uncons.flatMap {
         case None =>
           if (first) Pull.done
@@ -516,7 +516,7 @@ object text {
               )
           }
 
-      def go(state: State, s: Stream[F, String]): Pull[F, Byte, Unit] =
+      def go(state: State, s: Stream[F, String]): Pull.ToStream[F, Byte] =
         s.pull.uncons1.flatMap {
           case Some((hd, tl)) =>
             decode(state, hd) match {
@@ -578,7 +578,7 @@ object text {
           (out, ByteVector(bytes(idx), bytes(idx + 1)))
       }
 
-      def go(carry: ByteVector, s: Stream[F, Byte]): Pull[F, String, Unit] =
+      def go(carry: ByteVector, s: Stream[F, Byte]): Pull.ToStream[F, String] =
         s.pull.uncons.flatMap {
           case Some((hd, tl)) =>
             val (out, newCarry) = encode(carry ++ hd.toByteVector)
@@ -665,7 +665,7 @@ object text {
         (bldr: Buffer).flip()
         (Chunk.byteVector(ByteVector(bldr)), hi, midByte)
       }
-      def dropPrefix(s: Stream[F, String], acc: String): Pull[F, Byte, Unit] =
+      def dropPrefix(s: Stream[F, String], acc: String): Pull.ToStream[F, Byte] =
         s.pull.uncons1.flatMap {
           case Some((hd, tl)) =>
             if (acc.size + hd.size < 2) dropPrefix(tl, acc + hd)
@@ -678,7 +678,7 @@ object text {
           case None =>
             Pull.done
         }
-      def go(s: Stream[F, String], hi: Int, midByte: Boolean): Pull[F, Byte, Unit] =
+      def go(s: Stream[F, String], hi: Int, midByte: Boolean): Pull.ToStream[F, Byte] =
         s.pull.uncons1.flatMap {
           case Some((hd, tl)) =>
             val (out, newHi, newMidByte) = decode1(hd, hi, midByte)

--- a/core/shared/src/main/scala/fs2/timeseries/TimeSeries.scala
+++ b/core/shared/src/main/scala/fs2/timeseries/TimeSeries.scala
@@ -97,7 +97,7 @@ object TimeSeries {
     def go(
         nextTick: FiniteDuration,
         s: Stream[F, TimeStamped[A]]
-    ): Pull[F, TimeStamped[Option[A]], Unit] = {
+    ): Pull.ToStream[F, TimeStamped[Option[A]]] = {
       def tickTime(x: Int) = nextTick + (x * tickPeriod)
       s.pull.uncons.flatMap {
         case Some((hd, tl)) =>

--- a/core/shared/src/main/scala/fs2/timeseries/TimeStamped.scala
+++ b/core/shared/src/main/scala/fs2/timeseries/TimeStamped.scala
@@ -185,7 +185,7 @@ object TimeStamped {
     def doThrottle: Pipe2[F, TimeStamped[A], Unit, TimeStamped[A]] = {
 
       type PullFromSourceOrTicks =
-        (Stream[F, TimeStamped[A]], Stream[F, Unit]) => Pull[F, TimeStamped[A], Unit]
+        (Stream[F, TimeStamped[A]], Stream[F, Unit]) => Pull.ToStream[F, TimeStamped[A]]
 
       def takeUpto(
           chunk: Chunk[TimeStamped[A]],
@@ -311,7 +311,7 @@ object TimeStamped {
     def go(
         buffered: SortedMap[FiniteDuration, Chain[TimeStamped[A]]],
         s: Stream[F, TimeStamped[A]]
-    ): Pull[F, TimeStamped[A], Unit] =
+    ): Pull.ToStream[F, TimeStamped[A]] =
       s.pull.uncons.flatMap {
         case Some((hd, tl)) =>
           val all = Chain.fromSeq(hd.toList).foldLeft(buffered) { (acc, tsa) =>

--- a/core/shared/src/test/scala/fs2/PullSuite.scala
+++ b/core/shared/src/test/scala/fs2/PullSuite.scala
@@ -41,7 +41,7 @@ class PullSuite extends Fs2Suite {
 
   property("fromEither") {
     forAll { (either: Either[Throwable, Int]) =>
-      val pull: Pull[Fallible, Int, Unit] = Pull.fromEither[Fallible](either)
+      val pull: Pull.ToStream[Fallible, Int] = Pull.fromEither[Fallible](either)
 
       either match {
         case Left(l) => assertEquals(pull.stream.compile.toList, Left(l))
@@ -67,7 +67,7 @@ class PullSuite extends Fs2Suite {
 
   test("loop is stack safe") {
     val stackUnsafeSize = if (isJVM) 1000000 else 10000
-    def func(s: Int): Pull[Pure, INothing, Option[Int]] =
+    def func(s: Int): Pull.From[Pure, Option[Int]] =
       s match {
         case `stackUnsafeSize` => Pull.pure(None)
         case _                 => Pull.pure(Some(s + 1))
@@ -97,7 +97,7 @@ class PullSuite extends Fs2Suite {
 
   test("loopEither is stack safe") {
     val stackUnsafeSize = if (isJVM) 1000000 else 10000
-    def func(s: Int): Pull[Pure, INothing, Either[Int, Unit]] =
+    def func(s: Int): Pull.From[Pure, Either[Int, Unit]] =
       s match {
         case `stackUnsafeSize` => Pull.pure(Right(()))
         case _                 => Pull.pure(Left(s + 1))

--- a/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
@@ -261,7 +261,7 @@ class StreamInterruptSuite extends Fs2Suite {
 
   test("16 - issue #1179 - if a pipe is interrupted, it will not restart evaluation") {
     def p: Pipe[IO, Int, Int] = {
-      def loop(acc: Int, s: Stream[IO, Int]): Pull[IO, Int, Unit] =
+      def loop(acc: Int, s: Stream[IO, Int]): Pull.ToStream[IO, Int] =
         s.pull.uncons1.flatMap {
           case None           => Pull.output1[IO, Int](acc)
           case Some((hd, tl)) => Pull.output1[IO, Int](hd) >> loop(acc + hd, tl)

--- a/core/shared/src/test/scala/fs2/StreamTranslateSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamTranslateSuite.scala
@@ -89,7 +89,7 @@ class StreamTranslateSuite extends Fs2Suite {
   }
 
   test("5 - ok to translate a step leg that emits multiple chunks") {
-    def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull[Function0, Int, Unit] =
+    def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull.ToStream[Function0, Int] =
       step match {
         case None       => Pull.done
         case Some(step) => Pull.output(step.head) >> step.stepLeg.flatMap(goStep)
@@ -102,7 +102,7 @@ class StreamTranslateSuite extends Fs2Suite {
   }
 
   test("6 - ok to translate step leg that has uncons in its structure") {
-    def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull[Function0, Int, Unit] =
+    def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull.ToStream[Function0, Int] =
       step match {
         case None       => Pull.done
         case Some(step) => Pull.output(step.head) >> step.stepLeg.flatMap(goStep)
@@ -119,7 +119,7 @@ class StreamTranslateSuite extends Fs2Suite {
   }
 
   test("7 - ok to translate step leg that is forced back in to a stream") {
-    def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull[Function0, Int, Unit] =
+    def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull.ToStream[Function0, Int] =
       step match {
         case None => Pull.done
         case Some(step) =>

--- a/core/shared/src/test/scala/fs2/TimedPullsSuite.scala
+++ b/core/shared/src/test/scala/fs2/TimedPullsSuite.scala
@@ -38,7 +38,7 @@ class TimedPullsSuite extends Fs2Suite {
         s.covary[IO]
           .pull
           .timed { tp =>
-            def loop(tp: Pull.Timed[IO, Int]): Pull[IO, Int, Unit] =
+            def loop(tp: Pull.Timed[IO, Int]): Pull.ToStream[IO, Int] =
               tp.uncons.flatMap {
                 case None                   => Pull.done
                 case Some((Right(c), next)) => Pull.output(c) >> loop(next)
@@ -63,7 +63,7 @@ class TimedPullsSuite extends Fs2Suite {
           .metered(period)
           .pull
           .timed { tp =>
-            def loop(tp: Pull.Timed[IO, Int]): Pull[IO, Int, Unit] =
+            def loop(tp: Pull.Timed[IO, Int]): Pull.ToStream[IO, Int] =
               tp.uncons.flatMap {
                 case None                   => Pull.done
                 case Some((Right(c), next)) => Pull.output(c) >> tp.timeout(timeout) >> loop(next)
@@ -108,7 +108,7 @@ class TimedPullsSuite extends Fs2Suite {
       .metered(t)
       .pull
       .timed { tp =>
-        def go(tp: Pull.Timed[IO, Int]): Pull[IO, Int, Unit] =
+        def go(tp: Pull.Timed[IO, Int]): Pull.ToStream[IO, Int] =
           tp.uncons.flatMap {
             case Some((Right(c), n)) => Pull.output(c) >> go(n)
             case Some((Left(_), _))  => Pull.done
@@ -133,7 +133,7 @@ class TimedPullsSuite extends Fs2Suite {
     val prog =
       s.pull
         .timed { tp =>
-          def go(tp: Pull.Timed[IO, Int]): Pull[IO, String, Unit] =
+          def go(tp: Pull.Timed[IO, Int]): Pull.ToStream[IO, String] =
             tp.uncons.flatMap {
               case None => Pull.done
               case Some((Right(_), next)) =>
@@ -240,7 +240,7 @@ class TimedPullsSuite extends Fs2Suite {
     val prog =
       (Stream.sleep[IO](t) ++ Stream.never[IO]).pull
         .timed { tp =>
-          def go(tp: Pull.Timed[IO, Unit]): Pull[IO, String, Unit] =
+          def go(tp: Pull.Timed[IO, Unit]): Pull.ToStream[IO, String] =
             tp.uncons.flatMap {
               case None => Pull.done
               case Some((Right(_), n)) =>

--- a/io/js/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/js/src/main/scala/fs2/io/ioplatform.scala
@@ -159,7 +159,7 @@ private[fs2] trait ioplatform {
         .flatMap { writable =>
           def go(
               s: Stream[F, Byte]
-          ): Pull[F, INothing, Unit] = s.pull.uncons.flatMap {
+          ): Pull.ToStream[F, INothing] = s.pull.uncons.flatMap {
             case Some((head, tail)) =>
               Pull.eval {
                 F.async_[Unit] { cb =>

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -526,7 +526,7 @@ object Files extends FilesCompanionPlatform {
           cursor: WriteCursor[F],
           acc: Long,
           s: Stream[F, Byte]
-      ): Pull[F, Unit, Unit] = {
+      ): Pull.ToStream[F, Unit] = {
         val toWrite = (limit - acc).min(Int.MaxValue.toLong).toInt
         s.pull.unconsLimit(toWrite).flatMap {
           case Some((hd, tl)) =>

--- a/io/shared/src/main/scala/fs2/io/file/WriteCursor.scala
+++ b/io/shared/src/main/scala/fs2/io/file/WriteCursor.scala
@@ -45,7 +45,7 @@ final case class WriteCursor[F[_]](file: FileHandle[F], offset: Long) {
 
   /** Like `write` but returns a pull instead of an `F[WriteCursor[F]]`.
     */
-  def writePull(bytes: Chunk[Byte]): Pull[F, Nothing, WriteCursor[F]] =
+  def writePull(bytes: Chunk[Byte]): Pull.From[F, WriteCursor[F]] =
     write_(bytes, Pull.functionKInstance)
 
   private def write_[G[_]: Monad](bytes: Chunk[Byte], u: F ~> G): G[WriteCursor[F]] =
@@ -58,7 +58,7 @@ final case class WriteCursor[F[_]](file: FileHandle[F], offset: Long) {
   /** Writes all chunks from the supplied stream to the underlying file handle, returning a cursor
     * with offset incremented by the total number of bytes written.
     */
-  def writeAll(s: Stream[F, Byte]): Pull[F, Nothing, WriteCursor[F]] =
+  def writeAll(s: Stream[F, Byte]): Pull.From[F, WriteCursor[F]] =
     s.pull.uncons.flatMap {
       case Some((hd, tl)) => writePull(hd).flatMap(_.writeAll(tl))
       case None           => Pull.pure(this)

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -53,7 +53,7 @@ private[reactivestreams] final class StreamSubscription[F[_], A](
   def unsafeStart(): Unit = {
     def subscriptionPipe: Pipe[F, A, A] =
       in => {
-        def go(s: Stream[F, A]): Pull[F, A, Unit] =
+        def go(s: Stream[F, A]): Pull.ToStream[F, A] =
           Pull.eval(requests.take).flatMap {
             case Infinite => s.pull.echo
             case Finite(n) =>


### PR DESCRIPTION
Introduces type aliases and a new extension method to better (I hope) convey an intuition for how the differently parameterized `Pull` types fit together. It's a big diff but most of it is just changing code to use the new aliases. The core of the PR is in `Pull.Scala` and is as follows:

```scala
  /** A [[Pull]] instance that has has no unprocessed resource and can be converted to
    * a [[Stream[F, O]]] using [[StreamPullOps.stream]].
    */
  type ToStream[+F[_], +O] = Pull[F, O, Unit]

  /** A [[Pull]] instance with no output. Because its output type is [[INothing]] it can
    * be transformed via `flatMap` into Pulls with, and ultimately produce a Stream of, any
    * output type.
    */
  type From[+F[_], +R] = Pull[F, INothing, R]

  /** A [[Pull]] that is transforming a [[Stream[F, O]]] into a new [[Stream[F, O]]] but
    * may still have further elements from the source stream to process. Can be converted
    * to [[Pull.ToStream]] in three ways:
    *
    * - process the input stream further via `flatMap`
    * - echo remaining elements using `echo`
    * - drop remaining elements using `void`
    */
  type TransformStream[+F[_], +O] = Pull[F, O, Option[Stream[F, O]]]

  implicit final class StreamTransformPullOps[F[_], O](
      private val self: Pull.TransformStream[F, O]
  ) {
    /* Echoes the resource of this [[Pull]] to the output
     */
    def echo: Pull.ToStream[F, O] =
      self.flatMap(_.fold(Pull.done: Pull.ToStream[F, O])(_.pull.echo))
  }
```