### PR TITLE
Specialize every `Chunk`-to-`ByteVector` conversion

### DIFF
--- a/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
@@ -21,6 +21,8 @@
 
 package fs2
 
+import scodec.bits.ByteVector
+
 import scala.collection.immutable.ArraySeq
 import scala.collection.immutable
 import scala.reflect.ClassTag
@@ -113,6 +115,11 @@ private[fs2] trait ChunkCompanionPlatform { self: Chunk.type =>
     override def toIArray[O2 >: O: ClassTag]: IArray[O2] =
       if (offset == 0 && length == values.length) values
       else super.toIArray[O2]
+
+    override def toByteVector[B >: O](implicit ev: B =:= Byte): ByteVector =
+      if (values.isInstanceOf[Array[Byte]])
+        ByteVector.view(values.asInstanceOf[Array[Byte]], offset, length)
+      else ByteVector.viewAt(i => apply(i.toInt), size.toLong)
   }
 
   /** Creates a chunk from a `scala.collection.IterableOnce`. */

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -702,7 +702,7 @@ object Chunk
     override def toByteVector[B >: O](implicit ev: B =:= Byte): ByteVector =
       if (values.isInstanceOf[Array[Byte]])
         ByteVector.view(values.asInstanceOf[Array[Byte]], offset, length)
-      else ByteVector.view(this.asInstanceOf[ArraySlice[Byte]].toArray)
+      else ByteVector.viewAt(i => apply(i.toInt), size.toLong)
 
     protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) =
       ArraySlice(values, offset, n) -> ArraySlice(values, offset + n, length - n)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -700,7 +700,9 @@ object Chunk
       }
 
     override def toByteVector[B >: O](implicit ev: B =:= Byte): ByteVector =
-      ByteVector.view(values.asInstanceOf[Array[Byte]], offset, length)
+      if (values.isInstanceOf[Array[Byte]])
+        ByteVector.view(values.asInstanceOf[Array[Byte]], offset, length)
+      else ByteVector.view(this.asInstanceOf[ArraySlice[Byte]].toArray)
 
     protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) =
       ArraySlice(values, offset, n) -> ArraySlice(values, offset + n, length - n)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -564,7 +564,7 @@ object Chunk
     }
 
     override def toByteVector[B >: O](implicit ev: B =:= Byte): ByteVector =
-      ByteVector.viewAt(idx => apply(idx.toInt), size.toLong)
+      ByteVector.viewAt(idx => s(idx.toInt), s.length.toLong)
 
     override def toVector = s.toVector
 

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -221,6 +221,10 @@ class ChunkSuite extends Fs2Suite {
     Chunk.ArraySlice(Array[Any](0)).asInstanceOf[Chunk[Int]].toArray[Int]
   }
 
+  test("ArraySlice toByteVector") {
+    Chunk.ArraySlice(Array[Any](0.toByte)).asInstanceOf[Chunk[Byte]].toByteVector
+  }
+
   test("ArraySlice does not copy when chunk is already an ArraySlice instance") {
     val chunk: Chunk[Int] = Chunk.ArraySlice(Array(0))
     assert(chunk eq chunk.toArraySlice)


### PR DESCRIPTION
It is now guaranteed to be copy-free.