### PR TITLE
Use `default_tls13` for system s2n cipher prefs

### DIFF
--- a/io/native/src/main/scala/fs2/io/net/tls/TLSContextPlatform.scala
+++ b/io/native/src/main/scala/fs2/io/net/tls/TLSContextPlatform.scala
@@ -39,10 +39,14 @@ private[tls] trait TLSContextCompanionPlatform { self: TLSContext.type =>
     /** Creates a `TLSContext` from an `SSLContext`. */
     private[tls] final class AsyncBuilder[F[_]: Async] extends UnsealedBuilder[F] {
       def systemResource: Resource[F, TLSContext[F]] =
-        S2nConfig.builder.build.map(fromS2nConfig(_))
+        S2nConfig.builder.withCipherPreferences("default_tls13").build.map(fromS2nConfig(_))
 
       def insecureResource: Resource[F, TLSContext[F]] =
-        S2nConfig.builder.withDisabledX509Verification.build.map(fromS2nConfig(_))
+        S2nConfig.builder
+          .withCipherPreferences("default_tls13")
+          .withDisabledX509Verification
+          .build
+          .map(fromS2nConfig(_))
 
       def fromS2nConfig(cfg: S2nConfig): TLSContext[F] =
         new UnsealedTLSContext[F] {


### PR DESCRIPTION
Cipher preferences aka "security policies" are described here:
https://github.com/aws/s2n-tls/blob/9b91aca9732e1ee32befee66b8897b6cceb04499/docs/USAGE-GUIDE.md#security-policies

The default "default" does not enable TLS 1.3. However, this was annoying in practice, and also the s2n documentation says that:

> Currently TLS 1.2 is our default version, but we recommend TLS 1.3 where possible. To use TLS 1.3 you need a security policy that supports TLS 1.3.

https://github.com/aws/s2n-tls/blob/9b91aca9732e1ee32befee66b8897b6cceb04499/docs/USAGE-GUIDE.md#supported-tls-versions

So this PR now sets the "default_tls13" cipher preference for the default system and insecure `TLSContext`s. The `S2nConfig` builder itself does not set any preference.