### PR TITLE
Fix `Stream#parJoin` for short-circuiting monad transformers

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4049,19 +4049,18 @@ object Stream extends StreamLowPriority {
                       .compile
                       .drain
                       .guaranteeCase(oc =>
-                        lease.cancel.rethrow
-                          .guaranteeCase {
-                            case Outcome.Succeeded(fu) =>
-                              onOutcome(oc <* Outcome.succeeded(fu), Either.unit)
+                        lease.cancel.rethrow.guaranteeCase {
+                          case Outcome.Succeeded(fu) =>
+                            onOutcome(oc <* Outcome.succeeded(fu), Either.unit)
 
-                            case Outcome.Errored(e) =>
-                              onOutcome(oc, Either.left(e))
+                          case Outcome.Errored(e) =>
+                            onOutcome(oc, Either.left(e))
 
-                            case _ =>
-                              F.unit
-                          }
-                          .forceR(available.release >> decrementRunning)
+                          case _ =>
+                            F.unit
+                        }
                       )
+                      .forceR(available.release >> decrementRunning)
                   }.void
                 }
             }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4048,19 +4048,21 @@ object Stream extends StreamLowPriority {
                       .interruptWhen(done.map(_.nonEmpty))
                       .compile
                       .drain
-                      .guaranteeCase(oc =>
-                        lease.cancel.rethrow.guaranteeCase {
-                          case Outcome.Succeeded(fu) =>
-                            onOutcome(oc <* Outcome.succeeded(fu), Either.unit)
+                      .guaranteeCase { oc =>
+                        lease.cancel.rethrow
+                          .guaranteeCase {
+                            case Outcome.Succeeded(fu) =>
+                              onOutcome(oc <* Outcome.succeeded(fu), Either.unit)
 
-                          case Outcome.Errored(e) =>
-                            onOutcome(oc, Either.left(e))
+                            case Outcome.Errored(e) =>
+                              onOutcome(oc, Either.left(e))
 
-                          case _ =>
-                            F.unit
-                        }
-                      )
-                      .forceR(available.release >> decrementRunning)
+                            case _ =>
+                              F.unit
+                          }
+                          .forceR(available.release >> decrementRunning)
+                      }
+                      .handleError(_ => ())
                   }.void
                 }
             }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4055,7 +4055,7 @@ object Stream extends StreamLowPriority {
                               onOutcome(oc <* Outcome.succeeded(fu), Either.unit)
 
                             case Outcome.Errored(e) =>
-                              onOutcome(oc, Either.right(e))
+                              onOutcome(oc, Either.left(e))
 
                             case _ =>
                               F.unit

--- a/core/shared/src/test/scala/fs2/StreamParJoinSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamParJoinSuite.scala
@@ -231,9 +231,7 @@ class StreamParJoinSuite extends Fs2Suite {
         .compile
         .drain
         .value
-        .flatMap { actual =>
-          IO(assertEquals(actual, Left(TestException)))
-        }
+        .assertEquals(Left(TestException))
     }
 
     test("do not block while evaluating an EitherT.left outer stream") {

--- a/core/shared/src/test/scala/fs2/StreamParJoinSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamParJoinSuite.scala
@@ -210,15 +210,21 @@ class StreamParJoinSuite extends Fs2Suite {
         }
     }
 
-    test("do not block while evaluating a stream in EitherT[IO, Throwable, *] with multiple parJoins") {
+    test(
+      "do not block while evaluating a stream in EitherT[IO, Throwable, *] with multiple parJoins"
+    ) {
       case object TestException extends Throwable with NoStackTrace
       type F[A] = EitherT[IO, Throwable, A]
 
-      Stream.range(1, 64).covary[F]
-        .map(i => Stream.eval[F, Unit](
-          if (i == 7) EitherT.leftT(TestException)
-          else EitherT.right(IO.unit)
-        ))
+      Stream
+        .range(1, 64)
+        .covary[F]
+        .map(i =>
+          Stream.eval[F, Unit](
+            if (i == 7) EitherT.leftT(TestException)
+            else EitherT.right(IO.unit)
+          )
+        )
         .parJoin(4)
         .map(_ => Stream.eval[F, Unit](EitherT.right(IO.unit)))
         .parJoin(4)


### PR DESCRIPTION
PR fixes hang of the following stream:
```
case object TestException extends Throwable with NoStackTrace
type F[A] = EitherT[IO, Throwable, A]

Stream.range(1, 64).covary[F]
  .map(i => Stream.eval[F, Unit](
    if (i == 7) EitherT.leftT(TestException)
    else EitherT.right(IO.unit)
  ))
  .parJoin(4)
  .map(_ => Stream.eval[F, Unit](EitherT.right(IO.unit)))
  .parJoin(4)
  .compile
  .drain
```

**Problem description:**
For the given stream `lease.cancel` raises monad transformer error, so the following `available.release >> decrementRunning` chain is not invoked and therefore output stream is not closed. But this is only a part of the problem, even if we close the stream, it will swallow monad error and return successful result.


**Fix description:**
To fix the first part of the problem, I replaced `>>` monad composition with `forceR`, that is from `MonadCancel` so should work fine for short-circuiting monad transformers. To fix the second part, I raised `lease.cancel` failures into effect, separated success cancel with `guaranteeCase` and composed cancel result with the stream outcome `oc <* Outcome.succeeded(fu)`.