### PR TITLE
Upgrade sync compiler when runtime constraint is `Async`

### DIFF
--- a/core/shared/src/main/scala/fs2/Compiler.scala
+++ b/core/shared/src/main/scala/fs2/Compiler.scala
@@ -182,6 +182,8 @@ object Compiler extends CompilerLowPriority {
       case async: Async[F @unchecked] => forConcurrent(async)
       case _                          => new SyncTarget
     }
+
+    private[fs2] def mkSyncTarget[F[_]: Sync]: Target[F] = new SyncTarget
   }
 
   object Target extends TargetLowPriority {

--- a/core/shared/src/main/scala/fs2/Compiler.scala
+++ b/core/shared/src/main/scala/fs2/Compiler.scala
@@ -169,7 +169,7 @@ object Compiler extends CompilerLowPriority {
     def rootCancelScope: CancelScope = F.rootCancelScope
   }
 
-  private[fs2] trait TargetLowPriority { self: Target.type =>
+  private[fs2] trait TargetLowPriority {
 
     private final class SyncTarget[F[_]](implicit F0: Sync[F]) extends Target[F] {
       protected implicit val F: MonadCancelThrow[F] = F0
@@ -179,7 +179,7 @@ object Compiler extends CompilerLowPriority {
     }
 
     implicit def forSync[F[_]](implicit F: Sync[F]): Target[F] = F match {
-      case async: Async[F @unchecked] => forConcurrent(async)
+      case async: Async[F @unchecked] => Target.forConcurrent(async)
       case _                          => new SyncTarget
     }
 

--- a/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
@@ -357,7 +357,10 @@ class StreamInterruptSuite extends Fs2Suite {
       .assertEmits(List(2))
   }
 
-  def compileWithSync[F[_]: Sync, A](s: Stream[F, A]) = s.compile
+  def compileWithSync[F[_]: Sync, A](s: Stream[F, A]) = {
+    implicit val target = Compiler.Target.mkSyncTarget
+    s.compile
+  }
 
   test("23 - sync compiler interruption - succeeds when interrupted never") {
     val ioNever = IO.never[Either[Throwable, Unit]]

--- a/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
@@ -358,7 +358,7 @@ class StreamInterruptSuite extends Fs2Suite {
   }
 
   def compileWithSync[F[_]: Sync, A](s: Stream[F, A]) = {
-    implicit val target = Compiler.Target.mkSyncTarget
+    implicit val target: Compiler.Target[F] = Compiler.Target.mkSyncTarget
     s.compile
   }
 


### PR DESCRIPTION
This adopts the idea from https://github.com/typelevel/cats-effect/issues/2771, https://github.com/typelevel/cats-effect/issues/2772 to upgrade a sync compiler when at runtime the constraint is determined to be `Async`. Thoughts?