### PR TITLE
Unify ipv4 and ipv6 header parsing and provide shortcut for parsing udp datagrams from a pcap file

### DIFF
--- a/protocols/shared/src/main/scala/fs2/protocols/ip/IpHeader.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/ip/IpHeader.scala
@@ -1,0 +1,24 @@
+package fs2.protocols
+package ip
+
+import fs2.interop.scodec.StreamDecoder
+import fs2.protocols.ethernet.{EthernetFrameHeader, EtherType}
+
+import com.comcast.ip4s.IpAddress
+
+sealed trait IpHeader {
+  def protocol: Int
+  def sourceIp: IpAddress
+  def destinationIp: IpAddress
+}
+
+object IpHeader {
+  def sdecoder(ethernetHeader: EthernetFrameHeader): StreamDecoder[IpHeader] =
+    ethernetHeader.ethertype match {
+      case Some(EtherType.IPv4) => StreamDecoder.once(Ipv4Header.codec)
+      case Some(EtherType.IPv6) => StreamDecoder.once(Ipv6Header.codec)
+      case _ => StreamDecoder.empty
+    }
+}
+
+private[ip] trait UnsealedIpHeader extends IpHeader

--- a/protocols/shared/src/main/scala/fs2/protocols/ip/IpHeader.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/ip/IpHeader.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package fs2.protocols
 package ip
 
@@ -17,7 +38,7 @@ object IpHeader {
     ethernetHeader.ethertype match {
       case Some(EtherType.IPv4) => StreamDecoder.once(Ipv4Header.codec)
       case Some(EtherType.IPv6) => StreamDecoder.once(Ipv6Header.codec)
-      case _ => StreamDecoder.empty
+      case _                    => StreamDecoder.empty
     }
 }
 

--- a/protocols/shared/src/main/scala/fs2/protocols/ip/Ipv4Header.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/ip/Ipv4Header.scala
@@ -41,7 +41,7 @@ case class Ipv4Header(
     sourceIp: Ipv4Address,
     destinationIp: Ipv4Address,
     options: BitVector
-)
+) extends UnsealedIpHeader
 
 object Ipv4Header {
 

--- a/protocols/shared/src/main/scala/fs2/protocols/ip/Ipv6Header.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/ip/Ipv6Header.scala
@@ -40,7 +40,7 @@ case class Ipv6Header(
     hopLimit: Int,
     sourceIp: Ipv6Address,
     destinationIp: Ipv6Address
-)
+) extends UnsealedIpHeader
 
 object Ipv6Header {
   implicit val codec: Codec[Ipv6Header] = {

--- a/protocols/shared/src/main/scala/fs2/protocols/pcap/CaptureFile.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/pcap/CaptureFile.scala
@@ -87,19 +87,18 @@ object CaptureFile {
   import fs2.protocols.ip.IpHeader
   import fs2.protocols.ip.udp.DatagramHeader
   case class DatagramRecord(
-    ethernet: EthernetFrameHeader,
-    ip: IpHeader,
-    udp: DatagramHeader,
-    payload: Chunk[Byte]
+      ethernet: EthernetFrameHeader,
+      ip: IpHeader,
+      udp: DatagramHeader,
+      payload: Chunk[Byte]
   )
   def udpDatagrams: StreamDecoder[TimeStamped[DatagramRecord]] =
-    CaptureFile.payloadStreamDecoderPF {
-      case LinkType.Ethernet =>
-        for {
-          ethernetHeader <- EthernetFrameHeader.sdecoder
-          ipHeader <- IpHeader.sdecoder(ethernetHeader)
-          udpHeader <- DatagramHeader.sdecoder(ipHeader.protocol)
-          payload <- StreamDecoder.once(scodec.codecs.bytes)
-        } yield DatagramRecord(ethernetHeader, ipHeader, udpHeader, Chunk.byteVector(payload))
+    CaptureFile.payloadStreamDecoderPF { case LinkType.Ethernet =>
+      for {
+        ethernetHeader <- EthernetFrameHeader.sdecoder
+        ipHeader <- IpHeader.sdecoder(ethernetHeader)
+        udpHeader <- DatagramHeader.sdecoder(ipHeader.protocol)
+        payload <- StreamDecoder.once(scodec.codecs.bytes)
+      } yield DatagramRecord(ethernetHeader, ipHeader, udpHeader, Chunk.byteVector(payload))
     }
 }


### PR DESCRIPTION
Realized we should add these when working on udp-replay: https://github.com/mpilquist/udp-replay