### PR TITLE
Show `scalaJSLinkerConfig` setting in fs2-io.js docs

### DIFF
--- a/site/getstarted/install.md
+++ b/site/getstarted/install.md
@@ -24,8 +24,11 @@ The fs2-core as well as fs2-io and fs2-scodec libraries are also supported on Sc
 
 ```
 libraryDependencies += "co.fs2" %%% "fs2-core" % "@VERSION@"
-libraryDependencies += "co.fs2" %%% "fs2-io" % "@VERSION@" // Node.js only
 libraryDependencies += "co.fs2" %%% "fs2-scodec" % "@VERSION@"
+
+// Node.js only, and requires module support to be enabled
+libraryDependencies += "co.fs2" %%% "fs2-io" % "@VERSION@"
+scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)) 
 ```
 
 Release notes for each release are available on [Github](https://github.com/typelevel/fs2/releases/).


### PR DESCRIPTION
This is a common stumbling block :)