### PR TITLE
Chunk - Introduced an "Interspersed" class.

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1144,6 +1144,19 @@ object Chunk
       chunks.foldLeft(empty[O])(_ :+ _)
   }
 
+  class Interspersed[O](base: Chunk[O], sep: O, isFirst: Boolean) extends Chunk[O] {
+    override val size = (2 * base.size) - (if (isFirst) 1 else 0)
+
+    override def apply(i: Int): O = {
+      val isEven: Boolean = (i & 1) == 0
+      if ((isFirst == isEven))  base(i >> 1) else sep
+    }
+
+    override def copyToArray[O2 >: O](xs: Array[O2], start: Int): Unit = ???
+
+    override protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) = ???    
+  }
+
   def newBuilder[O]: Collector.Builder[O, Chunk[O]] =
     new Collector.Builder[O, Chunk[O]] {
       private[this] var acc = Chunk.empty[O]

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1716,18 +1716,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * This method preserves the Chunking structure of `this` stream.
     */
   def intersperse[O2 >: O](separator: O2): Stream[F, O2] = {
-    def doChunk(hd: Chunk[O], isFirst: Boolean): Chunk[O2] = {
-      val bldr = Vector.newBuilder[O2]
-      bldr.sizeHint(hd.size * 2 + (if (isFirst) 1 else 0))
-      val iter = hd.iterator
-      if (isFirst)
-        bldr += iter.next()
-      iter.foreach { o =>
-        bldr += separator
-        bldr += o
-      }
-      Chunk.vector(bldr.result())
-    }
+    def doChunk(hd: Chunk[O], isFirst: Boolean): Chunk[O2] =
+      new Chunk.Interspersed(hd, separator, isFirst)
+
     def go(str: Stream[F, O]): Pull[F, O2, Unit] =
       str.pull.uncons.flatMap {
         case None           => Pull.done


### PR DESCRIPTION
The current intersperse method would, from a 1024 elements chunk, generate a 2048 elements chunk out of which half are just the separator, which seems a waste of memory. Since "Chunk" is mostly an interface, we can add a bespoke Chunk implementation and thus change memory for CPU.

Note that the needed CPU is just a few bitwise / arithmetic ops.

