### PR TITLE
Fix Node.js `readRange` bug

### DIFF
--- a/io/js/src/main/scala/fs2/io/internal/facade/fs.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/fs.scala
@@ -46,6 +46,28 @@ package object fs {
   private[io] def createWriteStream(path: String, options: WriteStreamOptions): fs2.io.Writable =
     js.native
 
+  @js.native
+  @JSImport("fs", "read")
+  private[io] def read(
+      fd: Int,
+      buffer: Uint8Array,
+      offset: Int,
+      length: Int,
+      position: js.BigInt,
+      cb: js.Function3[js.Error, Int, Uint8Array, Unit]
+  ): Unit = js.native
+
+  @js.native
+  @JSImport("fs", "write")
+  private[io] def write(
+      fd: Int,
+      buffer: Uint8Array,
+      offset: Int,
+      length: Int,
+      position: js.BigInt,
+      cb: js.Function3[js.Error, Int, Uint8Array, Unit]
+  ): Unit = js.native
+
 }
 
 package fs {
@@ -213,21 +235,9 @@ package fs {
   @js.native
   private[io] trait FileHandle extends js.Object {
 
+    def fd: Int = js.native
+
     def datasync(): js.Promise[Unit] = js.native
-
-    def read(
-        buffer: Uint8Array,
-        offset: Int,
-        length: Int,
-        position: js.BigInt
-    ): js.Promise[FileHandleReadResult] = js.native
-
-    def write(
-        buffer: Uint8Array,
-        offset: Int,
-        length: Int,
-        position: js.BigInt
-    ): js.Promise[FileHandleWriteResult] = js.native
 
     def stat(options: StatOptions): js.Promise[BigIntStats] = js.native
 

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -64,11 +64,10 @@ class FilesSuite extends Fs2IoSuite with BaseFileSuite {
     test("reads half of a file") {
       Stream
         .resource(tempFile.evalMap(modify))
-        .flatMap(path => Files[IO].readRange(path, 4096, 0, 2))
-        .map(_ => 1)
+        .flatMap(path => Files[IO].readRange(path, 4096, 2, 4))
         .compile
-        .foldMonoid
-        .assertEquals(2)
+        .toList
+        .assertEquals(List[Byte](2, 3))
     }
     test("reads full file if end is bigger than file size") {
       Stream


### PR DESCRIPTION
Fixes a regression from https://github.com/typelevel/fs2/pull/3036.

Turns out I was calling the wrong function and it was silently ignoring the `js.BigInt` parameter. Sadly the correct function is much less ergonomic to use. Node.js APIs are the worst 😕 