### PR TITLE
Copy socket reads into `Array`-backed chunks

### DIFF
--- a/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -70,11 +70,10 @@ private[net] trait SocketCompanionPlatform {
         val result =
           if (read == 0) Chunk.empty
           else {
-            val dest = ByteBuffer.allocateDirect(read)
+            val dest = new Array[Byte](read)
             (buffer: Buffer).flip()
-            dest.put(buffer)
-            (dest: Buffer).flip()
-            Chunk.byteBuffer(dest)
+            buffer.get(dest)
+            Chunk.array(dest)
           }
         (buffer: Buffer).clear()
         result


### PR DESCRIPTION
Instead of `ByteBuffer.allocateDirect`-backed chunks. The JDK says this about direct byte buffers.

> The buffers returned by this method typically have somewhat higher allocation and deallocation costs than non-direct buffers. The contents of direct buffers may reside outside of the normal garbage-collected heap, and so their impact upon the memory footprint of an application might not be obvious. It is therefore recommended that direct buffers be allocated primarily for large, long-lived buffers that are subject to the underlying system's native I/O operations. In general it is best to allocate direct buffers only when they yield a measurable gain in program performance.

https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/ByteBuffer.html

I wouldn't say that the average chunk is "long-lived". And except for an echo server or something, it is unlikely to be used in a native I/O operation.

For the record, Ember likes to use said chunks like this 😅 
https://github.com/http4s/http4s/blob/db8fcaf241f86fcf90ee600e33ee849a8a94efd8/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala#L634-L639