### PR TITLE
Add unidocs artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,11 +96,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/2.5.x')
-        run: mkdir -p target node/js/target protocols/js/target .js/target core/js/target mdoc/target core/jvm/target .jvm/target .native/target scodec/jvm/target scodec/js/target io/js/target reactive-streams/target io/jvm/target protocols/jvm/target benchmark/target project/target
+        run: mkdir -p target node/js/target protocols/js/target unidocs/target .js/target core/js/target mdoc/target core/jvm/target .jvm/target .native/target scodec/jvm/target scodec/js/target io/js/target reactive-streams/target io/jvm/target protocols/jvm/target benchmark/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/2.5.x')
-        run: tar cf targets.tar target node/js/target protocols/js/target .js/target core/js/target mdoc/target core/jvm/target .jvm/target .native/target scodec/jvm/target scodec/js/target io/js/target reactive-streams/target io/jvm/target protocols/jvm/target benchmark/target project/target
+        run: tar cf targets.tar target node/js/target protocols/js/target unidocs/target .js/target core/js/target mdoc/target core/jvm/target .jvm/target .native/target scodec/jvm/target scodec/js/target io/js/target reactive-streams/target io/jvm/target protocols/jvm/target benchmark/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/2.5.x')

--- a/build.sbt
+++ b/build.sbt
@@ -170,6 +170,7 @@ lazy val root = tlCrossRootProject
     scodec,
     protocols,
     reactiveStreams,
+    unidocs,
     benchmark
   )
 
@@ -317,6 +318,20 @@ lazy val reactiveStreams = project
     Test / fork := true // Otherwise SubscriberStabilitySpec fails
   )
   .dependsOn(coreJVM % "compile->compile;test->test")
+
+lazy val unidocs = project
+  .in(file("unidocs"))
+  .enablePlugins(TypelevelUnidocPlugin)
+  .settings(
+    name := "fs2-docs",
+    ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(
+      core.jvm,
+      io.jvm,
+      scodec.jvm,
+      protocols.jvm,
+      reactiveStreams
+    )
+  )
 
 lazy val benchmark = project
   .in(file("benchmark"))

--- a/build.sbt
+++ b/build.sbt
@@ -324,6 +324,7 @@ lazy val unidocs = project
   .enablePlugins(TypelevelUnidocPlugin)
   .settings(
     name := "fs2-docs",
+    tlFatalWarnings := false,
     ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(
       core.jvm,
       io.jvm,


### PR DESCRIPTION
As previously mentioned, this adds a published unidocs artifact `fs2-docs`, like http4s and other projects are adopting.

https://www.javadoc.io/doc/org.http4s/http4s-docs_2.13/0.23.11/org/http4s/index.html

Still a bit annoying that you have to explicitly list the projects. Haven't figured out how to automate that yet. Feel free to pass if this over-complicates the build and we can consider again when it's easier.

After the undidocs are published in the next release, I'll PR an update to the site with the new API docs URL.