### PR TITLE
Prefer `js.BigInt` fs APIs on Node.js

### DIFF
--- a/io/js/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -52,7 +52,8 @@ private[file] trait FileHandleCompanionPlatform {
         }
 
       override def size: F[Long] =
-        F.fromPromise(F.delay(fd.stat())).map(_.size.toLong)
+        F.fromPromise(F.delay(fd.stat(new facade.fs.StatOptions { bigint = true })))
+          .map(_.size.toString.toLong)
 
       override def truncate(size: Long): F[Unit] =
         F.fromPromise(F.delay(fd.truncate(size.toDouble)))

--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -324,13 +324,6 @@ private[fs2] trait FilesCompanionPlatform {
     override def readAll(path: Path, chunkSize: Int, flags: Flags): Stream[F, Byte] =
       readStream(path, chunkSize, flags)(identity)
 
-    override def readRange(path: Path, chunkSize: Int, start: Long, end: Long): Stream[F, Byte] =
-      readStream(path, chunkSize, Flags.Read) { options =>
-        options.start = start.toDouble
-        options.end = (end - 1).toDouble
-        options
-      }
-
     def realPath(path: Path): F[Path] =
       F.fromPromise(F.delay(facade.fs.promises.realpath(path.toString))).map(Path(_)).adaptError {
         case NoSuchFileException(e) => e

--- a/io/js/src/main/scala/fs2/io/internal/facade/fs.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/fs.scala
@@ -114,7 +114,7 @@ package fs {
 
     def lchmod(path: String, mode: Double): js.Promise[Unit] = js.native
 
-    def lstat(path: String): js.Promise[Stats] = js.native
+    def lstat(path: String, options: StatOptions): js.Promise[BigIntStats] = js.native
 
     def mkdir(path: String, options: MkdirOptions): js.Promise[js.UndefOr[String]] = js.native
 
@@ -133,7 +133,7 @@ package fs {
 
     def rmdir(path: String): js.Promise[Unit] = js.native
 
-    def stat(path: String): js.Promise[Stats] = js.native
+    def stat(path: String, options: StatOptions): js.Promise[BigIntStats] = js.native
 
     def symlink(target: String, path: String): js.Promise[Unit] = js.native
 
@@ -157,6 +157,12 @@ package fs {
 
   }
 
+  private[io] trait StatOptions extends js.Object {
+
+    var bigint: js.UndefOr[Boolean] = js.undefined
+
+  }
+
   @js.native
   private[io] trait Dir extends js.Object {
 
@@ -174,21 +180,27 @@ package fs {
   }
 
   @js.native
-  private[io] trait Stats extends js.Object {
+  private[io] trait BigIntStats extends js.Object {
 
-    def dev: Double = js.native
+    def dev: js.BigInt = js.native
 
-    def ino: Double = js.native
+    def ino: js.BigInt = js.native
 
-    def mode: Double = js.native
+    def mode: js.BigInt = js.native
 
-    def size: Double = js.native
+    def size: js.BigInt = js.native
 
-    def atimeMs: Double = js.native
+    def atimeMs: js.BigInt = js.native
 
-    def ctimeMs: Double = js.native
+    def ctimeMs: js.BigInt = js.native
 
-    def mtimeMs: Double = js.native
+    def mtimeMs: js.BigInt = js.native
+
+    def atimeNs: js.BigInt = js.native
+
+    def ctimeNs: js.BigInt = js.native
+
+    def mtimeNs: js.BigInt = js.native
 
     def isFile(): Boolean = js.native
 
@@ -217,7 +229,7 @@ package fs {
         position: js.BigInt
     ): js.Promise[FileHandleWriteResult] = js.native
 
-    def stat(): js.Promise[Stats] = js.native
+    def stat(options: StatOptions): js.Promise[BigIntStats] = js.native
 
     def truncate(len: Double): js.Promise[Unit] = js.native
 

--- a/io/js/src/main/scala/fs2/io/internal/facade/fs.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/fs.scala
@@ -207,14 +207,14 @@ package fs {
         buffer: Uint8Array,
         offset: Int,
         length: Int,
-        position: Double
+        position: js.BigInt
     ): js.Promise[FileHandleReadResult] = js.native
 
     def write(
         buffer: Uint8Array,
         offset: Int,
         length: Int,
-        position: Double
+        position: js.BigInt
     ): js.Promise[FileHandleWriteResult] = js.native
 
     def stat(): js.Promise[Stats] = js.native

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -79,6 +79,15 @@ class FilesSuite extends Fs2IoSuite with BaseFileSuite {
         .foldMonoid
         .assertEquals(4)
     }
+    test("can handle Long range endpoints") {
+      Stream
+        .resource(tempFile.evalMap(modify))
+        .flatMap(path => Files[IO].readRange(path, 4096, 0, Long.MaxValue))
+        .map(_ => 1)
+        .compile
+        .foldMonoid
+        .assertEquals(4)
+    }
   }
 
   group("writeAll") {


### PR DESCRIPTION
Fixes https://github.com/typelevel/fs2/issues/2921.

Unfortunately not all Node.js APIs support `js.BigInt`, but where they do it offers better compatibility with the `Long`-based APIs exposed in FS2.