### PR TITLE
Fix broken link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Quick links:
 
 * [Microsite][microsite]
 * [About the library](#about)
-* [How to get latest version](#getit)
+* [How to get latest version](https://fs2.io/#/getstarted/install)
 * API docs: [fs2-core][core-api], [fs2-io][io-api], [fs2-reactive-streams][rx-api]
 * [Docs and getting help](#docs)
 


### PR DESCRIPTION
The link in the readme points to a section of the readme that doesn't exist anymore.

I'm not entirely sure if the link is the "correct one" because there are no other links to the microsite, but it points to a section with the information I was hoping for in the first place