### PR TITLE
Fix bincompat of `PartiallyAppliedFromIterator` on Scala 2.12

### DIFF
--- a/core/shared/src/main/scala-2.12/fs2/PartiallyAppliedFromBlockingIteratorCrossCompat.scala
+++ b/core/shared/src/main/scala-2.12/fs2/PartiallyAppliedFromBlockingIteratorCrossCompat.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import cats.effect.kernel.Sync
+
+private[fs2] trait PartiallyAppliedFromBlockingIteratorCrossCompat {
+  @deprecated("bincompat", "3.2.10")
+  private[fs2] def `apply$extension`[F[_], A](
+      dummy: Boolean,
+      iterator: Iterator[A],
+      chunkSize: Int,
+      F: Sync[F]
+  ): Stream[F, A] =
+    new Stream.PartiallyAppliedFromIterator(dummy).apply(iterator, chunkSize)(F)
+}

--- a/core/shared/src/main/scala-2.13+/fs2/PartiallyAppliedFromBlockingIteratorCrossCompat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/PartiallyAppliedFromBlockingIteratorCrossCompat.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+private[fs2] trait PartiallyAppliedFromBlockingIteratorCrossCompat

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3296,7 +3296,7 @@ object Stream extends StreamLowPriority {
   def fromEither[F[_]]: PartiallyAppliedFromEither[F] =
     new PartiallyAppliedFromEither(dummy = true)
 
-  private[fs2] final class PartiallyAppliedFromIterator[F[_]](
+  final class PartiallyAppliedFromIterator[F[_]](
       private val blocking: Boolean
   ) extends AnyVal {
     def apply[A](iterator: Iterator[A], chunkSize: Int)(implicit F: Sync[F]): Stream[F, A] =
@@ -3318,7 +3318,7 @@ object Stream extends StreamLowPriority {
     }
   }
 
-  private[fs2] final class PartiallyAppliedFromBlockingIterator[F[_]](
+  final class PartiallyAppliedFromBlockingIterator[F[_]](
       private val blocking: Boolean
   ) extends AnyVal {
     def apply[A](iterator: Iterator[A], chunkSize: Int)(implicit F: Sync[F]): Stream[F, A] =

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3318,16 +3318,7 @@ object Stream extends StreamLowPriority {
     }
   }
 
-  object PartiallyAppliedFromIterator {
-    @deprecated("bincompat", "3.2.10")
-    private[fs2] def `apply$extension`[F[_], A](
-        dummy: Boolean,
-        iterator: Iterator[A],
-        chunkSize: Int,
-        F: Sync[F]
-    ): Stream[F, A] =
-      new PartiallyAppliedFromIterator(dummy).apply(iterator, chunkSize)(F)
-  }
+  object PartiallyAppliedFromIterator extends PartiallyAppliedFromBlockingIteratorCrossCompat
 
   final class PartiallyAppliedFromBlockingIterator[F[_]] private[fs2] (
       private val blocking: Boolean

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3318,6 +3318,17 @@ object Stream extends StreamLowPriority {
     }
   }
 
+  object PartiallyAppliedFromIterator {
+    @deprecated("bincompat", "3.2.10")
+    private[fs2] def `apply$extension`[F[_], A](
+        dummy: Boolean,
+        iterator: Iterator[A],
+        chunkSize: Int,
+        F: Sync[F]
+    ): Stream[F, A] =
+      new PartiallyAppliedFromIterator(dummy).apply(iterator, chunkSize)(F)
+  }
+
   final class PartiallyAppliedFromBlockingIterator[F[_]](
       private val blocking: Boolean
   ) extends AnyVal {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3296,7 +3296,7 @@ object Stream extends StreamLowPriority {
   def fromEither[F[_]]: PartiallyAppliedFromEither[F] =
     new PartiallyAppliedFromEither(dummy = true)
 
-  final class PartiallyAppliedFromIterator[F[_]](
+  final class PartiallyAppliedFromIterator[F[_]] private[fs2] (
       private val blocking: Boolean
   ) extends AnyVal {
     def apply[A](iterator: Iterator[A], chunkSize: Int)(implicit F: Sync[F]): Stream[F, A] =
@@ -3329,7 +3329,7 @@ object Stream extends StreamLowPriority {
       new PartiallyAppliedFromIterator(dummy).apply(iterator, chunkSize)(F)
   }
 
-  final class PartiallyAppliedFromBlockingIterator[F[_]](
+  final class PartiallyAppliedFromBlockingIterator[F[_]] private[fs2] (
       private val blocking: Boolean
   ) extends AnyVal {
     def apply[A](iterator: Iterator[A], chunkSize: Int)(implicit F: Sync[F]): Stream[F, A] =


### PR DESCRIPTION
Fixes https://github.com/typelevel/fs2/issues/2939.

This was my fault due to changes in https://github.com/typelevel/fs2/pull/2933.

Inline comments below.