### PR TITLE
Return client `TLSSocket` only after handshake is complete on Node.js

### DIFF
--- a/io/js/src/main/scala/fs2/io/net/tls/TLSContextPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/tls/TLSContextPlatform.scala
@@ -60,7 +60,7 @@ private[tls] trait TLSContextCompanionPlatform { self: TLSContext.type =>
           ): Resource[F, TLSSocket[F]] = Dispatcher[F]
             .flatMap { dispatcher =>
               if (clientMode) {
-                Resource.eval(F.deferred[Unit]).flatMap { handshook =>
+                Resource.eval(F.deferred[Unit]).flatMap { handshake =>
                   TLSSocket
                     .forAsync(
                       socket,
@@ -72,12 +72,12 @@ private[tls] trait TLSContextCompanionPlatform { self: TLSContext.type =>
                         val tlsSock = facade.tls.connect(options)
                         tlsSock.once(
                           "secureConnect",
-                          () => dispatcher.unsafeRunAndForget(handshook.complete(()))
+                          () => dispatcher.unsafeRunAndForget(handshake.complete(()))
                         )
                         tlsSock
                       }
                     )
-                    .evalTap(_ => handshook.get)
+                    .evalTap(_ => handshake.get)
                 }
               } else {
                 Resource.eval(F.deferred[Either[Throwable, Unit]]).flatMap { verifyError =>

--- a/io/js/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
@@ -84,6 +84,7 @@ private[tls] trait TLSSocketCompanionPlatform { self: TLSSocket.type =>
         readable
       ).race(errorDef.get.flatMap(F.raiseError[SuspendedStream[F, Byte]]).toResource)
         .map(_.merge)
+      _ <- errorDef.tryGet.map(_.toLeft(())).rethrow.toResource
     } yield new AsyncTLSSocket(
       tlsSock,
       readStream,

--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -110,7 +110,7 @@ class TLSSocketSuite extends TLSSuite {
         tlsContext <- Resource.eval(testTlsContext(true))
         addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))
         (serverAddress, server) = addressAndConnections
-        client <- Network[IO]
+        client = Network[IO]
           .client(serverAddress)
           .flatMap(
             tlsContext
@@ -131,9 +131,10 @@ class TLSSocketSuite extends TLSSuite {
             socket.reads.chunks.foreach(socket.write(_))
           }.parJoinUnbounded
 
-          val client =
+          val client = Stream.resource(clientSocket).flatMap { clientSocket =>
             Stream.exec(clientSocket.write(msg)) ++
               clientSocket.reads.take(msg.size.toLong)
+          }
 
           client.concurrently(echoServer)
         }
@@ -149,7 +150,7 @@ class TLSSocketSuite extends TLSSuite {
         tlsContext <- Resource.eval(Network[IO].tlsContext.system)
         addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))
         (serverAddress, server) = addressAndConnections
-        client <- Network[IO]
+        client = Network[IO]
           .client(serverAddress)
           .flatMap(
             tlsContext
@@ -170,9 +171,10 @@ class TLSSocketSuite extends TLSSuite {
             socket.reads.chunks.foreach(socket.write(_))
           }.parJoinUnbounded
 
-          val client =
+          val client = Stream.resource(clientSocket).flatMap { clientSocket =>
             Stream.exec(clientSocket.write(msg)) ++
               clientSocket.reads.take(msg.size.toLong)
+          }
 
           client.concurrently(echoServer)
         }
@@ -189,7 +191,7 @@ class TLSSocketSuite extends TLSSuite {
         clientContext <- Resource.eval(testTlsContext(false))
         addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))
         (serverAddress, server) = addressAndConnections
-        client <- Network[IO]
+        client = Network[IO]
           .client(serverAddress)
           .flatMap(
             clientContext
@@ -217,9 +219,10 @@ class TLSSocketSuite extends TLSSuite {
             socket.reads.chunks.foreach(socket.write(_))
           }.parJoinUnbounded
 
-          val client =
+          val client = Stream.resource(clientSocket).flatMap { clientSocket =>
             Stream.exec(clientSocket.write(msg)) ++
               clientSocket.reads.take(msg.size.toLong)
+          }
 
           client.concurrently(echoServer)
         }
@@ -229,7 +232,7 @@ class TLSSocketSuite extends TLSSuite {
     }
 
     List(TLSv1, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`).foreach { protocol =>
-      test(s"$protocol - applicationProtocol and session".only) {
+      test(s"$protocol - applicationProtocol and session") {
         val msg = Chunk.array(("Hello, world! " * 20000).getBytes)
 
         val setup = for {

--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -31,6 +31,8 @@ import cats.syntax.all._
 
 import com.comcast.ip4s._
 
+import SecureContext.SecureVersion._
+
 class TLSSocketSuite extends TLSSuite {
   val size = 8192
 
@@ -95,7 +97,6 @@ class TLSSocketSuite extends TLSSuite {
             .assertEquals(httpOk)
         }
 
-      import SecureContext.SecureVersion._
       List(TLSv1, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`).foreach { protocol =>
         writesBeforeReading(protocol)
         readsBeforeWriting(protocol)
@@ -227,58 +228,61 @@ class TLSSocketSuite extends TLSSuite {
         .intercept[SSLException]
     }
 
-    test("applicationProtocol and session".only) {
-      val msg = Chunk.array(("Hello, world! " * 20000).getBytes)
+    List(TLSv1, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`).foreach { protocol =>
+      test(s"$protocol - applicationProtocol and session".only) {
+        val msg = Chunk.array(("Hello, world! " * 20000).getBytes)
 
-      val setup = for {
-        tlsContext <- Resource.eval(testTlsContext(true))
-        addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))
-        (serverAddress, server) = addressAndConnections
-        client = Network[IO]
-          .client(serverAddress)
-          .flatMap(
-            tlsContext
-              .clientBuilder(_)
-              .withParameters(
-                TLSParameters(
-                  checkServerIdentity =
-                    Some((sn, _) => Either.cond(sn == "localhost", (), new RuntimeException())),
-                  alpnProtocols = Some(List("h2"))
+        val setup = for {
+          tlsContext <- Resource.eval(testTlsContext(true, Some(protocol)))
+          addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))
+          (serverAddress, server) = addressAndConnections
+          client = Network[IO]
+            .client(serverAddress)
+            .flatMap(
+              tlsContext
+                .clientBuilder(_)
+                .withParameters(
+                  TLSParameters(
+                    checkServerIdentity =
+                      Some((sn, _) => Either.cond(sn == "localhost", (), new RuntimeException())),
+                    alpnProtocols = Some(List("h2"))
+                  )
                 )
-              )
+                .build
+            )
+        } yield server.flatMap(s =>
+          Stream.resource(
+            tlsContext
+              .serverBuilder(s)
+              .withParameters(TLSParameters(alpnProtocols = Some(List("h2"))))
               .build
           )
-      } yield server.flatMap(s =>
-        Stream.resource(
-          tlsContext
-            .serverBuilder(s)
-            .withParameters(TLSParameters(alpnProtocols = Some(List("h2"))))
-            .build
-        )
-      ) -> client
+        ) -> client
 
-      Stream
-        .resource(setup)
-        .flatMap { case (server, clientSocket) =>
-          val echoServer = server
-            .evalTap(s => s.applicationProtocol.assertEquals("h2"))
-            .map { socket =>
-              socket.reads.chunks.foreach(socket.write(_)) ++ Stream.exec(socket.session.void)
+        Stream
+          .resource(setup)
+          .flatMap { case (server, clientSocket) =>
+            val echoServer = server
+              .evalTap(s => s.applicationProtocol.assertEquals("h2"))
+              .map { socket =>
+                socket.reads.chunks.foreach(socket.write(_)) ++ Stream.exec(socket.session.void)
+              }
+              .parJoinUnbounded
+
+            val client = Stream.resource(clientSocket).flatMap { clientSocket =>
+              Stream.exec(clientSocket.applicationProtocol.assertEquals("h2")) ++
+                Stream.exec(clientSocket.session.void) ++
+                Stream.exec(clientSocket.write(msg)) ++
+                clientSocket.reads.take(msg.size.toLong)
             }
-            .parJoinUnbounded
 
-          val client = Stream.resource(clientSocket).flatMap { clientSocket =>
-            Stream.exec(clientSocket.applicationProtocol.assertEquals("h2")) ++
-              Stream.exec(clientSocket.session.void) ++
-              Stream.exec(clientSocket.write(msg)) ++
-              clientSocket.reads.take(msg.size.toLong)
+            client.concurrently(echoServer)
           }
-
-          client.concurrently(echoServer)
-        }
-        .compile
-        .to(Chunk)
-        .assertEquals(msg)
+          .compile
+          .to(Chunk)
+          .assertEquals(msg)
+      }
     }
+
   }
 }

--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -227,7 +227,7 @@ class TLSSocketSuite extends TLSSuite {
         .intercept[SSLException]
     }
 
-    test("applicationProtocol and session".only) {
+    test("applicationProtocol and session") {
       val msg = Chunk.array(("Hello, world! " * 20000).getBytes)
 
       val setup = for {

--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -262,15 +262,14 @@ class TLSSocketSuite extends TLSSuite {
         .flatMap { case (server, clientSocket) =>
           val echoServer = server
             .evalTap(s => s.applicationProtocol.assertEquals("h2"))
-            // .evalTap(s => s.session.void)
             .map { socket =>
-              socket.reads.chunks.foreach(socket.write(_))
+              socket.reads.chunks.foreach(socket.write(_)) ++ Stream.exec(socket.session.void)
             }
             .parJoinUnbounded
 
           val client = Stream.resource(clientSocket).flatMap { clientSocket =>
             Stream.exec(clientSocket.applicationProtocol.assertEquals("h2")) ++
-              // Stream.exec(clientSocket.session.void) ++
+              Stream.exec(clientSocket.session.void) ++
               Stream.exec(clientSocket.write(msg)) ++
               clientSocket.reads.take(msg.size.toLong)
           }

--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSuite.scala
@@ -33,7 +33,10 @@ import scala.scalajs.js
 
 abstract class TLSSuite extends Fs2Suite {
 
-  def testTlsContext(privateKey: Boolean): IO[TLSContext[IO]] = Files[IO]
+  def testTlsContext(
+      privateKey: Boolean,
+      version: Option[SecureContext.SecureVersion] = None
+  ): IO[TLSContext[IO]] = Files[IO]
     .readAll(Path("io/shared/src/test/resources/keystore.json"))
     .through(text.utf8.decode)
     .compile
@@ -42,6 +45,8 @@ abstract class TLSSuite extends Fs2Suite {
     .map { certKey =>
       Network[IO].tlsContext.fromSecureContext(
         SecureContext(
+          minVersion = version,
+          maxVersion = version,
           ca = List(certKey.cert.asRight).some,
           cert = List(certKey.cert.asRight).some,
           key =


### PR DESCRIPTION
This is what I meant to fix before I got distracted by https://github.com/typelevel/fs2/security/advisories/GHSA-2cpx-6pqp-wf35.

The problem came up in the ember h2 client, which needs to know the negotiated application protocol. On the JVM side, writing a `Chunk.empty` to the socket kickstarts the handshaking and blocks (semantically, hopefully) until it completes. So the negotiated application protocol is available in the next operation.

```scala
_ <- Resource.eval(tlsSocket.write(Chunk.empty))
protocol <- Resource.eval(H2TLS.protocol(tlsSocket))
```

https://github.com/http4s/http4s/blob/7fcbd6d58b923a5cae7c66100845c6dd1a857498/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala#L142-L143

Unfortunately this trick does not work for JS. So the `write` was completing before the handshake was negotiated, and attempting to check the `applicationProtocol` in the next step was coming up empty and the connection would fallback to http/1.1.

In Node.js, a `'secureConnect'` event is emitted when handshaking completes and the negotiated application protocol  is available. This PR modifies the client-mode `TLSSocket` upgrade to await this event before returning the socket.

As it turns out, the changes in https://github.com/typelevel/fs2/security/advisories/GHSA-2cpx-6pqp-wf35 actually do the equivalent thing for a server-mode `TLSSocket` by waiting for the `'secure'` event to indicate handshake completion.

While writing a test for this, I also added a test for session access, which is also controlled by an emitted `'session'` event on Node.js.

Tests also needed some minor refactoring so that the client and server connections are established in parallel.