### PR TITLE
Tiny docs correction in guide.md

### DIFF
--- a/site/guide.md
+++ b/site/guide.md
@@ -288,7 +288,7 @@ The `Pull[F[_],O,R]` type represents a program that may pull values from one or 
 [`Pull` class](https://github.com/functional-streams-for-scala/fs2/blob/main/core/shared/src/main/scala/fs2/Pull.scala)
 for the full set of operations on `Pull`.
 
-A pull that writes a single a single output of type `Int` can be constructed with `Pull.output1`.
+A pull that writes a single output of type `Int` can be constructed with `Pull.output1`.
 
 ```scala mdoc:reset
 import fs2._


### PR DESCRIPTION
Removed duplicate 'a single'.

Thanks for opening a PR!

Target the `main` branch if this PR is targeted for the 3.x series and the `series/2.5.x` branch if targeted for the 2.5.x series.

If the CI build fails due to Scalafmt, run `sbt scalafmtAll` and push the changes (generally a good idea to run this prior to opening the PR).

Feel free to ask questions on the fs2 and fs2-dev channels on the [Typelevel Discord server](https://discord.gg/9V8FZTVZ9R).
