### PR TITLE
Respect FIFO for bounded Channel

### DIFF
--- a/core/shared/src/main/scala/fs2/concurrent/Channel.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Channel.scala
@@ -218,19 +218,19 @@ object Channel {
                   else (state.copy(waiting = waiting.some), state)
                 }
                 .flatMap {
-                  case s @ State(values, stateSize, ignorePreviousWaiting @ _, producers, closed) =>
+                  case s @ State(initValues, stateSize, ignorePreviousWaiting @ _, producers, closed) =>
                     if (shouldEmit(s)) {
                       var size = stateSize
-                      val moreValues = List.newBuilder[A]
+                      val tailValues = List.newBuilder[A]
                       var unblock = F.unit
 
                       producers.foreach { case (value, producer) =>
                         size += 1
-                        moreValues += value
+                        tailValues += value
                         unblock = unblock <* producer.complete(())
                       }
 
-                      val toEmit = makeChunk(values, moreValues.result(), size)
+                      val toEmit = makeChunk(initValues, tailValues.result(), size)
 
                       unblock.as(Pull.output(toEmit) >> consumeLoop)
                     } else {

--- a/core/shared/src/main/scala/fs2/concurrent/Channel.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Channel.scala
@@ -218,7 +218,13 @@ object Channel {
                   else (state.copy(waiting = waiting.some), state)
                 }
                 .flatMap {
-                  case s @ State(initValues, stateSize, ignorePreviousWaiting @ _, producers, closed) =>
+                  case s @ State(
+                        initValues,
+                        stateSize,
+                        ignorePreviousWaiting @ _,
+                        producers,
+                        closed
+                      ) =>
                     if (shouldEmit(s)) {
                       var size = stateSize
                       val tailValues = List.newBuilder[A]

--- a/core/shared/src/test/scala/fs2/concurrent/ChannelSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/ChannelSuite.scala
@@ -144,7 +144,7 @@ class ChannelSuite extends Fs2Suite {
         } yield ()
         f.start
       }
-      result <- IO.sleep(5.seconds) *> chan.stream.compile.toList.flatTap(IO.println)
+      result <- IO.sleep(5.seconds) *> chan.stream.compile.toList
     } yield result
 
     TestControl.executeEmbed(l).assertEquals((0 until 5).toList)

--- a/core/shared/src/test/scala/fs2/concurrent/ChannelSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/ChannelSuite.scala
@@ -24,6 +24,7 @@ package concurrent
 
 import cats.syntax.all._
 import cats.effect.IO
+import cats.effect.testkit.TestControl
 import scala.concurrent.duration._
 
 import org.scalacheck.effect.PropF.forAllF
@@ -130,6 +131,24 @@ class ChannelSuite extends Fs2Suite {
     } yield isClosedBefore
 
     p.assertEquals(true)
+  }
+
+  test("Channel.synchronous respects fifo") {
+    val l = for {
+      chan <- Channel.synchronous[IO, Int]
+      _ <- chan.send(0).start
+      _ <- (0 until 5).toList.traverse_ { i =>
+        val f = for {
+          _ <- IO.sleep(i.second)
+          _ <- chan.send(i)
+          _ <- if (i == 4) chan.close.void else IO.unit
+        } yield ()
+        f.start
+      }
+      result <- IO.sleep(5.seconds) *> chan.stream.compile.toList.flatTap(IO.println)
+    } yield result
+
+    TestControl.executeEmbed(l).assertEquals((0 until 5).toList)
   }
 
 }

--- a/core/shared/src/test/scala/fs2/concurrent/ChannelSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/ChannelSuite.scala
@@ -136,7 +136,6 @@ class ChannelSuite extends Fs2Suite {
   test("Channel.synchronous respects fifo") {
     val l = for {
       chan <- Channel.synchronous[IO, Int]
-      _ <- chan.send(0).start
       _ <- (0 until 5).toList.traverse_ { i =>
         val f = for {
           _ <- IO.sleep(i.second)


### PR DESCRIPTION
H/t @davesmith00000 for reporting and @Daenyth for helping to diagnose it.

The issue was first identified in terms of a synchronous channel: while the channel is blocked awaiting a consumer producers are queued, but then dequeued in reverse-order when there is downstream consumption. This causes the elements to become reversed, effectively FILO.