### PR TITLE
Use CharsetEncoder for encoding texts

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/TextBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/TextBenchmark.scala
@@ -36,7 +36,7 @@ class TextBenchmark {
   var asciiBytes: Array[Byte] = _
   var strings: Array[String] = _
 
-  @Param(Array("utf-8", "iso-2022-kr"))
+  @Param(Array("utf-8", "utf-16", "iso-2022-kr"))
   var charsetName: String = _
   var charset: Charset = _
 

--- a/benchmark/src/main/scala/fs2/benchmark/TextBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/TextBenchmark.scala
@@ -46,7 +46,9 @@ class TextBenchmark {
     asciiBytes = (0 until asciiStringSize).map { _ =>
       (rng.nextInt(126) + 1).toByte
     }.toArray
-    strings = new String(asciiBytes).grouped(16).toArray // chunk it up to be more real-world
+    strings = new String(asciiBytes)
+      .grouped(asciiStringSize / 16) // chunk it up to be more real-world
+      .toArray
     charset = Charset.forName(charsetName)
   }
 

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -331,7 +331,7 @@ object text {
         val out = ByteBuffer.allocate(outBufferSize)
 
         val inBuffer = toEncode.toCharBuffer
-        val result = encoder.encode(inBuffer, out, isLast)
+        encoder.encode(inBuffer, out, isLast)
         (out: Buffer).flip()
 
         val nextAcc =

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -343,15 +343,11 @@ object text {
         }
 
         if (out.remaining() > 0) {
-          Pull.output1(Chunk.byteBuffer(out)) >> encodeC(encoder, nextAcc, rest)
+          Pull.output1(Chunk.ByteBuffer.view(out)) >> encodeC(encoder, nextAcc, rest)
         } else if (!isLast) {
           encodeC(encoder, nextAcc, rest)
         } else if (nextAcc.nonEmpty) {
-          encodeC(
-            encoder,
-            nextAcc,
-            rest
-          )
+          encodeC(encoder, nextAcc, rest)
         } else flush(encoder, ByteBuffer.allocate(0))
       }
 
@@ -365,7 +361,7 @@ object text {
         case res if res.isUnderflow =>
           if (out.position() > 0) {
             (out: Buffer).flip()
-            Pull.output1(Chunk.byteBuffer(out)) >> Pull.done
+            Pull.output1(Chunk.ByteBuffer.view(out)) >> Pull.done
           } else
             Pull.done
         case res if res.isOverflow =>

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -493,5 +493,12 @@ class TextSuite extends Fs2Suite {
         assertEquals(s, Right("\u0940"))
       }
     }
+
+    test("doesn't produce BOMs in the middle of strings") {
+      // protect against regressions of #3006 that come from encoding each element in the stream individually,
+      // leading to BOMs wherever an input string begins
+      val s = Stream("1", "2", "3").through(encode(StandardCharsets.UTF_16)).compile.toList
+      assertEquals(s, List(-2, -1, 0, 49, 0, 50, 0, 51).map(_.toByte))
+    }
   }
 }

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -502,7 +502,7 @@ class TextSuite extends Fs2Suite {
     }
 
     test("replaces unmappable characters") {
-      val s = Stream("à").through(encode(Charset.forName("iso-2022-kr"))).compile.toList
+      val s = Stream("à").through(encode(Charset.forName("ascii"))).compile.toList
       assertEquals(s, List(63).map(_.toByte)) // 63 = ? (the usual replacement character)
     }
   }

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -500,5 +500,10 @@ class TextSuite extends Fs2Suite {
       val s = Stream("1", "2", "3").through(encode(StandardCharsets.UTF_16)).compile.toList
       assertEquals(s, List(-2, -1, 0, 49, 0, 50, 0, 51).map(_.toByte))
     }
