### PR TITLE
Node.js Gzip

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -158,7 +158,8 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
     "fs2.compression.Compression.gunzip$default$1$"
   ),
   ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.ChunkCompanionPlatform.makeArrayBuilder"),
-  ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.concurrent.Channel.trySend")
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.concurrent.Channel.trySend"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.compression.Compression.gunzip")
 )
 
 lazy val root = tlCrossRootProject

--- a/core/js/src/main/scala/fs2/compression/CompressionPlatform.scala
+++ b/core/js/src/main/scala/fs2/compression/CompressionPlatform.scala
@@ -22,6 +22,91 @@
 package fs2
 package compression
 
-private[compression] trait CompressionPlatform[F[_]]
+private[compression] trait CompressionPlatform[F[_]] {
+
+  /** Returns a pipe that incrementally compresses input into the GZIP format
+    * as defined by RFC 1952 at https://www.ietf.org/rfc/rfc1952.txt. Output is
+    * compatible with the GNU utils `gunzip` utility, as well as really anything
+    * else that understands GZIP. Note, however, that the GZIP format is not
+    * "stable" in the sense that all compressors will produce identical output
+    * given identical input. Part of the header seeding is arbitrary and chosen by
+    * the compression implementation. For this reason, the exact bytes produced
+    * by this pipe will differ in insignificant ways from the exact bytes produced
+    * by a tool like the GNU utils `gzip`.
+    *
+    * GZIP wraps a deflate stream with file attributes and stream integrity validation.
+    * Therefore, GZIP is a good choice for compressing finite, complete, readily-available,
+    * continuous or file streams. A simpler deflate stream may be better suited to
+    * real-time, intermittent, fragmented, interactive or discontinuous streams where
+    * network protocols typically provide stream integrity validation.
+    *
+    * @param bufferSize The buffer size which will be used to page data
+    *                   into chunks. This will be the chunk size of the
+    *                   output stream. You should set it to be equal to
+    *                   the size of the largest chunk in the input stream.
+    *                   Setting this to a size which is ''smaller'' than
+    *                   the chunks in the input stream will result in
+    *                   performance degradation of roughly 50-75%. Default
+    *                   size is 32 KB.
+    * @param deflateLevel     level the compression level (0-9)
+    * @param deflateStrategy  strategy compression strategy -- see `java.util.zip.Deflater` for details
+    * @param modificationTime optional file modification time
+    * @param fileName         optional file name
+    * @param comment          optional file comment
+    */
+  def gzip(
+      bufferSize: Int = 1024 * 32,
+      deflateLevel: Option[Int] = None,
+      deflateStrategy: Option[Int] = None,
+      modificationTime: Option[Nothing] = None,
+      fileName: Option[Nothing] = None,
+      comment: Option[Nothing] = None
+  ): Pipe[F, Byte, Byte] =
+    gzip(
+      fileName = fileName,
+      modificationTime = modificationTime,
+      comment = comment,
+      deflateParams = DeflateParams(
+        bufferSize = bufferSize,
+        header = ZLibParams.Header.GZIP,
+        level = deflateLevel
+          .map(DeflateParams.Level.apply)
+          .getOrElse(DeflateParams.Level.DEFAULT),
+        strategy = deflateStrategy
+          .map(DeflateParams.Strategy.apply)
+          .getOrElse(DeflateParams.Strategy.DEFAULT),
+        flushMode = DeflateParams.FlushMode.DEFAULT
+      )
+    )
+
+  /** Returns a pipe that incrementally compresses input into the GZIP format
+    * as defined by RFC 1952 at https://www.ietf.org/rfc/rfc1952.txt. Output is
+    * compatible with the GNU utils `gunzip` utility, as well as really anything
+    * else that understands GZIP. Note, however, that the GZIP format is not
+    * "stable" in the sense that all compressors will produce identical output
+    * given identical input. Part of the header seeding is arbitrary and chosen by
+    * the compression implementation. For this reason, the exact bytes produced
+    * by this pipe will differ in insignificant ways from the exact bytes produced
+    * by a tool like the GNU utils `gzip`.
+    *
+    * GZIP wraps a deflate stream with file attributes and stream integrity validation.
+    * Therefore, GZIP is a good choice for compressing finite, complete, readily-available,
+    * continuous or file streams. A simpler deflate stream may be better suited to
+    * real-time, intermittent, fragmented, interactive or discontinuous streams where
+    * network protocols typically provide stream integrity validation.
+    *
+    * @param fileName         optional file name
+    * @param modificationTime optional file modification time
+    * @param comment          optional file comment
+    * @param deflateParams    see [[compression.DeflateParams]]
+    */
+  def gzip(
+      fileName: Option[Nothing],
+      modificationTime: Option[Nothing],
+      comment: Option[Nothing],
+      deflateParams: DeflateParams
+  ): Pipe[F, Byte, Byte]
+
+}
 
 private[compression] trait CompressionCompanionPlatform

