### PR TITLE
Bump base version to 3.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.tools.mima.core._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion := "3.3"
+ThisBuild / tlBaseVersion := "3.4"
 
 ThisBuild / organization := "co.fs2"
 ThisBuild / organizationName := "Functional Streams for Scala"


### PR DESCRIPTION
I could have sworn I did this in https://github.com/typelevel/fs2/pull/3000, but I guess I forgot. A minor bump for the Scala 3.2.0 bump.