### PR TITLE
Add `Stream#{hold1,hold1Resource}`

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1540,6 +1540,13 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   def holdOption[F2[x] >: F[x]: Concurrent, O2 >: O]: Stream[F2, Signal[F2, Option[O2]]] =
     map(Some(_): Option[O2]).hold(None)
 
+  /** Like [[hold]] but does not require an initial value. The signal is not emitted until the initial value is emitted from this stream */
+  def hold1[F2[x] >: F[x]: Concurrent, O2 >: O]: Stream[F2, Signal[F2, O2]] =
+    this.pull.uncons1.flatMap {
+      case Some((o, tail)) => tail.hold(o).underlying
+      case None            => Pull.done
+    }.streamNoScope
+
   /** Like [[hold]] but returns a `Resource` rather than a single element stream.
     */
   def holdResource[F2[x] >: F[x]: Concurrent, O2 >: O](
@@ -1551,6 +1558,10 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       .compile
       .resource
       .lastOrError
+
+  /** Like [[hold1]] but returns a `Resource` rather than a single element stream. */
+  def hold1Resource[F2[x] >: F[x]: Concurrent, O2 >: O]: Resource[F2, Signal[F2, O2]] =
+    hold1.compile.resource.lastOrError
 
   /**  Like [[holdResource]] but does not require an initial value,
     *  and hence all output elements are wrapped in `Some`.

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1543,7 +1543,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   /** Like [[hold]] but does not require an initial value. The signal is not emitted until the initial value is emitted from this stream */
   def hold1[F2[x] >: F[x]: Concurrent, O2 >: O]: Stream[F2, Signal[F2, O2]] =
     this.pull.uncons1.flatMap {
-      case Some((o, tail)) => tail.hold(o).underlying
+      case Some((o, tail)) => tail.hold[F2, O2](o).underlying
       case None            => Pull.done
     }.streamNoScope
 
@@ -1561,7 +1561,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
 
   /** Like [[hold1]] but returns a `Resource` rather than a single element stream. */
   def hold1Resource[F2[x] >: F[x]: Concurrent, O2 >: O]: Resource[F2, Signal[F2, O2]] =
-    hold1.compile.resource.lastOrError
+    hold1[F2, O2].compile.resource.lastOrError
 
   /**  Like [[holdResource]] but does not require an initial value,
     *  and hence all output elements are wrapped in `Some`.


### PR DESCRIPTION
existing:
- `hold` takes an initial value for the signal
- `holdOption` uses `None` as the initial value for the signal

this PR:
- `hold1` blocks until the stream emits its first value, then emits a signal with that initial value

Name (and API) subject to bikeshed of course.