--- a/core/js/src/main/scala/fs2/compression/GunzipResult.scala
+++ b/core/js/src/main/scala/fs2/compression/GunzipResult.scala
@@ -19,8 +19,26 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package fs2.io
+package fs2
+package compression
 
-object compression extends compressionplatform {
-  type ZipException = java.util.zip.ZipException
-}
+/** Gunzip decompression results including file properties and
+  * decompressed content stream, used as follows:
+  *   stream
+  *     .through(gunzip[IO]())
+  *     .flatMap { gunzipResult =>
+  *       // Access properties here.
+  *       gunzipResult.content
+  *     }
+  *
+  * @param content Uncompressed content stream.
+  * @param modificationTime Modification time of compressed file.
+  * @param fileName File name.
+  * @param comment File comment.
+  */
+case class GunzipResult[F[_]](
+    content: Stream[F, Byte],
+    modificationTime: Option[Nothing] = None,
+    fileName: Option[Nothing] = None,
+    comment: Option[Nothing] = None
+)

--- a/core/jvm/src/main/scala/fs2/compression/CompressionPlatform.scala
+++ b/core/jvm/src/main/scala/fs2/compression/CompressionPlatform.scala
@@ -115,44 +115,6 @@ private[compression] trait CompressionPlatform[F[_]] { self: Compression[F] =>
       deflateParams: DeflateParams
   ): Pipe[F, Byte, Byte]
 
-  /** Returns a pipe that incrementally decompresses input according to the GZIP
-    * format as defined by RFC 1952 at https://www.ietf.org/rfc/rfc1952.txt. Any
-    * errors in decompression will be sequenced as exceptions into the output
-    * stream. Decompression is handled in a streaming and async fashion without
-    * any thread blockage.
-    *
-    * The chunk size here is actually really important. Matching the input stream
-    * largest chunk size, or roughly 8 KB (whichever is larger) is a good rule of
-    * thumb.
-    *
-    * @param bufferSize The bounding size of the input buffer. This should roughly
-    *                   match the size of the largest chunk in the input stream.
-    *                   This will also be the chunk size in the output stream.
-    *                    Default size is 32 KB.
-    * @return See [[compression.GunzipResult]]
-    */
-  def gunzip(bufferSize: Int = 1024 * 32): Stream[F, Byte] => Stream[F, GunzipResult[F]] =
-    gunzip(
-      InflateParams(
-        bufferSize = bufferSize,
-        header = ZLibParams.Header.GZIP
-      )
-    )
-
-  /** Returns a pipe that incrementally decompresses input according to the GZIP
-    * format as defined by RFC 1952 at https://www.ietf.org/rfc/rfc1952.txt. Any
-    * errors in decompression will be sequenced as exceptions into the output
-    * stream. Decompression is handled in a streaming and async fashion without
-    * any thread blockage.
-    *
-    * The chunk size here is actually really important. Matching the input stream
-    * largest chunk size, or roughly 8 KB (whichever is larger) is a good rule of
-    * thumb.
-    *
-    * @param inflateParams See [[compression.InflateParams]]
-    * @return See [[compression.GunzipResult]]
-    */
-  def gunzip(inflateParams: InflateParams): Stream[F, Byte] => Stream[F, GunzipResult[F]]
 }
 
 private[compression] trait CompressionCompanionPlatform {

--- a/core/jvm/src/test/scala/fs2/JvmCompressionSuite.scala
+++ b/core/jvm/src/test/scala/fs2/JvmCompressionSuite.scala
@@ -373,29 +373,4 @@ class JvmCompressionSuite extends CompressionSuite {
       StandardCharsets.ISO_8859_1
     )
 
-  group("maybeGunzip") {
-    def maybeGunzip[F[_]: Compression](s: Stream[F, Byte]): Stream[F, Byte] =
-      s.pull
-        .unconsN(2, allowFewer = true)
-        .flatMap {
-          case Some((hd, tl)) =>
-            if (hd == Chunk[Byte](0x1f, 0x8b.toByte))
-              Compression[F].gunzip(128)(tl.cons(hd)).flatMap(_.content).pull.echo
-            else tl.cons(hd).pull.echo
-          case None => Pull.done
-        }
-        .stream
-
-    test("not gzip") {
-      forAllF { (s: Stream[Pure, Byte]) =>
-        maybeGunzip[IO](s).compile.toList.assertEquals(s.toList)
-      }
-    }
-
-    test("gzip") {
-      forAllF { (s: Stream[Pure, Byte]) =>
-        maybeGunzip[IO](Compression[IO].gzip()(s)).compile.toList.assertEquals(s.toList)
-      }
-    }
-  }
 }

