### PR TITLE
Don't propagate errors into Node.js

### DIFF
--- a/io/js/src/main/scala/fs2/io/NodeStream.scala
+++ b/io/js/src/main/scala/fs2/io/NodeStream.scala
@@ -37,8 +37,6 @@ trait Readable extends EventEmitter {
 
   protected[io] def destroy(): this.type = js.native
 
-  protected[io] def destroy(error: js.Error): this.type = js.native
-
   protected[io] def push(chunk: js.typedarray.Uint8Array): Boolean = js.native
 
   protected[io] def readableEnded: Boolean = js.native
@@ -52,7 +50,7 @@ trait Readable extends EventEmitter {
 @nowarn
 trait Writable extends EventEmitter {
 
-  protected[io] def destroy(error: js.Error): this.type = js.native
+  protected[io] def destroy(): this.type = js.native
 
   protected[io] def write(
       chunk: js.typedarray.Uint8Array,
@@ -70,7 +68,7 @@ trait Writable extends EventEmitter {
   */
 @js.native
 trait Duplex extends Readable with Writable {
-  protected[io] override def destroy(error: js.Error): this.type = js.native
+  protected[io] override def destroy(): this.type = js.native
 }
 
 final class StreamDestroyedException private[io] () extends IOException


### PR DESCRIPTION
H/t @satabin for reporting in https://github.com/satabin/fs2-data/pull/335#issuecomment-1155058038.

Previously, exceptions encountered in `fs2.Stream` would also be propagated into the Node.js stream it was interopping with. In v3.2.8 this started crashing the Node.js process with:

```
node:events:505
      throw er; // Unhandled 'error' event
      ^
Error: unexpected '1' before object key
    at $c_Lfs2_io_internal_ThrowableOps$ThrowableOps.toJSError__sjs_js_Error (/home/runner/work/fs2-data/fs2-data/json/circe/.js/target/scala-2.13/fs2-data-json-circe-test-fastopt/main.js:11048:10)
    at /home/runner/work/fs2-data/fs2-data/json/circe/.js/target/scala-2.13/fs2-data-json-circe-test-fastopt/main.js:11134:92
    ...
```

(Note: the `unexpected '1' before object key` is an expected error raised in the fs2-data test suite.)

Propagating the error seems sensible, but probably is not the right thing to do.
1. It's not necessary to preserve the error, since it's already being handled primarily through the FS2/CE3 control flow, propagation would simply be a side-channel. 
2. The error is likely to be unhandled on the Node.js side, which means it will crash the process. This effectively circumvents FS2/CE3 control flow which is undesirable.

I think this was an existing bug, that became exposed through the changes in https://github.com/typelevel/fs2/pull/2918. Specifically in 0c717498d3de30fd018b1d9611984a4caec7e4d1 besides replacing the facade I swapped in the `MicrotaskExecutor` for `SyncIO` (probably should have done it in another PR :) This introduced a new `cede`/`yield` due to the `evalOn` which gave the error event an opportunity to emit when previously it did not.