### PR TITLE
Extract Unit Chunks, Pull, Stream. 

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -526,6 +526,8 @@ object Chunk
     override def toString = "empty"
   }
 
+  private[fs2] val unit: Chunk[Unit] = singleton(())
+
   /** Chunk with no elements. */
   def empty[A]: Chunk[A] = empty_
 


### PR DESCRIPTION
- Add a `unit` chunk, which is just a singleton that contains a unit. 
- Add an `outUnit` Pull, which is just an `Output` around that chunk. Use it in a few places within Pull. 
- Add an `unit` Stream, which merely emits one unit value and ends.
- 