### PR TITLE
Fix Memory Leak bug 2969.

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -1205,8 +1205,10 @@ object Pull extends PullLowPriority {
           )
 
         case fmout: FlatMapOutput[G, z, _] => // y = Unit
-          val fmrunr = new FlatMapR(getCont(), fmout.fun)
-          F.unit >> go(scope, extendedTopLevelScope, translation, fmrunr, fmout.stream)
+          val v = getCont()
+          val runr = buildR[G, z, End]
+          F.unit >> go(scope, extendedTopLevelScope, translation, runr, fmout.stream).attempt
+            .flatMap(_.fold(goErr(_, v), _.apply(new FlatMapR(v, fmout.fun))))
 
         case u: Uncons[G, y] @unchecked =>
           val v = getCont()


### PR DESCRIPTION
https://github.com/typelevel/fs2/issues/2969 uncovered some memory leaks that happen with the use of FlatMap alone. Using the middle buildR seems to fix it, just as it did for `Uncons` and `StepRun`.

_Pending work_: to add a memory leak test that reproduces the leak found in that issue.
