### PR TITLE
Align the semantics of spawn with the ones of concurrently

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -553,8 +553,15 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     */
   def concurrently[F2[x] >: F[x], O2](
       that: Stream[F2, O2]
-  )(implicit F: Concurrent[F2]): Stream[F2, O] = {
-    val fstream: F2[Stream[F2, O]] = for {
+  )(implicit F: Concurrent[F2]): Stream[F2, O] =
+    concurrentlyAux(that).flatMap { case (startBack, fore) => startBack >> fore }
+
+  private def concurrentlyAux[F2[x] >: F[x], O2](
+      that: Stream[F2, O2]
+  )(implicit
+      F: Concurrent[F2]
+  ): Stream[F2, (Stream[F2, Fiber[F2, Throwable, Unit]], Stream[F2, O])] = {
+    val fstream: F2[(Stream[F2, Fiber[F2, Throwable, Unit]], Stream[F2, O])] = for {
       interrupt <- F.deferred[Unit]
       backResult <- F.deferred[Either[Throwable, Unit]]
     } yield {
@@ -571,10 +578,10 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       // We use F.fromEither to bring errors from the back into the fore
       val stopBack: F2[Unit] = interrupt.complete(()) >> backResult.get.flatMap(F.fromEither)
 
-      Stream.bracket(compileBack.start)(_ => stopBack) >> watch(this)
+      (Stream.bracket(compileBack.start)(_ => stopBack), watch(this))
     }
 
-    Stream.eval(fstream).flatten
+    Stream.eval(fstream)
   }
 
   /** Prepends a chunk onto the front of this stream.
@@ -2565,10 +2572,15 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     resultPull.stream
   }
 
-  /** Starts this stream and cancels it as finalization of the returned stream.
+  /** Starts this stream in the background and cancels it as finalization of the returned stream.
+    *
+    * Any errors that occur in the background stream results in the foreground stream terminating
+    * with an error.
     */
-  def spawn[F2[x] >: F[x]: Concurrent]: Stream[F2, Fiber[F2, Throwable, Unit]] =
-    Stream.supervise(this.covary[F2].compile.drain)
+  def spawn[F2[x] >: F[x]](implicit F: Concurrent[F2]): Stream[F2, Fiber[F2, Throwable, Unit]] =
+    Stream.emit[F2, Unit](()).concurrentlyAux(this).flatMap { case (startBack, fore) =>
+      startBack.flatTap(_ => fore)
+    }
 
   /** Breaks the input into chunks where the delimiter matches the predicate.
     * The delimiter does not appear in the output. Two adjacent delimiters in the

--- a/core/shared/src/test/scala/fs2/StreamSpawnSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpawnSuite.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import scala.concurrent.duration._
+
+import cats.effect.IO
+import cats.effect.std.Semaphore
+import org.scalacheck.effect.PropF.forAllF
+
+class StreamSpawnSuite extends Fs2Suite {
+
+  implicit class SpawnOps[F[_], A](s: Stream[F, A]) {
+    def spawning[F2[x] >: F[x]](s2: Stream[F, Any])(implicit
+        F: cats.effect.Concurrent[F2]
+    ): Stream[F2, A] =
+      s2.spawn[F2].flatMap(_ => s)
+  }
+
+  test("when background stream terminates, overall stream continues") {
+    forAllF { (s1: Stream[Pure, Int], s2: Stream[Pure, Int]) =>
+      s1.delayBy[IO](25.millis).spawning(s2).assertEmitsSameAs(s1)
+    }
+  }
+
+  test("when background stream fails, overall stream fails") {
+    forAllF { (s: Stream[Pure, Int]) =>
+      s.delayBy[IO](25.millis)
+        .spawning(Stream.raiseError[IO](new Err))
+        .intercept[Err]
+        .void
+    }
+  }
+
+  test("when primary stream fails, overall stream fails and background stream is terminated") {
+    Stream
+      .eval(Semaphore[IO](0))
+      .flatMap { semaphore =>
+        val bg = Stream.repeatEval(IO(1) *> IO.sleep(50.millis)).onFinalize(semaphore.release)
+        val fg = Stream.raiseError[IO](new Err).delayBy(25.millis)
+        fg.spawning(bg).onFinalize(semaphore.acquire)
+      }
+      .intercept[Err]
+  }
+
+  test("when primary stream terminates, background stream is terminated") {
+    forAllF { (s: Stream[Pure, Int]) =>
+      Stream
+        .eval(Semaphore[IO](0))
+        .flatMap { semaphore =>
+          val bg = Stream.repeatEval(IO(1) *> IO.sleep(50.millis)).onFinalize(semaphore.release)
+          val fg = s.delayBy[IO](25.millis)
+          fg.spawning(bg).onFinalize(semaphore.acquire)
+        }
+        .compile
+        .drain
+    }
+  }
+
+  test("when background stream fails, primary stream fails even when hung") {
+    forAllF { (s: Stream[Pure, Int]) =>
+      Stream
+        .eval(IO.deferred[Unit])
+        .flatMap { gate =>
+          Stream(1)
+            .delayBy[IO](25.millis)
+            .append(s)
+            .spawning(Stream.raiseError[IO](new Err))
+            .evalTap(_ => gate.get)
+        }
+        .intercept[Err]
+        .void
+    }
+  }
+
+  test("Cancelling the resulting fiber stops the background stream") {
+    Stream
+      .eval(Semaphore[IO](0))
+      .flatMap { semaphore =>
+        val bg = Stream.repeatEval(IO(1) *> IO.sleep(50.millis)).onFinalize(semaphore.release)
+        bg.spawn.evalMap(fiber => IO.sleep(25.millis) >> fiber.cancel.guarantee(semaphore.acquire))
+      }
+      .compile
+      .drain
+  }
+
+}

--- a/core/shared/src/test/scala/fs2/StreamSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamSuite.scala
@@ -423,6 +423,12 @@ class StreamSuite extends Fs2Suite {
         released <- ref.get
       } yield assert(released)
     }
+
+    test("spawn") {
+      testCancelation {
+        constantStream.spawn
+      }
+    }
   }
 
   group("map") {


### PR DESCRIPTION
Context : https://discord.com/channels/632277896739946517/632310980449402880/1007228488555708476

This changes the implementation of `spawn` in order for the resulting stream to fail when the background stream fails, aligning it with the semantics of `concurrently`. This makes spawn behaviouraly equivalent to `Stream(()).concurrently(self)`, whilst still exposing a handle to the background fiber, allowing for its manual cancelation. 

If changing the existing behaviour of "spawn" is deemed risky, could another name be suggested ? (if the addition is considered valuable by the maintainers, that is) 

