### PR TITLE
Minor refactor to `SignallingRef#discrete`

### DIFF
--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -240,10 +240,9 @@ object SignallingRef {
             def cleanup(id: Long): F[Unit] =
               state.update(s => s.copy(listeners = s.listeners - id))
 
-            Stream.bracket(newId)(cleanup).flatMap { id =>
-              Stream.eval(state.get).flatMap { state =>
-                Stream.emit(state.value) ++ go(id, state.lastUpdate)
-              }
+            Stream.eval(state.get).flatMap { state =>
+              Stream.emit(state.value) ++
+                Stream.bracket(newId)(cleanup).flatMap(go(_, state.lastUpdate))
             }
           }
 


### PR DESCRIPTION
So that the first element (i.e. the current state of the `Signal`) may be emitted before bracketing.