### PR TITLE
Add @unchecked to ignore uncheckable local class

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -951,8 +951,8 @@ object Pull extends PullLowPriority {
           def outLoop(acc: Pull[G, X, Unit], pred: Run[G, X, F[End]]): F[End] =
             // bit of an ugly hack to avoid a stack overflow when these accummulate
             pred match {
-              case vrun: ViewRunner => outLoop(bindView(acc, vrun.view), vrun.prevRunner)
-              case _                => pred.out(head, scope, acc)
+              case vrun: ViewRunner @unchecked => outLoop(bindView(acc, vrun.view), vrun.prevRunner)
+              case _                           => pred.out(head, scope, acc)
             }
           outLoop(tail, this)
         }


### PR DESCRIPTION
This pr adds in an `@unchecked` in order for this code to correctly run
in the community build. This is cherry-picked from some code that
@dwijnand added in
https://github.com/dotty-staging/fs2/commit/1ba97a221819aa3d44f3e2e3a3266e1947bce8dc
to get fs2 to pass the community build with the following reason:

> This is because the local class is defined in terms of a type parameter,
> so it's not type sound to assume it's a safe check, see dotty issue 4812

I recently had the `dotty-staging/fs2` fork updated to the latest to be
able to update the community build to sbt 1.7.1, but this commit got
lost and since it's easier to just stay in sync instead of diverging I
figured I'd try to just upstream this.

Without this change you can see the error in https://github.com/lampepfl/dotty/runs/7468138435?check_suite_focus=true

```
[error] -- Error: /__w/dotty/dotty/community-build/community-projects/fs2/core/shared/src/main/scala/fs2/Pull.scala:954:19
[error] 954 |case vrun: ViewRunner => outLoop(bindView(acc, vrun.view), vrun.prevRunner)
[error]     |                   ^
[error]     |             the type test for ViewRunner cannot be checked at runtime
[error] one error found
[error] (coreJVM / Compile / compileIncremental) Compilation failed
[error] Total time: 26 s, completed Jul 22, 2022 2:51:57 PM
```