### PR TITLE
Weird interaction between cancelation and interruptWhen

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
+++ b/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
@@ -92,7 +92,7 @@ final private[fs2] case class InterruptContext[F[_]](
           case Right(oc) =>
             oc.embed(F.canceled.as(canceledError)).map(_.leftMap(Outcome.Errored(_)))
           case Left(oc) =>
-            oc.embed(F.pure(Outcome.Canceled[Id, Throwable, Unique.Token]())).map(Left(_))
+            oc.embedNever.map(Left(_))
         }
     }
 }

--- a/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
+++ b/core/shared/src/main/scala/fs2/internal/InterruptContext.scala
@@ -91,7 +91,8 @@ final private[fs2] case class InterruptContext[F[_]](
         F.raceOutcome(deferred.get, fa.attempt).flatMap {
           case Right(oc) =>
             oc.embed(F.canceled.as(canceledError)).map(_.leftMap(Outcome.Errored(_)))
-          case Left(oc) => oc.embedNever.map(Left(_))
+          case Left(oc) =>
+            oc.embed(F.pure(Outcome.Canceled[Id, Throwable, Unique.Token]())).map(Left(_))
         }
     }
 }

--- a/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
@@ -374,6 +374,7 @@ class StreamInterruptSuite extends Fs2Suite {
     IO.race(compileWithSync(s).drain, interrupt).map(_.isRight).assert
   }
 
+  // https://github.com/typelevel/fs2/issues/2963
   test("25 - interaction of interruptWhen and eval(canceled)") {
     SignallingRef[IO, Boolean](false)
       .flatMap { sig =>


### PR DESCRIPTION
Fix  hanging when combining `Stream.eval(F.canceled)` and `interruptWhen`.

I believe that the `.as(canceledError)` is safe as our `fa.attempt` was canceled which means that cancelation is unmasked in this scope and hence `F.canceled.as(canceledError) <-> F.canceled`. This matches the behaviour in `Scope#interruptibleEval` when there is no interrupt context and it binds `fa.attempt` directly.