--- a/core/jvm/src/test/scala/fs2/JvmCompressionSuite.scala
+++ b/core/jvm/src/test/scala/fs2/JvmCompressionSuite.scala
@@ -233,21 +233,6 @@ class JvmCompressionSuite extends CompressionSuite {
     }
   }
 
-  test("gzip.compresses input") {
-    val uncompressed =
-      getBytes(""""
-                   |"A type system is a tractable syntactic method for proving the absence
-                   |of certain program behaviors by classifying phrases according to the
-                   |kinds of values they compute."
-                   |-- Pierce, Benjamin C. (2002). Types and Programming Languages""")
-    Stream
-      .chunk[IO, Byte](Chunk.array(uncompressed))
-      .through(Compression[IO].gzip(2048))
-      .compile
-      .toVector
-      .map(compressed => assert(compressed.length < uncompressed.length))
-  }
-
   test("gzip.compresses input, with FLG.FHCRC set") {
     Stream
       .chunk[IO, Byte](Chunk.array(getBytes("Foo")))
@@ -335,30 +320,6 @@ class JvmCompressionSuite extends CompressionSuite {
       .toVector
       .map(vector => new String(vector.toArray, StandardCharsets.US_ASCII))
       .assertEquals(expectedContent)
-  }
-
-  test("gzip and gunzip are reusable") {
-    val bytesIn: Int = 1024 * 1024
-    val chunkSize = 1024
-    val gzipStream = Compression[IO].gzip(bufferSize = chunkSize)
-    val gunzipStream = Compression[IO].gunzip(bufferSize = chunkSize)
-    val stream = Stream
-      .chunk[IO, Byte](Chunk.array(1.to(bytesIn).map(_.toByte).toArray))
-      .through(gzipStream)
-      .through(gunzipStream)
-      .flatMap(_.content)
-    for {
-      first <-
-        stream
-          .fold(Vector.empty[Byte]) { case (vector, byte) => vector :+ byte }
-          .compile
-          .last
-      second <-
-        stream
-          .fold(Vector.empty[Byte]) { case (vector, byte) => vector :+ byte }
-          .compile
-          .last
-    } yield assertEquals(first, second)
   }
 
   def toEncodableFileName(fileName: String): String =

--- a/core/shared/src/main/scala/fs2/compression/Compression.scala
+++ b/core/shared/src/main/scala/fs2/compression/Compression.scala
@@ -32,6 +32,44 @@ sealed trait Compression[F[_]] extends CompressionPlatform[F] {
 
   def inflate(inflateParams: InflateParams): Pipe[F, Byte, Byte]
 
+  /** Returns a pipe that incrementally decompresses input according to the GZIP
+    * format as defined by RFC 1952 at https://www.ietf.org/rfc/rfc1952.txt. Any
+    * errors in decompression will be sequenced as exceptions into the output
+    * stream. Decompression is handled in a streaming and async fashion without
+    * any thread blockage.
+    *
+    * The chunk size here is actually really important. Matching the input stream
+    * largest chunk size, or roughly 8 KB (whichever is larger) is a good rule of
+    * thumb.
+    *
+    * @param bufferSize The bounding size of the input buffer. This should roughly
+    *                   match the size of the largest chunk in the input stream.
+    *                   This will also be the chunk size in the output stream.
+    *                    Default size is 32 KB.
+    * @return See [[compression.GunzipResult]]
+    */
+  def gunzip(bufferSize: Int = 1024 * 32): Stream[F, Byte] => Stream[F, GunzipResult[F]] =
+    gunzip(
+      InflateParams(
+        bufferSize = bufferSize,
+        header = ZLibParams.Header.GZIP
+      )
+    )
+
+  /** Returns a pipe that incrementally decompresses input according to the GZIP
+    * format as defined by RFC 1952 at https://www.ietf.org/rfc/rfc1952.txt. Any
+    * errors in decompression will be sequenced as exceptions into the output
+    * stream. Decompression is handled in a streaming and async fashion without
+    * any thread blockage.
+    *
+    * The chunk size here is actually really important. Matching the input stream
+    * largest chunk size, or roughly 8 KB (whichever is larger) is a good rule of
+    * thumb.
+    *
+    * @param inflateParams See [[compression.InflateParams]]
+    * @return See [[compression.GunzipResult]]
+    */
+  def gunzip(inflateParams: InflateParams): Stream[F, Byte] => Stream[F, GunzipResult[F]]
 }
 
 object Compression extends CompressionCompanionPlatform {

--- a/core/shared/src/test/scala/fs2/CompressionSuite.scala
+++ b/core/shared/src/test/scala/fs2/CompressionSuite.scala
@@ -281,6 +281,45 @@ abstract class CompressionSuite(implicit compression: Compression[IO]) extends F
     } yield assertEquals(first, second)
   }
 
