### PR TITLE
Add override for size in `Chunk` instance

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1129,6 +1129,7 @@ object Chunk
           else b
         go(0)
       }
+      override def size[A](fa: Chunk[A]): Long = fa.size.toLong
       override def toList[A](fa: Chunk[A]): List[A] = fa.toList
       override def isEmpty[A](fa: Chunk[A]): Boolean = fa.isEmpty
       override def empty[A]: Chunk[A] = Chunk.empty


### PR DESCRIPTION
Override the default implementation of `size` in `UnorderedFoldable` for `Chunk` so that it directly delegates to the `size` method, saving a traversal.