+
+    test("replaces unmappable characters") {
+      val s = Stream("à").through(encode(Charset.forName("iso-2022-kr"))).compile.toList
+      assertEquals(s, List(63).map(_.toByte)) // 63 = ? (the usual replacement character)
+    }
   }
 }

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -36,11 +36,12 @@ class TextSuite extends Fs2Suite {
   override def scalaCheckTestParameters =
     super.scalaCheckTestParameters.withMinSuccessfulTests(1000)
 
+  def genStringNoBom: Gen[String] =
+    Arbitrary.arbitrary[String].filterNot(s => s.startsWith("\ufeff") || s.startsWith("\ufffe"))
+
   group("utf8.decoder") {
     def utf8Bytes(s: String): Chunk[Byte] = Chunk.array(s.getBytes("UTF-8"))
     def utf8String(bs: Chunk[Byte]): String = new String(bs.toArray, "UTF-8")
-
-    def genStringNoBom: Gen[String] = Arbitrary.arbitrary[String].filterNot(_.startsWith("\ufeff"))
 
     def checkChar(c: Char): Unit =
       if (c != '\ufeff')
@@ -493,17 +494,72 @@ class TextSuite extends Fs2Suite {
         assertEquals(s, Right("\u0940"))
       }
     }
-
+  }
+  group("encode") {
     test("doesn't produce BOMs in the middle of strings") {
       // protect against regressions of #3006 that come from encoding each element in the stream individually,
       // leading to BOMs wherever an input string begins
-      val s = Stream("1", "2", "3").through(encode(StandardCharsets.UTF_16)).compile.toList
-      assertEquals(s, List(-2, -1, 0, 49, 0, 50, 0, 51).map(_.toByte))
+      val s = Stream("1", "2", "3")
+      val expected = Map(
+        StandardCharsets.UTF_8 -> List(49, 50, 51),
+        StandardCharsets.UTF_16 -> List(-2, -1, 0, 49, 0, 50, 0, 51),
+        StandardCharsets.UTF_16BE -> List(0, 49, 0, 50, 0, 51),
+        StandardCharsets.UTF_16LE -> List(49, 0, 50, 0, 51, 0)
+      ) ++ (if (isJVM)
+              Map(
+                Charset.forName("UTF-32") -> List(0, 0, 0, 49, 0, 0, 0, 50, 0, 0, 0, 51),
+                Charset.forName("UTF-32BE") -> List(0, 0, 0, 49, 0, 0, 0, 50, 0, 0, 0, 51),
+                Charset.forName("UTF-32LE") -> List(49, 0, 0, 0, 50, 0, 0, 0, 51, 0, 0, 0)
+              )
+            else Map.empty)
+      expected.foreach { case (charset, exp) =>
+        assertEquals(
+          s.through(encode(charset)).compile.toList,
+          exp.map(_.toByte),
+          s"failed BOM test for $charset"
+        )
+      }
     }
 
     test("replaces unmappable characters") {
       val s = Stream("à").through(encode(Charset.forName("ascii"))).compile.toList
       assertEquals(s, List(63).map(_.toByte)) // 63 = ? (the usual replacement character)
+    }
+
+    property("encode andThen decode = id for all unicode charsets") {
+      forAll(genStringNoBom) { (s: String) =>
+        if (s.nonEmpty) {
+          val charsets = List(
+            StandardCharsets.UTF_16LE,
+            StandardCharsets.UTF_16BE,
+            StandardCharsets.UTF_8,
+            StandardCharsets.UTF_16
+          ) ++ (if (isJVM)
+                  List(
+                    Charset.forName("UTF-32"),
+                    Charset.forName("UTF-32BE"),
+                    Charset.forName("UTF-32LE")
+                  )
+                else Nil)
+
+          charsets.foreach { charset =>
+            assertEquals(
+              Stream[Fallible, String](s)
+                .through(encodeC(charset))
+                .through(decodeCWithCharset(charset))
+                .toList,
+              Right(List(s))
+            )
+            assertEquals(
+              Stream[Fallible, String](s)
+                .through(encode(charset))
+                .through(decodeWithCharset(charset))
+                .toList,
+              Right(List(s))
+            )
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Avoids problems like multiple BOMs when encoding with a charset that adds them (UTF-16).

Opening as a draft as there's a problem with backwards compatibility, see inline comments.

Closes #3006
