### PR TITLE
Use `interruptible` in `writeOutputStream`

### DIFF
--- a/io/jvm/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -212,6 +212,23 @@ class IoPlatformSuite extends Fs2Suite {
       readOutputStream(1)(_ => EitherT.left[Unit](IO.unit)).compile.drain.value
         .timeout(5.seconds)
     }
+
+    test("writeOutputStream doesn't hang on error") {
+      val s = Stream
+        .emit[IO, Byte](0)
+        .repeat
+        .take(3)
+        .through { in =>
+          readOutputStream(1) { out =>
+            in
+              .through(writeOutputStream(IO.pure(out)))
+              .compile
+              .drain
+          }
+        }
+
+      (s >> Stream.raiseError[IO](new RuntimeException("boom"))).compile.drain
+    }
   }
 
   group("readResource") {

--- a/io/jvm/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -228,6 +228,7 @@ class IoPlatformSuite extends Fs2Suite {
         }
 
       (s >> Stream.raiseError[IO](new RuntimeException("boom"))).compile.drain
+        .intercept[RuntimeException]
     }
   }
 

--- a/io/shared/src/main/scala/fs2/io/io.scala
+++ b/io/shared/src/main/scala/fs2/io/io.scala
@@ -104,7 +104,7 @@ package object io extends ioplatform {
   )(implicit F: Sync[F]): Pipe[F, Byte, Nothing] =
     s => {
       def useOs(os: OutputStream): Stream[F, Nothing] =
-        s.chunks.foreach(c => F.blocking(os.write(c.toArray)))
+        s.chunks.foreach(c => F.interruptible(os.write(c.toArray)))
 
       val os =
         if (closeAfterUse) Stream.bracket(fos)(os => F.blocking(os.close()))


### PR DESCRIPTION
Fixes https://github.com/typelevel/fs2/issues/2931.

As I understand it, interruptibility [doesn't come for free](https://github.com/typelevel/cats-effect/blob/7cb291426cadb359c786b1d318a46bced55d4ba3/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala#L27-L146). How do we feel about placing it in the hot path here? Maybe it should be configurable?