### PR TITLE
Disable embedded resources on Native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -311,9 +311,6 @@ lazy val io = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.net.tls.TLSSocket.forAsync")
     )
   )
-  .nativeSettings(
-    nativeConfig ~= { _.withEmbedResources(true) }
-  )
 
 lazy val scodec = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("scodec"))

--- a/io/native/src/test/scala/fs2/io/net/tls/TLSSuite.scala
+++ b/io/native/src/test/scala/fs2/io/net/tls/TLSSuite.scala
@@ -26,15 +26,17 @@ package tls
 
 import cats.effect.IO
 import cats.effect.kernel.Resource
+import fs2.io.file.Files
+import fs2.io.file.Path
 import scodec.bits.ByteVector
 
 abstract class TLSSuite extends Fs2IoSuite {
   def testTlsContext: Resource[IO, TLSContext[IO]] = for {
     cert <- Resource.eval {
-      readClassResource[IO, TLSSuite]("/cert.pem").compile.to(ByteVector)
+      Files[IO].readAll(Path("io/shared/src/test/resources/cert.pem")).compile.to(ByteVector)
     }
     key <- Resource.eval {
-      readClassResource[IO, TLSSuite]("/key.pem").compile.to(ByteVector)
+      Files[IO].readAll(Path("io/shared/src/test/resources/key.pem")).compile.to(ByteVector)
     }
     cfg <- S2nConfig.builder
       .withCertChainAndKeysToStore(List(CertChainAndKey(cert, key)))
@@ -44,7 +46,7 @@ abstract class TLSSuite extends Fs2IoSuite {
 
   def testClientTlsContext: Resource[IO, TLSContext[IO]] = for {
     cert <- Resource.eval {
-      readClassResource[IO, TLSSuite]("/cert.pem").compile.to(ByteVector)
+      Files[IO].readAll(Path("io/shared/src/test/resources/cert.pem")).compile.to(ByteVector)
     }
     cfg <- S2nConfig.builder
       .withPemsToTrustStore(List(cert.decodeAscii.toOption.get))


### PR DESCRIPTION
I suspect this is what has been causing the CI flakes. So disabling should confirm it, and also save us the headache until this is fixed upstream.