+  test("gzip.compresses input") {
+    val uncompressed =
+      getBytes(""""
+                   |"A type system is a tractable syntactic method for proving the absence
+                   |of certain program behaviors by classifying phrases according to the
+                   |kinds of values they compute."
+                   |-- Pierce, Benjamin C. (2002). Types and Programming Languages""")
+    Stream
+      .chunk[IO, Byte](Chunk.array(uncompressed))
+      .through(Compression[IO].gzip(2048))
+      .compile
+      .toVector
+      .map(compressed => assert(compressed.length < uncompressed.length))
+  }
+
+  test("gzip and gunzip are reusable") {
+    val bytesIn: Int = 1024 * 1024
+    val chunkSize = 1024
+    val gzipStream = Compression[IO].gzip(bufferSize = chunkSize)
+    val gunzipStream = Compression[IO].gunzip(bufferSize = chunkSize)
+    val stream = Stream
+      .chunk[IO, Byte](Chunk.array(1.to(bytesIn).map(_.toByte).toArray))
+      .through(gzipStream)
+      .through(gunzipStream)
+      .flatMap(_.content)
+    for {
+      first <-
+        stream
+          .fold(Vector.empty[Byte]) { case (vector, byte) => vector :+ byte }
+          .compile
+          .last
+      second <-
+        stream
+          .fold(Vector.empty[Byte]) { case (vector, byte) => vector :+ byte }
+          .compile
+          .last
+    } yield assertEquals(first, second)
+  }
+
   group("maybeGunzip") {
     def maybeGunzip[F[_]: Compression](s: Stream[F, Byte]): Stream[F, Byte] =
       s.pull

--- a/core/shared/src/test/scala/fs2/CompressionSuite.scala
+++ b/core/shared/src/test/scala/fs2/CompressionSuite.scala
@@ -280,4 +280,30 @@ abstract class CompressionSuite(implicit compression: Compression[IO]) extends F
           .last
     } yield assertEquals(first, second)
   }
+
+  group("maybeGunzip") {
+    def maybeGunzip[F[_]: Compression](s: Stream[F, Byte]): Stream[F, Byte] =
+      s.pull
+        .unconsN(2, allowFewer = true)
+        .flatMap {
+          case Some((hd, tl)) =>
+            if (hd == Chunk[Byte](0x1f, 0x8b.toByte))
+              Compression[F].gunzip(128)(tl.cons(hd)).flatMap(_.content).pull.echo
+            else tl.cons(hd).pull.echo
+          case None => Pull.done
+        }
+        .stream
+
+    test("not gzip") {
+      forAllF { (s: Stream[Pure, Byte]) =>
+        maybeGunzip[IO](s).compile.toList.assertEquals(s.toList)
+      }
+    }
+
+    test("gzip") {
+      forAllF { (s: Stream[Pure, Byte]) =>
+        maybeGunzip[IO](Compression[IO].gzip()(s)).compile.toList.assertEquals(s.toList)
+      }
+    }
+  }
 }

--- a/core/shared/src/test/scala/fs2/CompressionSuite.scala
+++ b/core/shared/src/test/scala/fs2/CompressionSuite.scala
@@ -82,6 +82,36 @@ abstract class CompressionSuite(implicit compression: Compression[IO]) extends F
     )
   )
 
