### PR TITLE
Use `bounded` rather than `synchronous` in `parJoin`

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4055,7 +4055,7 @@ object Stream extends StreamLowPriority {
           // starts with 1 because outer stream is running by default
           running <- SignallingRef(1)
           outcomes <- Channel.unbounded[F, F[Unit]]
-          output <- Channel.synchronous[F, Chunk[O]]
+          output <- Channel.bounded[F, Chunk[O]](maxOpen)
         } yield {
           def stop(rslt: Option[Throwable]): F[Unit] =
             done.update {
@@ -4167,7 +4167,7 @@ object Stream extends StreamLowPriority {
                 signalResult(fiber)
             }
             .flatMap { _ =>
-              output.stream.flatMap(Stream.chunk)
+              output.stream.unchunks
             }
         }
 


### PR DESCRIPTION
Copy/pasting some of my explanation from [this Discord discussion](https://discord.com/channels/632277896739946517/839257183782436945/1034125609678405733):

The problem with `synchronous` is it basically eliminates parallel execution once you fill to `maxOpen`. As a reminder, even with `synchronous`, you will still have `maxOpen` chunks in memory since the streams have all run at least one step, it's just that these chunks are in memory *in the `flatMap` on the `Deferred`*, rather than directly in the `Channel`.  But the parallel execution thing is what I'm thinking right now. Imagine the downstream runs strictly slower than the upstreams. You will have the following stages in order:

1. Nothing has happened yet
2. Upstreams start running in parallel (parallelism factor = `maxOpen`)
3. Upstreams all produce their first chunk and block
4. Downstream consumes a single chunk
5. One upstream begins executing on its second chunk
6. Downstream consumes a second chunk
7. One other upstream begins executing on its second chunk
8. etc etc…

In other words, due to `synchronous`, `parJoin` is not actually parallel in a lot of cases! It is parallel *resource consumption*, but it is not parallel *execution*.

`bounded` fixes this because it allows downstream to consume up to `maxOpen` chunks at once, which in turn unblocks up to `maxOpen` of the upstreams. With `bounded(maxOpen)`, you get a sequence which looks more like the following:

1. Nothing has happened yet
2. Upstreams start running in parallel (parallelism factor = `maxOpen`)
3. Upstreams all produce their first chunk and proceed to their second ones
4. Downstream consumes up to `maxOpen` chunks
5. More upstreams produce chunks, maybe getting blocked because they're running too fast, maybe not

Maximum parallelism factor is `maxOpen + 1` (all upstreams + the downstream). Maximum memory footprint is `maxOpen * 2`. At steady-state, if all are proceeding at the same rate, the parallelism will equal the maximum parallelism. If the downstream is slower than the upstreams, then the parallelism will converge to `maxOpen` (whereas in the `synchronous` implementation, when the downstream is slow the parallelism converges to `1`).