### PR TITLE
`Stream#uncons` update Scala doc

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4234,7 +4234,7 @@ object Stream extends StreamLowPriority {
   ) extends AnyVal {
 
     /** Waits for a chunk of elements to be available in the source stream.
-      * The ''non-empty''' chunk of elements along with a new stream are provided as the resource of the returned pull.
+      * The '''non-empty''' chunk of elements along with a new stream are provided as the resource of the returned pull.
       * The new stream can be used for subsequent operations, like awaiting again.
       * A `None` is returned as the resource of the pull upon reaching the end of the stream.
       */


### PR DESCRIPTION
The number of quotes does not match, therefore the section is not rendered as intended.

That is how it looks right now:
<img width="626" alt="image" src="https://user-images.githubusercontent.com/6395483/197411563-7a3a3e62-ed22-4051-9009-52cc1e3d29df.png">