+  test("inflate please wrap") {
+    Stream
+      .chunk[IO, Byte](
+        Chunk.array(
+          Array[Byte](120, -100, -53, -52, 75, -53, 73, 44, 73, 85, 40, -56, 73, 77, 44, 78, 85, 40,
+            47, 74, 44, 0, 0, 73, -20, 7, 88)
+        )
+      )
+      .through(Compression[IO].inflate(InflateParams.DEFAULT))
+      .through(text.utf8.decode)
+      .compile
+      .string
+      .assertEquals("inflate please wrap")
+  }
+
+  test("inflate please nowrap") {
+    Stream
+      .chunk[IO, Byte](
+        Chunk.array(
+          Array[Byte](-53, -52, 75, -53, 73, 44, 73, 85, 40, -56, 73, 77, 44, 78, 85, -56, -53, 47,
+            47, 74, 44, 0, 0)
+        )
+      )
+      .through(Compression[IO].inflate(InflateParams(header = ZLibParams.Header.GZIP)))
+      .through(text.utf8.decode)
+      .compile
+      .string
+      .assertEquals("inflate please nowrap")
+  }
+
   test("deflate input") {
     forAllF { (s: String, level0: Int, strategy0: Int, nowrap: Boolean) =>
       val level = (level0 % 10).abs

--- a/io/js/src/main/scala/fs2/io/compressionplatform.scala
+++ b/io/js/src/main/scala/fs2/io/compressionplatform.scala
@@ -46,7 +46,7 @@ private[io] trait compressionplatform {
         Stream
           .resource(suspendReadableAndRead() {
             deflateParams.header match {
-              case ZLibParams.Header.GZIP => facade.zlib.createGzip(options)
+              case ZLibParams.Header.GZIP => facade.zlib.createDeflateRaw(options)
               case ZLibParams.Header.ZLIB => facade.zlib.createDeflate(options)
             }
           })
@@ -67,7 +67,7 @@ private[io] trait compressionplatform {
         Stream
           .resource(suspendReadableAndRead() {
             inflateParams.header match {
-              case ZLibParams.Header.GZIP => facade.zlib.createGunzip(options)
+              case ZLibParams.Header.GZIP => facade.zlib.createInflateRaw(options)
               case ZLibParams.Header.ZLIB => facade.zlib.createInflate(options)
             }
           })

--- a/io/js/src/main/scala/fs2/io/compressionplatform.scala
+++ b/io/js/src/main/scala/fs2/io/compressionplatform.scala
@@ -26,16 +26,66 @@ import cats.effect.kernel.Async
 import cats.syntax.all._
 import fs2.compression.Compression
 import fs2.compression.DeflateParams
+import fs2.compression.GunzipResult
 import fs2.compression.InflateParams
 import fs2.compression.ZLibParams
 import fs2.io.internal.facade
 
 private[io] trait compressionplatform {
 
+  class ZipException(msg: String) extends IOException(msg)
+
   implicit def fs2ioCompressionForAsync[F[_]](implicit F: Async[F]): Compression[F] =
     new Compression.UnsealedCompression[F] {
 
-      override def deflate(deflateParams: DeflateParams): Pipe[F, Byte, Byte] = in => {
+      def deflate(deflateParams: DeflateParams): Pipe[F, Byte, Byte] =
+        deflateImpl(deflateParams) { options =>
+          deflateParams.header match {
+            case ZLibParams.Header.GZIP => facade.zlib.createDeflateRaw(options)
+            case ZLibParams.Header.ZLIB => facade.zlib.createDeflate(options)
+          }
+        }
+
+      def inflate(inflateParams: InflateParams): Pipe[F, Byte, Byte] =
+        inflateImpl(inflateParams) { options =>
+          inflateParams.header match {
+            case ZLibParams.Header.GZIP => facade.zlib.createInflateRaw(options)
+            case ZLibParams.Header.ZLIB => facade.zlib.createInflate(options)
+          }
+        }
+
+      def gzip(
+          fileName: Option[Nothing],
+          modificationTime: Option[Nothing],
+          comment: Option[Nothing],
+          deflateParams: DeflateParams
+      ): Pipe[F, Byte, Byte] = deflateImpl(deflateParams) { options =>
+        deflateParams.header match {
+          case ZLibParams.Header.GZIP => facade.zlib.createGzip(options)
+          case ZLibParams.Header.ZLIB =>
+            throw new ZipException(
+              s"${ZLibParams.Header.GZIP} header type required, not ${deflateParams.header}."
+            )
+        }
+      }
+
+      def gunzip(inflateParams: InflateParams): Stream[F, Byte] => Stream[F, GunzipResult[F]] =
+        in => {
+          val content = inflateImpl(inflateParams) { options =>
+            inflateParams.header match {
+              case ZLibParams.Header.GZIP => facade.zlib.createGunzip(options)
+              case ZLibParams.Header.ZLIB =>
+                throw new ZipException(
+                  s"${ZLibParams.Header.GZIP} header type required, not ${inflateParams.header}."
+                )
+            }
+          }
+          Stream.emit(GunzipResult(content(in)))
+        }
+
+      def deflateImpl(
+          deflateParams: DeflateParams
+      )(f: facade.zlib.Options => facade.zlib.Zlib): Pipe[F, Byte, Byte] = in => {
         val options = new facade.zlib.Options {
           chunkSize = deflateParams.bufferSizeOrMinimum
           level = deflateParams.level.juzDeflaterLevel
@@ -44,12 +94,7 @@ private[io] trait compressionplatform {
         }
 
         Stream
-          .resource(suspendReadableAndRead() {
-            deflateParams.header match {
-              case ZLibParams.Header.GZIP => facade.zlib.createDeflateRaw(options)
-              case ZLibParams.Header.ZLIB => facade.zlib.createDeflate(options)
-            }
-          })
+          .resource(suspendReadableAndRead()(f(options)))
           .flatMap { case (deflate, out) =>
             out
               .concurrently(in.through(writeWritable[F](deflate.pure.widen)))
@@ -59,18 +104,15 @@ private[io] trait compressionplatform {
           }
       }
 
-      override def inflate(inflateParams: InflateParams): Pipe[F, Byte, Byte] = in => {
+      def inflateImpl(
+          inflateParams: InflateParams
+      )(f: facade.zlib.Options => facade.zlib.Zlib): Pipe[F, Byte, Byte] = in => {
         val options = new facade.zlib.Options {
           chunkSize = inflateParams.bufferSizeOrMinimum
         }
 
         Stream
-          .resource(suspendReadableAndRead() {
-            inflateParams.header match {
-              case ZLibParams.Header.GZIP => facade.zlib.createInflateRaw(options)
-              case ZLibParams.Header.ZLIB => facade.zlib.createInflate(options)
-            }
-          })
+          .resource(suspendReadableAndRead()(f(options)))
           .flatMap { case (inflate, out) =>
             out
               .concurrently(in.through(writeWritable[F](inflate.pure.widen)))

--- a/io/js/src/main/scala/fs2/io/compressionplatform.scala
+++ b/io/js/src/main/scala/fs2/io/compressionplatform.scala
@@ -60,6 +60,7 @@ private[io] trait compressionplatform {
           comment: Option[Nothing],
           deflateParams: DeflateParams
       ): Pipe[F, Byte, Byte] = deflateImpl(deflateParams) { options =>
+        require(!deflateParams.fhCrcEnabled, "FHCRC is not supported on Node.js")
         deflateParams.header match {
           case ZLibParams.Header.GZIP => facade.zlib.createGzip(options)
           case ZLibParams.Header.ZLIB =>

--- a/io/js/src/main/scala/fs2/io/internal/facade/zlib.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/zlib.scala
@@ -49,9 +49,9 @@ package object zlib {
   private[io] def createGzip(options: Options): Zlib = js.native
 
   @js.native
-  @JSImport("zlib", "gzipSync")
+  @JSImport("zlib", "deflateRawSync")
   @nowarn
-  private[io] def gzipSync(buffer: Uint8Array, options: Options): Uint8Array = js.native
+  private[io] def deflateRawSync(buffer: Uint8Array, options: Options): Uint8Array = js.native
 
   @js.native
   @JSImport("zlib", "createGunzip")
@@ -59,9 +59,9 @@ package object zlib {
   private[io] def createGunzip(options: Options): Zlib = js.native
 
   @js.native
-  @JSImport("zlib", "gunzipSync")
+  @JSImport("zlib", "inflateRawSync")
   @nowarn
-  private[io] def gunzipSync(buffer: Uint8Array, options: Options): Uint8Array = js.native
+  private[io] def inflateRawSync(buffer: Uint8Array, options: Options): Uint8Array = js.native
 
   @js.native
   @JSImport("zlib", "createInflate")

--- a/io/js/src/main/scala/fs2/io/internal/facade/zlib.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/zlib.scala
@@ -83,7 +83,6 @@ package object zlib {
   @nowarn
   private[io] def gunzipSync(buffer: Uint8Array): Uint8Array = js.native
 
-
 }
 
 package zlib {

--- a/io/js/src/main/scala/fs2/io/internal/facade/zlib.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/zlib.scala
@@ -78,6 +78,12 @@ package object zlib {
   @nowarn
   private[io] def inflateSync(buffer: Uint8Array, options: Options): Uint8Array = js.native
 
+  @js.native
+  @JSImport("zlib", "gunzipSync")
+  @nowarn
+  private[io] def gunzipSync(buffer: Uint8Array): Uint8Array = js.native
+
+
 }
 
 package zlib {

--- a/io/js/src/main/scala/fs2/io/internal/facade/zlib.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/zlib.scala
@@ -34,6 +34,11 @@ package object zlib {
   private[io] def createDeflate(options: Options): Zlib = js.native
 
   @js.native
+  @JSImport("zlib", "createDeflateRaw")
+  @nowarn
+  private[io] def createDeflateRaw(options: Options): Zlib = js.native
+
+  @js.native
   @JSImport("zlib", "deflateSync")
   @nowarn
   private[io] def deflateSync(buffer: Uint8Array, options: Options): Uint8Array = js.native
@@ -62,6 +67,11 @@ package object zlib {
   @JSImport("zlib", "createInflate")
   @nowarn
   private[io] def createInflate(options: Options): Zlib = js.native
+
+  @js.native
+  @JSImport("zlib", "createInflateRaw")
+  @nowarn
+  private[io] def createInflateRaw(options: Options): Zlib = js.native
 
   @js.native
   @JSImport("zlib", "inflateSync")

--- a/io/js/src/test/scala/fs2/io/NodeJSCompressionSuite.scala
+++ b/io/js/src/test/scala/fs2/io/NodeJSCompressionSuite.scala
@@ -22,9 +22,14 @@
 package fs2
 package io
 
+import cats.effect._
 import fs2.CompressionSuite
+import fs2.compression._
 import fs2.io.compression._
 import fs2.io.internal.facade
+import org.scalacheck.effect.PropF.forAllF
+
+import java.nio.charset.StandardCharsets
 
 class NodeJSCompressionSuite extends CompressionSuite {
 
@@ -55,6 +60,176 @@ class NodeJSCompressionSuite extends CompressionSuite {
       else
         facade.zlib.inflateSync(in, options)
     Chunk.uint8Array(out).toArray
+  }
+
+  test("gzip |> gunzip ~= id") {
+    forAllF {
+      (
+          s: String,
+          level: DeflateParams.Level,
+          strategy: DeflateParams.Strategy,
+          flushMode: DeflateParams.FlushMode
+      ) =>
+        Stream
+          .chunk(Chunk.array(s.getBytes))
+          .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
+          .through(
+            Compression[IO].gzip(
+              fileName = None,
+              modificationTime = None,
+              comment = None,
+              DeflateParams(
+                bufferSize = 8192,
+                header = ZLibParams.Header.GZIP,
+                level = level,
+                strategy = strategy,
+                flushMode = flushMode
+              )
+            )
+          )
+          .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
+          .through(
+            Compression[IO].gunzip(8192)
+          )
+          .flatMap { gunzipResult =>
+            gunzipResult.content
+          }
+          .compile
+          .toVector
+          .assertEquals(s.getBytes.toVector)
+    }
+  }
+
+  test("gzip |> gunzip ~= id (mutually prime chunk sizes, compression larger)") {
+    forAllF {
+      (
+          s: String,
+          level: DeflateParams.Level,
+          strategy: DeflateParams.Strategy,
+          flushMode: DeflateParams.FlushMode
+      ) =>
+        Stream
+          .chunk(Chunk.array(s.getBytes))
+          .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
+          .through(
+            Compression[IO].gzip(
+              fileName = None,
+              modificationTime = None,
+              comment = None,
+              DeflateParams(
+                bufferSize = 1031,
+                header = ZLibParams.Header.GZIP,
+                level = level,
+                strategy = strategy,
+                flushMode = flushMode
+              )
+            )
+          )
+          .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
+          .through(
+            Compression[IO].gunzip(509)
+          )
+          .flatMap { gunzipResult =>
+            gunzipResult.content
+          }
+          .compile
+          .toVector
+          .assertEquals(s.getBytes.toVector)
+    }
+  }
+
+  test("gzip |> gunzip ~= id (mutually prime chunk sizes, decompression larger)") {
+    forAllF {
+      (
+          s: String,
+          level: DeflateParams.Level,
+          strategy: DeflateParams.Strategy,
+          flushMode: DeflateParams.FlushMode
+      ) =>
+        Stream
+          .chunk(Chunk.array(s.getBytes))
+          .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
+          .through(
+            Compression[IO].gzip(
+              fileName = None,
+              modificationTime = None,
+              comment = None,
+              DeflateParams(
+                bufferSize = 509,
+                header = ZLibParams.Header.GZIP,
+                level = level,
+                strategy = strategy,
+                flushMode = flushMode
+              )
+            )
+          )
+          .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
+          .through(
+            Compression[IO].gunzip(1031)
+          )
+          .flatMap { gunzipResult =>
+            gunzipResult.content
+          }
+          .compile
+          .toVector
+          .assertEquals(s.getBytes.toVector)
+    }
+  }
+
+  test("gzip |> gunzipSync ~= id") {
+    forAllF {
+      (
+          s: String,
+          level: DeflateParams.Level,
+          strategy: DeflateParams.Strategy,
+          flushMode: DeflateParams.FlushMode
+      ) =>
+        Stream
+          .chunk[IO, Byte](Chunk.array(s.getBytes))
+          .rechunkRandomlyWithSeed(0.1, 2)(System.nanoTime())
+          .through(
+            Compression[IO].gzip(
+              fileName = None,
+              modificationTime = None,
+              comment = None,
+              DeflateParams(
+                bufferSize = 1024,
+                header = ZLibParams.Header.GZIP,
+                level = level,
+                strategy = strategy,
+                flushMode = flushMode
+              )
+            )
+          )
+          .compile
+          .to(Array)
+          .map { bytes =>
+            val buffer = Chunk.uint8Array(facade.zlib.gunzipSync(Chunk.array(bytes).toUint8Array))
+
+            assertEquals(buffer.toVector, s.getBytes.toVector)
+          }
+    }
+  }
+
+  test("unix.gzip |> gunzip") {
+    val expectedContent = "fs2.compress implementing RFC 1952\n"
+    val compressed = Array(0x1f, 0x8b, 0x08, 0x08, 0x62, 0xe9, 0x39, 0x5e, 0x00, 0x03, 0x66, 0x73,
+      0x32, 0x2e, 0x63, 0x6f, 0x6d, 0x70, 0x72, 0x65, 0x73, 0x73, 0x00, 0x4b, 0x2b, 0x36, 0xd2,
+      0x4b, 0xce, 0xcf, 0x2d, 0x28, 0x4a, 0x2d, 0x2e, 0x56, 0xc8, 0xcc, 0x2d, 0xc8, 0x49, 0xcd,
+      0x4d, 0xcd, 0x2b, 0xc9, 0xcc, 0x4b, 0x57, 0x08, 0x72, 0x73, 0x56, 0x30, 0xb4, 0x34, 0x35,
+      0xe2, 0x02, 0x00, 0x57, 0xb3, 0x5e, 0x6d, 0x23, 0x00, 0x00, 0x00).map(_.toByte)
+    Stream
+      .chunk(Chunk.array(compressed))
+      .through(
+        Compression[IO].gunzip()
+      )
+      .flatMap { gunzipResult =>
+        gunzipResult.content
+      }
+      .compile
+      .toVector
+      .map(vector => new String(vector.toArray, StandardCharsets.US_ASCII))
+      .assertEquals(expectedContent)
   }
 
 }

--- a/io/js/src/test/scala/fs2/io/NodeJSCompressionSuite.scala
+++ b/io/js/src/test/scala/fs2/io/NodeJSCompressionSuite.scala
@@ -28,7 +28,7 @@ import fs2.io.internal.facade
 
 class NodeJSCompressionSuite extends CompressionSuite {
 
-  override def deflateStream(
+  def deflateStream(
       b: Array[Byte],
       level: Int,
       strategy: Int,
@@ -40,18 +40,18 @@ class NodeJSCompressionSuite extends CompressionSuite {
     options.strategy = strategy
     val out =
       if (nowrap)
-        facade.zlib.gzipSync(in, options)
+        facade.zlib.deflateRawSync(in, options)
       else
         facade.zlib.deflateSync(in, options)
     Chunk.uint8Array(out).toArray
   }
 
-  override def inflateStream(b: Array[Byte], nowrap: Boolean): Array[Byte] = {
+  def inflateStream(b: Array[Byte], nowrap: Boolean): Array[Byte] = {
     val in = Chunk.array(b).toUint8Array
     val options = new facade.zlib.Options {}
     val out =
       if (nowrap)
-        facade.zlib.gunzipSync(in, options)
+        facade.zlib.inflateRawSync(in, options)
       else
         facade.zlib.inflateSync(in, options)
     Chunk.uint8Array(out).toArray

--- a/io/jvm/src/main/scala/fs2/io/compressionplatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/compressionplatform.scala
@@ -26,5 +26,8 @@ import cats.effect.kernel.Sync
 import fs2.compression.Compression
 
 private[io] trait compressionplatform {
+
+  type ZipException = java.util.zip.ZipException
+
   implicit def fs2ioCompressionForSync[F[_]: Sync]: Compression[F] = Compression.forSync
 }

--- a/io/shared/src/main/scala/fs2/io/compression.scala
+++ b/io/shared/src/main/scala/fs2/io/compression.scala
@@ -21,6 +21,4 @@
 
 package fs2.io
 
-object compression extends compressionplatform {
-  type ZipException = java.util.zip.ZipException
-}
+object compression extends compressionplatform


### PR DESCRIPTION
Closes https://github.com/typelevel/fs2/pull/2771, with many apologies to @yurique for their heroic effort on that 🙏 

In https://github.com/typelevel/fs2/pull/2771 we attempted to cross-build the existing Gzip implementation on the JVM. Instead, this PR delegates directly to the Node.js Gzip implementation. This is better for performance and is much simpler to implement. However, we are unable to support the optional headers for filename, comment, and timestamp. Fortunately http4s does not require these in its Gzip middlewares.

There is an unfortunate amount of duplication of tests and scaladocs in this PR.