### PR TITLE
Short-circuit JS TLS handshake listener if an error event is emitted

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -279,7 +279,8 @@ lazy val io = crossProject(JVMPlatform, JSPlatform)
       ),
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
         "fs2.io.net.tls.SecureContext#SecureVersion#TLSv1.3.toJS"
-      )
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.net.tls.TLSSocket.forAsync")
     )
   )
 

--- a/io/js/src/main/scala/fs2/io/internal/facade/events.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/events.scala
@@ -52,6 +52,8 @@ private[io] trait EventEmitter extends js.Object {
 
   protected[io] def removeAllListeners(): this.type = js.native
 
+  protected[io] def removeAllListeners(eventName: String): this.type = js.native
+
 }
 
 private[io] object EventEmitter {

--- a/io/js/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
@@ -42,56 +42,35 @@ private[tls] trait TLSSocketCompanionPlatform { self: TLSSocket.type =>
 
   private[tls] def forAsync[F[_]](
       socket: Socket[F],
-      upgrade: fs2.io.Duplex => facade.tls.TLSSocket
+      upgrade: fs2.io.Duplex => facade.tls.TLSSocket,
+      dispatcher: Dispatcher[F]
   )(implicit F: Async[F]): Resource[F, TLSSocket[F]] =
     for {
-      dispatcher <- Dispatcher[F]
       duplexOut <- mkDuplex(socket.reads)
       (duplex, out) = duplexOut
       _ <- out.through(socket.writes).compile.drain.background
       sessionRef <- SignallingRef[F].of(Option.empty[SSLSession]).toResource
-      sessionListener = { session =>
-        dispatcher.unsafeRunAndForget(
-          sessionRef.set(Some(new SSLSession(ByteVector.view(session))))
-        )
-      }: js.Function1[js.typedarray.Uint8Array, Unit]
-      errorDef <- F.deferred[Throwable].toResource
-      errorListener = { error =>
-        val ex = js.JavaScriptException(error)
-        dispatcher.unsafeRunAndForget(
-          errorDef.complete(IOException.unapply(ex).getOrElse(ex))
-        )
-      }: js.Function1[js.Error, Unit]
       tlsSockReadable <- suspendReadableAndRead(
         destroyIfNotEnded = false,
         destroyIfCanceled = false
       ) {
         val tlsSock = upgrade(duplex)
-        tlsSock.on("session", sessionListener)
-        tlsSock.on("error", errorListener)
+        tlsSock.on[js.typedarray.Uint8Array](
+          "session",
+          session =>
+            dispatcher.unsafeRunAndForget(
+              sessionRef.set(Some(new SSLSession(ByteVector.view(session))))
+            )
+        )
         tlsSock
       }
-        .flatMap { case tlsSockReadable @ (tlsSock, _) =>
-          Resource.pure(tlsSockReadable).onFinalize {
-            F.delay {
-              tlsSock.removeListener("session", sessionListener)
-              tlsSock.removeListener("error", errorListener)
-            }
-          }
-        }
       (tlsSock, readable) = tlsSockReadable
-      readStream <- SuspendedStream(
-        readable
-      ).race(errorDef.get.flatMap(F.raiseError[SuspendedStream[F, Byte]]).toResource)
-        .map(_.merge)
-      _ <- errorDef.tryGet.map(_.toLeft(())).rethrow.toResource
+      _ <- Resource.unit[F].onFinalize(F.delay(tlsSock.removeAllListeners("session")))
+      readStream <- SuspendedStream(readable)
     } yield new AsyncTLSSocket(
       tlsSock,
       readStream,
-      sessionRef.discrete.unNone.head
-        .concurrently(Stream.eval(errorDef.get.flatMap(F.raiseError[Unit])))
-        .compile
-        .lastOrError,
+      sessionRef.discrete.unNone.head.compile.lastOrError,
       F.delay[Any](tlsSock.alpnProtocol).flatMap {
         case false            => "".pure // mimicking JVM
         case protocol: String => protocol.pure

--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -323,7 +323,7 @@ class TLSSocketSuite extends TLSSuite {
         .assertEquals(msg)
     }
 
-    test("do not hang on SSL connect failure".only) {
+    test("do not hang on SSL connect failure") {
       val msg = Chunk.array(("Hello, world! " * 20000).getBytes)
 
       val setup = for {
@@ -356,7 +356,7 @@ class TLSSocketSuite extends TLSSuite {
         }
         .compile
         .to(Chunk)
-        .assertEquals(msg)
+        .intercept[SSLException]
     }
   }
 }

--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -287,11 +287,47 @@ class TLSSocketSuite extends TLSSuite {
       }
     }
 
-    test("echo insecure client with Endpoint verification") {
+    test("echo insecure client") {
       val msg = Chunk.array(("Hello, world! " * 20000).getBytes)
 
       val setup = for {
         clientContext <- Resource.eval(Network[IO].tlsContext.insecure)
+        tlsContext <- Resource.eval(testTlsContext(true))
+        addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))
+        (serverAddress, server) = addressAndConnections
+        client = Network[IO]
+          .client(serverAddress)
+          .flatMap(s =>
+            clientContext
+              .clientBuilder(s)
+              .build
+          )
+      } yield server.flatMap(s => Stream.resource(tlsContext.server(s))) -> client
+
+      Stream
+        .resource(setup)
+        .flatMap { case (server, clientSocket) =>
+          val echoServer = server.map { socket =>
+            socket.reads.chunks.foreach(socket.write(_))
+          }.parJoinUnbounded
+
+          val client = Stream.resource(clientSocket).flatMap { clientSocket =>
+            Stream.exec(clientSocket.write(msg)) ++
+              clientSocket.reads.take(msg.size.toLong)
+          }
+
+          client.concurrently(echoServer)
+        }
+        .compile
+        .to(Chunk)
+        .assertEquals(msg)
+    }
+
+    test("do not hang on SSL connect failure".only) {
+      val msg = Chunk.array(("Hello, world! " * 20000).getBytes)
+
+      val setup = for {
+        clientContext <- Resource.eval(Network[IO].tlsContext.system)
         tlsContext <- Resource.eval(testTlsContext(true))
         addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))
         (serverAddress, server) = addressAndConnections


### PR DESCRIPTION
This is the bug I discovered while working on https://github.com/typelevel/fs2/pull/2958#issue-1321593368. Skunk also hit it in https://github.com/tpolecat/skunk/pull/696. This was a regression due to https://github.com/typelevel/fs2/pull/2957.

If an error occurred during TLS handshaking on Node.js it was hanging waiting on the `'secure'`/`'secureConnect'` event to indicate the handshake completed. This PR relocates the `'error'` listener such that it will short-circuit the await for a `'secure'`/`'secureConnect'` event if it emits.