### PR TITLE
Aggressively short-circuit `processByteOrderMark` to avoid unnecessary `utf8.decode` buffering

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -171,8 +171,9 @@ object text {
                 if (newBuffer.startsWith(utf8BomSeq)) newBuffer.drop(3)
                 else newBuffer
               doPull(Chunk.empty, Stream.emits(rem.chunks) ++ tl)
-            } else
+            } else if (newBuffer.startsWith(utf8BomSeq.take(newBuffer.size)))
               processByteOrderMark(newBuffer, tl)
+            else doPull(Chunk.empty, Stream.emits(newBuffer.chunks) ++ tl)
           case None =>
             if (buffer ne null)
               doPull(Chunk.empty, Stream.emits(buffer.chunks))

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -153,6 +153,16 @@ class TextSuite extends Fs2Suite {
           assertEquals(Stream.emits(c.toArray[Byte]).through(text.utf8.decode).compile.string, s)
         }
       }
+      test("does not force buffering") {
+        val s1 = Stream(97, 98, 99).map(_.toByte).chunkLimit(1).unchunks
+        assertEquals(s1.through(text.utf8.decode).chunks.compile.count, 3L)
+
+        val s2 = Stream(0xef, 98, 99).map(_.toByte).chunkLimit(1).unchunks
+        assertEquals(s2.through(text.utf8.decode).chunks.compile.count, 2L)
+
+        val s3 = Stream(0xef, 0xbb, 99).map(_.toByte).chunkLimit(1).unchunks
+        assertEquals(s3.through(text.utf8.decode).chunks.compile.count, 1L)
+      }
     }
 
     group("Markus Kuhn UTF-8 stress tests") {

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -149,8 +149,11 @@ class TextSuite extends Fs2Suite {
       }
       property("spanning chunks") {
         forAll(genStringNoBom) { (s: String) =>
-          val c = bom ++ utf8Bytes(s)
-          assertEquals(Stream.emits(c.toArray[Byte]).through(text.utf8.decode).compile.string, s)
+          forAll(Gen.chooseNum(0, s.length + bom.size, 0, 1, 2, 3, 4)) { splitIndex =>
+            val (c1, c2) = (bom ++ utf8Bytes(s)).splitAt(splitIndex)
+            assertEquals(Stream(c1, c2).unchunks.through(text.utf8.decode).compile.string, s)
+          }
+
         }
       }
       test("does not force buffering") {


### PR DESCRIPTION
Fixes the buffering demonstrated in this snippet:
```scala
//> using lib "co.fs2::fs2-core::3.3.0"

import fs2._

@main def main = Stream[Pure, Byte](49, 50, 51, 52).chunkLimit(1).unchunks
  .through(text.utf8.decode).debugChunks().compile.drain
```

```
Chunk(1, 2, 3)
Chunk(4)
```

h/t @mn98 for the report.