### PR TITLE
Make some unsealeds less private

### DIFF
--- a/io/js-jvm/src/main/scala/fs2/io/net/Network.scala
+++ b/io/js-jvm/src/main/scala/fs2/io/net/Network.scala
@@ -59,7 +59,7 @@ sealed trait Network[F[_]]
 }
 
 object Network extends NetworkCompanionPlatform {
-  private[net] trait UnsealedNetwork[F[_]] extends Network[F]
+  private[fs2] trait UnsealedNetwork[F[_]] extends Network[F]
 
   def apply[F[_]](implicit F: Network[F]): F.type = F
 }

--- a/io/native/src/main/scala/fs2/io/net/Network.scala
+++ b/io/native/src/main/scala/fs2/io/net/Network.scala
@@ -30,7 +30,7 @@ sealed trait Network[F[_]] extends NetworkPlatform[F] with SocketGroup[F] {
 }
 
 object Network extends NetworkCompanionPlatform {
-  private[net] trait UnsealedNetwork[F[_]] extends Network[F]
+  private[fs2] trait UnsealedNetwork[F[_]] extends Network[F]
 
   def apply[F[_]](implicit F: Network[F]): F.type = F
 }

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -409,7 +409,7 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
 }
 
 object Files extends FilesCompanionPlatform {
-  private[file] abstract class UnsealedFiles[F[_]](implicit F: Async[F]) extends Files[F] {
+  private[fs2] abstract class UnsealedFiles[F[_]](implicit F: Async[F]) extends Files[F] {
 
     def readAll(path: Path, chunkSize: Int, flags: Flags): Stream[F, Byte] =
       Stream.resource(readCursor(path, flags)).flatMap { cursor =>


### PR DESCRIPTION
This way I can implement `Network` and `Files` in the `fs2.io.uring` package. Future projects may want to implement them in e.g. `fs2.libuv`.