### PR TITLE
Deprecate INothing

### DIFF
--- a/core/jvm/src/main/scala/fs2/compression/CompressionPlatform.scala
+++ b/core/jvm/src/main/scala/fs2/compression/CompressionPlatform.scala
@@ -904,13 +904,13 @@ private[compression] trait CompressionCompanionPlatform {
       private def unconsUntil[O: ClassTag](
           predicate: O => Boolean,
           softLimit: Int
-      ): Stream[F, O] => Pull[F, INothing, Option[(Chunk[O], Stream[F, O])]] =
+      ): Stream[F, O] => Pull[F, Nothing, Option[(Chunk[O], Stream[F, O])]] =
         stream => {
           def go(
               acc: List[Chunk[O]],
               rest: Stream[F, O],
               size: Int = 0
-          ): Pull[F, INothing, Option[(Chunk[O], Stream[F, O])]] =
+          ): Pull[F, Nothing, Option[(Chunk[O], Stream[F, O])]] =
             rest.pull.uncons.flatMap {
               case None =>
                 Pull.pure(None)

--- a/core/shared/src/main/scala/fs2/concurrent/Topic.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Topic.scala
@@ -184,7 +184,7 @@ object Topic {
                 .as(chan.stream)
             }
 
-        def publish: Pipe[F, A, INothing] = { in =>
+        def publish: Pipe[F, A, Nothing] = { in =>
           (in ++ Stream.exec(close.void))
             .evalMap(publish1)
             .takeWhile(_.isRight)

--- a/core/shared/src/main/scala/fs2/fs2.scala
+++ b/core/shared/src/main/scala/fs2/fs2.scala
@@ -47,5 +47,6 @@ package object fs2 {
 
   /** Alias for `Nothing` which works better with type inference.
     */
+  @deprecated("Use Nothing instead", "3.3.0")
   type INothing <: Nothing
 }

--- a/core/shared/src/test/scala/fs2/CompilationTest.scala
+++ b/core/shared/src/test/scala/fs2/CompilationTest.scala
@@ -107,7 +107,9 @@ object ThisModuleShouldCompile {
 
   // Ensure that .to(Collector) syntax works even when target type is known (regression #1709)
   val z: List[Int] = Stream.range(0, 5).compile.to(List)
-  Stream.empty[Id].covaryOutput[Byte].compile.to(Chunk): Chunk[Byte]
+  (Stream.empty[Id]: Stream[Id, Byte]).compile.to(Chunk): Chunk[Byte]
+  // Following doesn't compile; Scala 2 gets confused with the Nothing output param, Scala 3 works
+  // Stream.empty[Id].covaryOutput[Byte].compile.to(Chunk): Chunk[Byte]
 
   Stream(1, 2, 3).compile.to(Set)
   Stream(1, 2, 3).to(List)

--- a/core/shared/src/test/scala/fs2/PullSuite.scala
+++ b/core/shared/src/test/scala/fs2/PullSuite.scala
@@ -67,7 +67,7 @@ class PullSuite extends Fs2Suite {
 
   test("loop is stack safe") {
     val stackUnsafeSize = if (isJVM) 1000000 else 10000
-    def func(s: Int): Pull[Pure, INothing, Option[Int]] =
+    def func(s: Int): Pull[Pure, Nothing, Option[Int]] =
       s match {
         case `stackUnsafeSize` => Pull.pure(None)
         case _                 => Pull.pure(Some(s + 1))
@@ -97,7 +97,7 @@ class PullSuite extends Fs2Suite {
 
   test("loopEither is stack safe") {
     val stackUnsafeSize = if (isJVM) 1000000 else 10000
-    def func(s: Int): Pull[Pure, INothing, Either[Int, Unit]] =
+    def func(s: Int): Pull[Pure, Nothing, Either[Int, Unit]] =
       s match {
         case `stackUnsafeSize` => Pull.pure(Right(()))
         case _                 => Pull.pure(Left(s + 1))

--- a/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
@@ -97,7 +97,7 @@ class StreamInterruptSuite extends Fs2Suite {
       val interrupt =
         Stream.sleep_[IO](20.millis).compile.drain.attempt
 
-      def loop: Stream[IO, INothing] =
+      def loop: Stream[IO, Nothing] =
         Stream.eval(IO.unit) >> loop
 
       loop

--- a/core/shared/src/test/scala/fs2/StreamObserveSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamObserveSuite.scala
@@ -30,7 +30,7 @@ import org.scalacheck.effect.PropF.forAllF
 
 class StreamObserveSuite extends Fs2Suite {
   trait Observer {
-    def apply[O](s: Stream[IO, O])(observation: Pipe[IO, O, INothing]): Stream[IO, O]
+    def apply[O](s: Stream[IO, O])(observation: Pipe[IO, O, Nothing]): Stream[IO, O]
   }
 
   def observationTests(label: String, observer: Observer): Unit =
@@ -89,14 +89,14 @@ class StreamObserveSuite extends Fs2Suite {
 
       test("handle multiple consecutive observations") {
         forAllF { (s: Stream[Pure, Int]) =>
-          val sink: Pipe[IO, Int, INothing] = _.foreach(_ => IO.unit)
+          val sink: Pipe[IO, Int, Nothing] = _.foreach(_ => IO.unit)
           observer(observer(s)(sink))(sink).assertEmitsSameAs(s)
         }
       }
 
       test("no hangs on failures") {
         forAllF { (s: Stream[Pure, Int]) =>
-          val sink: Pipe[IO, Int, INothing] =
+          val sink: Pipe[IO, Int, Nothing] =
             in => spuriousFail(in.foreach(_ => IO.unit))
           val src: Stream[IO, Int] = spuriousFail(s.covary[IO])
           src.observe(sink).observe(sink).attempt.compile.drain
@@ -107,7 +107,7 @@ class StreamObserveSuite extends Fs2Suite {
   observationTests(
     "observe",
     new Observer {
-      def apply[O](s: Stream[IO, O])(observation: Pipe[IO, O, INothing]): Stream[IO, O] =
+      def apply[O](s: Stream[IO, O])(observation: Pipe[IO, O, Nothing]): Stream[IO, O] =
         s.observe(observation)
     }
   )
@@ -115,7 +115,7 @@ class StreamObserveSuite extends Fs2Suite {
   observationTests(
     "observeAsync",
     new Observer {
-      def apply[O](s: Stream[IO, O])(observation: Pipe[IO, O, INothing]): Stream[IO, O] =
+      def apply[O](s: Stream[IO, O])(observation: Pipe[IO, O, Nothing]): Stream[IO, O] =
         s.observeAsync(maxQueued = 10)(observation)
     }
   )

--- a/core/shared/src/test/scala/fs2/concurrent/BroadcastSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/BroadcastSuite.scala
@@ -84,7 +84,7 @@ class BroadcastSuite extends Fs2Suite {
 
   test("pipes should not be empty") {
     interceptMessage[AssertionError]("assertion failed: pipes should not be empty")(
-      Stream.empty.broadcastThrough[IO, INothing]()
+      Stream.empty.broadcastThrough[IO, Nothing]()
     )
   }
 }

--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -359,7 +359,7 @@ private[fs2] trait FilesCompanionPlatform {
     override def size(path: Path): F[Long] =
       stat(path).map(_.size.toLong)
 
-    override def writeAll(path: Path, flags: Flags): Pipe[F, Byte, INothing] =
+    override def writeAll(path: Path, flags: Flags): Pipe[F, Byte, Nothing] =
       in =>
         in.through {
           writeWritable(

--- a/io/js/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/js/src/main/scala/fs2/io/ioplatform.scala
@@ -152,14 +152,14 @@ private[fs2] trait ioplatform {
   def writeWritable[F[_]](
       writable: F[Writable],
       endAfterUse: Boolean = true
-  )(implicit F: Async[F]): Pipe[F, Byte, INothing] =
+  )(implicit F: Async[F]): Pipe[F, Byte, Nothing] =
     in =>
       Stream
         .eval(writable.map(_.asInstanceOf[streamMod.Writable]))
         .flatMap { writable =>
           def go(
               s: Stream[F, Byte]
-          ): Pull[F, INothing, Unit] = s.pull.uncons.flatMap {
+          ): Pull[F, Nothing, Unit] = s.pull.uncons.flatMap {
             case Some((head, tail)) =>
               Pull.eval {
                 F.async_[Unit] { cb =>
@@ -307,13 +307,13 @@ private[fs2] trait ioplatform {
   def stdin[F[_]: Async](ignored: Int): Stream[F, Byte] = stdin
 
   /** Pipe of bytes that writes emitted values to standard output asynchronously. */
-  def stdout[F[_]: Async]: Pipe[F, Byte, INothing] = stdoutAsync
+  def stdout[F[_]: Async]: Pipe[F, Byte, Nothing] = stdoutAsync
 
-  private def stdoutAsync[F[_]: Async]: Pipe[F, Byte, INothing] =
+  private def stdoutAsync[F[_]: Async]: Pipe[F, Byte, Nothing] =
     writeWritable(processMod.stdout.asInstanceOf[Writable].pure, false)
 
   /** Pipe of bytes that writes emitted values to standard error asynchronously. */
-  def stderr[F[_]: Async]: Pipe[F, Byte, INothing] =
+  def stderr[F[_]: Async]: Pipe[F, Byte, Nothing] =
     writeWritable(processMod.stderr.asInstanceOf[Writable].pure, false)
 
   /** Writes this stream to standard output asynchronously, converting each element to
@@ -321,7 +321,7 @@ private[fs2] trait ioplatform {
     */
   def stdoutLines[F[_]: Async, O: Show](
       charset: Charset = StandardCharsets.UTF_8
-  ): Pipe[F, O, INothing] =
+  ): Pipe[F, O, Nothing] =
     _.map(_.show).through(text.encode(charset)).through(stdoutAsync)
 
   /** Stream of `String` read asynchronously from standard input decoded in UTF-8. */
@@ -344,13 +344,13 @@ private[fs2] trait ioplatform {
     readInputStream(Sync[F].blocking(System.in), bufSize, false)
 
   /** Pipe of bytes that writes emitted values to standard output asynchronously. */
-  private[fs2] def stdout[F[_]: Sync]: Pipe[F, Byte, INothing] = stdoutSync
+  private[fs2] def stdout[F[_]: Sync]: Pipe[F, Byte, Nothing] = stdoutSync
 
-  private def stdoutSync[F[_]: Sync]: Pipe[F, Byte, INothing] =
+  private def stdoutSync[F[_]: Sync]: Pipe[F, Byte, Nothing] =
     writeOutputStream(Sync[F].blocking(System.out), false)
 
   /** Pipe of bytes that writes emitted values to standard error asynchronously. */
-  private[fs2] def stderr[F[_]: Sync]: Pipe[F, Byte, INothing] =
+  private[fs2] def stderr[F[_]: Sync]: Pipe[F, Byte, Nothing] =
     writeOutputStream(Sync[F].blocking(System.err), false)
 
   /** Writes this stream to standard output asynchronously, converting each element to
@@ -358,7 +358,7 @@ private[fs2] trait ioplatform {
     */
   private[fs2] def stdoutLines[F[_]: Sync, O: Show](
       charset: Charset
-  ): Pipe[F, O, INothing] =
+  ): Pipe[F, O, Nothing] =
     _.map(_.show).through(text.encode(charset)).through(stdoutSync)
 
   /** Stream of `String` read asynchronously from standard input decoded in UTF-8. */

--- a/io/js/src/main/scala/fs2/io/net/DatagramSocketPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/DatagramSocketPlatform.scala
@@ -113,7 +113,7 @@ private[net] trait DatagramSocketCompanionPlatform {
       )
     }
 
-    override def writes: Pipe[F, Datagram, INothing] = _.foreach(write)
+    override def writes: Pipe[F, Datagram, Nothing] = _.foreach(write)
 
     override def localAddress: F[SocketAddress[IpAddress]] =
       F.delay {

--- a/io/js/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -103,7 +103,7 @@ private[net] trait SocketCompanionPlatform {
     override def write(bytes: Chunk[Byte]): F[Unit] =
       Stream.chunk(bytes).through(writes).compile.drain
 
-    override def writes: Pipe[F, Byte, INothing] =
+    override def writes: Pipe[F, Byte, Nothing] =
       writeWritable(sock.asInstanceOf[Writable].pure, endAfterUse = false)
   }
 

--- a/io/js/src/test/scala/fs2/io/file/BaseFileSuite.scala
+++ b/io/js/src/test/scala/fs2/io/file/BaseFileSuite.scala
@@ -78,7 +78,7 @@ trait BaseFileSuite {
       .drain
       .as(file)
 
-  protected def modifyLater(file: Path): Stream[IO, INothing] =
+  protected def modifyLater(file: Path): Stream[IO, Nothing] =
     Stream
       .range(0, 4)
       .map(_.toByte)

--- a/io/jvm/src/main/scala/fs2/io/file/DeprecatedFilesApi.scala
+++ b/io/jvm/src/main/scala/fs2/io/file/DeprecatedFilesApi.scala
@@ -356,7 +356,7 @@ private[file] trait DeprecatedFilesApi[F[_]] { self: Files[F] =>
   def writeAll(
       path: JPath,
       flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
-  ): Pipe[F, Byte, INothing] =
+  ): Pipe[F, Byte, Nothing] =
     writeAll(Path.fromNioPath(path), Flags.fromOpenOptions(StandardOpenOption.WRITE +: flags))
 
   /** Returns a `WriteCursor` for the specified path.
@@ -383,7 +383,7 @@ private[file] trait DeprecatedFilesApi[F[_]] { self: Files[F] =>
       computePath: F[JPath],
       limit: Long,
       flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
-  ): Pipe[F, Byte, INothing] =
+  ): Pipe[F, Byte, Nothing] =
     writeRotate(
       computePath.map(Path.fromNioPath),
       limit,

--- a/io/jvm/src/main/scala/fs2/io/file/file.scala
+++ b/io/jvm/src/main/scala/fs2/io/file/file.scala
@@ -86,7 +86,7 @@ package object file {
   def writeAll[F[_]: Async](
       path: JPath,
       flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
-  ): Pipe[F, Byte, INothing] = Files[F].writeAll(path, flags)
+  ): Pipe[F, Byte, Nothing] = Files[F].writeAll(path, flags)
 
   /** Writes all data to a sequence of files, each limited in size to `limit`.
     *
@@ -100,7 +100,7 @@ package object file {
       computePath: F[JPath],
       limit: Long,
       flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
-  )(implicit F: Async[F]): Pipe[F, Byte, INothing] =
+  )(implicit F: Async[F]): Pipe[F, Byte, Nothing] =
     Files[F].writeRotate(computePath, limit, flags)
 
   /** Creates a [[Watcher]] for the default file system.

--- a/io/jvm/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/ioplatform.scala
@@ -119,11 +119,11 @@ private[fs2] trait ioplatform {
     readInputStream(Sync[F].blocking(System.in), bufSize, false)
 
   /** Pipe of bytes that writes emitted values to standard output asynchronously. */
-  def stdout[F[_]: Sync]: Pipe[F, Byte, INothing] =
+  def stdout[F[_]: Sync]: Pipe[F, Byte, Nothing] =
     writeOutputStream(Sync[F].blocking(System.out), false)
 
   /** Pipe of bytes that writes emitted values to standard error asynchronously. */
-  def stderr[F[_]: Sync]: Pipe[F, Byte, INothing] =
+  def stderr[F[_]: Sync]: Pipe[F, Byte, Nothing] =
     writeOutputStream(Sync[F].blocking(System.err), false)
 
   /** Writes this stream to standard output asynchronously, converting each element to
@@ -131,7 +131,7 @@ private[fs2] trait ioplatform {
     */
   def stdoutLines[F[_]: Sync, O: Show](
       charset: Charset = StandardCharsets.UTF_8
-  ): Pipe[F, O, INothing] =
+  ): Pipe[F, O, Nothing] =
     _.map(_.show).through(text.encode(charset)).through(stdout)
 
   /** Stream of `String` read asynchronously from standard input decoded in UTF-8. */

--- a/io/jvm/src/main/scala/fs2/io/net/DatagramSocketGroupPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/DatagramSocketGroupPlatform.scala
@@ -95,7 +95,7 @@ private[net] trait DatagramSocketGroupCompanionPlatform {
               }
             }
 
-          def writes: Pipe[F, Datagram, INothing] =
+          def writes: Pipe[F, Datagram, Nothing] =
             _.foreach(write)
 
           def close: F[Unit] = Async[F].delay(adsg.close(ctx))

--- a/io/jvm/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -102,7 +102,7 @@ private[net] trait SocketCompanionPlatform {
     def reads: Stream[F, Byte] =
       Stream.repeatEval(read(defaultReadSize)).unNoneTerminate.unchunks
 
-    def writes: Pipe[F, Byte, INothing] =
+    def writes: Pipe[F, Byte, Nothing] =
       _.chunks.foreach(write)
   }
 

--- a/io/jvm/src/main/scala/fs2/io/net/tls/DTLSSocket.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/tls/DTLSSocket.scala
@@ -75,7 +75,7 @@ object DTLSSocket {
         def write(datagram: Datagram): F[Unit] =
           engine.write(datagram.bytes)
 
-        def writes: Pipe[F, Datagram, INothing] =
+        def writes: Pipe[F, Datagram, Nothing] =
           _.foreach(write)
         def localAddress: F[SocketAddress[IpAddress]] = socket.localAddress
         def join(join: MulticastJoin[IpAddress], interface: NetworkInterface): F[GroupMembership] =

--- a/io/jvm/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
@@ -81,7 +81,7 @@ private[tls] trait TLSSocketCompanionPlatform { self: TLSSocket.type =>
       def reads: Stream[F, Byte] =
         Stream.repeatEval(read(8192)).unNoneTerminate.unchunks
 
-      def writes: Pipe[F, Byte, INothing] =
+      def writes: Pipe[F, Byte, Nothing] =
         _.chunks.foreach(write)
 
       def endOfOutput: F[Unit] =

--- a/io/jvm/src/test/scala/fs2/io/file/BaseFileSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/file/BaseFileSuite.scala
@@ -64,7 +64,7 @@ trait BaseFileSuite extends Fs2Suite {
   protected def modify(file: Path): IO[Path] =
     IO(JFiles.write(file.toNioPath, Array[Byte](0, 1, 2, 3))).as(file)
 
-  protected def modifyLater(file: Path): Stream[IO, INothing] =
+  protected def modifyLater(file: Path): Stream[IO, Nothing] =
     Stream
       .range(0, 4)
       .map(_.toByte)

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -370,12 +370,12 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
     * Use `writeAll(path, Flags.Append)` to append to the end of
     * the file, or pass other flags to further customize behavior.
     */
-  def writeAll(path: Path): Pipe[F, Byte, INothing] = writeAll(path, Flags.Write)
+  def writeAll(path: Path): Pipe[F, Byte, Nothing] = writeAll(path, Flags.Write)
 
   /** Writes all data to the file at the specified path, using the
     * specified flags to open the file.
     */
-  def writeAll(path: Path, flags: Flags): Pipe[F, Byte, INothing]
+  def writeAll(path: Path, flags: Flags): Pipe[F, Byte, Nothing]
 
   /** Returns a `WriteCursor` for the specified path.
     */
@@ -398,7 +398,7 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
       computePath: F[Path],
       limit: Long,
       flags: Flags
-  ): Pipe[F, Byte, INothing]
+  ): Pipe[F, Byte, Nothing]
 }
 
 object Files extends FilesCompanionPlatform {
@@ -486,7 +486,7 @@ object Files extends FilesCompanionPlatform {
     def writeAll(
         path: Path,
         flags: Flags
-    ): Pipe[F, Byte, INothing] =
+    ): Pipe[F, Byte, Nothing] =
       in =>
         Stream
           .resource(writeCursor(path, flags))
@@ -512,7 +512,7 @@ object Files extends FilesCompanionPlatform {
         computePath: F[Path],
         limit: Long,
         flags: Flags
-    ): Pipe[F, Byte, INothing] = {
+    ): Pipe[F, Byte, Nothing] = {
       def openNewFile: Resource[F, FileHandle[F]] =
         Resource
           .eval(computePath)

--- a/io/shared/src/main/scala/fs2/io/io.scala
+++ b/io/shared/src/main/scala/fs2/io/io.scala
@@ -101,9 +101,9 @@ package object io extends ioplatform {
   def writeOutputStream[F[_]](
       fos: F[OutputStream],
       closeAfterUse: Boolean = true
-  )(implicit F: Sync[F]): Pipe[F, Byte, INothing] =
+  )(implicit F: Sync[F]): Pipe[F, Byte, Nothing] =
     s => {
-      def useOs(os: OutputStream): Stream[F, INothing] =
+      def useOs(os: OutputStream): Stream[F, Nothing] =
         s.chunks.foreach(c => F.blocking(os.write(c.toArray)))
 
       val os =

--- a/io/shared/src/main/scala/fs2/io/net/DatagramSocket.scala
+++ b/io/shared/src/main/scala/fs2/io/net/DatagramSocket.scala
@@ -50,7 +50,7 @@ trait DatagramSocket[F[_]] extends DatagramSocketPlatform[F] {
 
   /** Writes supplied datagrams to this udp socket.
     */
-  def writes: Pipe[F, Datagram, INothing]
+  def writes: Pipe[F, Datagram, Nothing]
 
   /** Returns the local address of this udp socket. */
   def localAddress: F[SocketAddress[IpAddress]]

--- a/io/shared/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/shared/src/main/scala/fs2/io/net/Socket.scala
@@ -68,7 +68,7 @@ trait Socket[F[_]] {
 
   /** Writes the supplied stream of bytes to this socket via `write` semantics.
     */
-  def writes: Pipe[F, Byte, INothing]
+  def writes: Pipe[F, Byte, Nothing]
 }
 
 object Socket extends SocketCompanionPlatform


### PR DESCRIPTION
This PR deprecates the `INothing` type alias as it appears to no longer be necessary with modern compilers. Only a single use site is impacted by this deprecation (in CompilationTest.scala).