### PR TITLE
Use ubuntu-22.04 for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         scala: [3.1.3, 2.12.17, 2.13.8]
         java: [temurin@17]
         project: [rootJS, rootJVM, rootNative]
@@ -123,7 +123,7 @@ jobs:
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/2.5.x')
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         scala: [2.13.8]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ val NewScala = "2.13.8"
 ThisBuild / crossScalaVersions := Seq("3.1.3", "2.12.17", NewScala)
 ThisBuild / tlVersionIntroduced := Map("3" -> "3.0.3")
 
+ThisBuild / githubWorkflowOSes := Seq("ubuntu-22.04")
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 ThisBuild / githubWorkflowBuildPreamble +=
   WorkflowStep.Run(


### PR DESCRIPTION
Gets us out of dependency hell with brew glibc (used by brew s2n-tls) being newer than the glibc ubuntu-20 is using.