### PR TITLE
Optimize `Chunk#toByteVector` when backed by a `ByteBuffer`

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -365,6 +365,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
   def toByteVector[B >: O](implicit ev: B =:= Byte): ByteVector =
     this match {
       case c: Chunk.ByteVectorChunk => c.toByteVector
+      case c: Chunk.ByteBuffer => ByteVector.view(c.buf.asReadOnlyBuffer())
       case other =>
         val slice = other.asInstanceOf[Chunk[Byte]].toArraySlice
         ByteVector.view(slice.values, slice.offset, slice.length)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -365,7 +365,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
   def toByteVector[B >: O](implicit ev: B =:= Byte): ByteVector =
     this match {
       case c: Chunk.ByteVectorChunk => c.toByteVector
-      case c: Chunk.ByteBuffer =>
+      case c: Chunk.ByteBuffer      =>
         // if c is a view, position/limit of underlying buffer may have changed
         val bb = c.buf.asReadOnlyBuffer()
         bb.position(c.offset)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -365,7 +365,12 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
   def toByteVector[B >: O](implicit ev: B =:= Byte): ByteVector =
     this match {
       case c: Chunk.ByteVectorChunk => c.toByteVector
-      case c: Chunk.ByteBuffer => ByteVector.view(c.buf.asReadOnlyBuffer())
+      case c: Chunk.ByteBuffer =>
+        // if c is a view, position/limit of underlying buffer may have changed
+        val bb = c.buf.asReadOnlyBuffer()
+        bb.position(c.offset)
+        bb.limit(c.offset + c.size)
+        ByteVector.view(bb)
       case other =>
         val slice = other.asInstanceOf[Chunk[Byte]].toArraySlice
         ByteVector.view(slice.values, slice.offset, slice.length)

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -137,7 +137,7 @@ class ChunkSuite extends Fs2Suite {
         }
       }
 
-      if (implicitly[ClassTag[A]] == ClassTag.Byte)
+      if (implicitly[ClassTag[A]] == ClassTag.Byte) {
         property("toByteBuffer.byte") {
           forAll { (c: Chunk[A]) =>
             implicit val ev: A =:= Byte = null
@@ -147,6 +147,14 @@ class ChunkSuite extends Fs2Suite {
             assertEquals[Any, Any](arr.toVector, c.toArray.toVector)
           }
         }
+
+        property("toByteVector") {
+          forAll { (c: Chunk[A]) =>
+            implicit val ev: A =:= Byte = null
+            assertEquals[Any, Any](c.toByteVector.toArray.toVector, c.toArray.toVector)
+          }
+        }
+      }
 
       checkAll(s"Eq[Chunk[$of]]", EqTests[Chunk[A]].eqv)
       checkAll("Monad[Chunk]", MonadTests[Chunk].monad[A, A, A])


### PR DESCRIPTION
When a `Chunk` is backed by `ByteBuffer` it is not necessary to copy the bytes to convert it to a `ByteVector`. This PR implements the conversion by creating a `ByteVector` "view" that directly wraps the chunk's underlying `ByteBuffer`.