### PR TITLE
Fix StackOverflow bug 3011.

### DIFF
--- a/core/shared/src/test/scala/fs2/StreamSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamSuite.scala
@@ -149,9 +149,23 @@ class StreamSuite extends Fs2Suite {
         Stream.evals(SyncIO(Option(42))).compile.lastOrError.assertEquals(42)
     }
 
-    property("flatMap") {
-      forAll { (s: Stream[Pure, Stream[Pure, Int]]) =>
-        assertEquals(s.flatMap(inner => inner).toList, s.toList.flatMap(inner => inner.toList))
+    group("flatMap") {
+
+      property("list homomorphism") {
+        forAll { (s: Stream[Pure, Stream[Pure, Int]]) =>
+          assertEquals(s.flatMap(i => i).toList, s.toList.flatMap(_.toList))
+        }
+      }
+
+      test("Stack safety - Regression #3011") {
+        // https://github.com/typelevel/fs2/issues/3011
+        val res = fs2.Stream
+          .emits(List.fill(100000)(()))
+          .flatMap(_ => fs2.Stream.empty)
+          .compile
+          .toList
+
+        assertEquals(res, Nil)
       }
     }
 
@@ -1020,4 +1034,5 @@ class StreamSuite extends Fs2Suite {
       }
     }
   }
+
 }


### PR DESCRIPTION
Fixes #3011 

Issue 3011 https://github.com/typelevel/fs2/issues/3011 showed an existing StackOverflow loop, caused by the short-cut optimisation of `transformWith` together with the recursion. This only happened when the stream included a `FlatMapOutput` such that 
- The chunk is too large, since the size of the stack is proportional to the number of elements in the chunk. 
- The "seeding" function was immediately returning an empty stream, that is, a `Succeeded(())`. 

The solution is to add an internal whirl-loop, which optimises this cyclic path away in tail-recursive way. We also add the reported case as a unit test.

