### PR TITLE
Fix `meteredStartImmediately` first delay timing

### DIFF
--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -1003,6 +1003,17 @@ class StreamCombinatorsSuite extends Fs2Suite {
       .map(results => assert(results.size == 3))
   }
 
+  test("meteredStartImmediately should not wait between events that last longer than the rate") {
+    Stream
+      .eval[IO, Int](IO.sleep(1.second).as(1))
+      .repeatN(10)
+      .meteredStartImmediately(1.second)
+      .interruptAfter(4500.milliseconds)
+      .compile
+      .toList
+      .map(results => assert(results.size == 4))
+  }
+
   test("spaced should wait between events") {
     Stream
       .eval[IO, Int](IO.sleep(1.second).as(1))


### PR DESCRIPTION
Due to the way meteredStartImmediately is implemented the delay between the first and the second emitted element exhibits different behaviour than the delay beteen the Nth and (N+1)th element. This is noticible whenever processing of the first element takes significant time. The first delay behaves like in `fixedDelay` and the remaining delays behave like in `fixedRate`. 

In f87b1944e42a5c88d674e8494ccdf65d9ca4dd28 I reproduced the issue with a new test based on the existing "metered should not wait between events that last longer than the rate".

In 9286953c5701a6cc9c9cdc33934d22be2e491b16 I introduced `fixedRateStartImmediately` and then used it to implement `meteredStartImmediately`.

I introduced the startImmediatelly behaviour as a separete method `fixedRateStartImmediately` (like `metered` and `meteredStartImmediately`). Alternatively it could be introduced as a Boolean parameter of `fixedDelay` (like in `spaced`), while keeping the `fixedDelay` with it's current signature for bincompat. Please give me a hint which approach is prefered.