### PR TITLE
Cross `hash` for JS and Native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install brew formulae (ubuntu)
         if: (matrix.project == 'rootNative') && startsWith(matrix.os, 'ubuntu')
-        run: /home/linuxbrew/.linuxbrew/bin/brew install s2n
+        run: /home/linuxbrew/.linuxbrew/bin/brew install openssl s2n
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck

--- a/build.sbt
+++ b/build.sbt
@@ -236,8 +236,12 @@ lazy val coreJS = core.js
   )
 
 lazy val coreNative = core.native
+  .enablePlugins(ScalaNativeBrewedConfigPlugin)
   .disablePlugins(DoctestPlugin)
   .settings(commonNativeSettings)
+  .settings(
+    Test / nativeBrewFormulas += "openssl"
+  )
 
 lazy val io = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("io"))

--- a/core/js/src/main/scala/fs2/hash.scala
+++ b/core/js/src/main/scala/fs2/hash.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.typedarray.Uint8Array
+
+/** Provides various cryptographic hashes as pipes. Supported only on Node.js. */
+object hash {
+
+  /** Computes an MD2 digest. */
+  def md2[F[_]]: Pipe[F, Byte, Byte] = digest(createHash("md2"))
+
+  /** Computes an MD5 digest. */
+  def md5[F[_]]: Pipe[F, Byte, Byte] = digest(createHash("md5"))
+
+  /** Computes a SHA-1 digest. */
+  def sha1[F[_]]: Pipe[F, Byte, Byte] =
+    digest(createHash("sha1"))
+
+  /** Computes a SHA-256 digest. */
+  def sha256[F[_]]: Pipe[F, Byte, Byte] =
+    digest(createHash("sha256"))
+
+  /** Computes a SHA-384 digest. */
+  def sha384[F[_]]: Pipe[F, Byte, Byte] =
+    digest(createHash("sha384"))
+
+  /** Computes a SHA-512 digest. */
+  def sha512[F[_]]: Pipe[F, Byte, Byte] =
+    digest(createHash("sha512"))
+
+  /** Computes the digest of the source stream, emitting the digest as a chunk
+    * after completion of the source stream.
+    */
+  private[this] def digest[F[_]](hash: => Hash): Pipe[F, Byte, Byte] =
+    in =>
+      Stream.suspend {
+        in.chunks
+          .fold(hash) { (d, c) =>
+            val bytes = c.toUint8Array
+            d.update(bytes)
+            d
+          }
+          .flatMap(d => Stream.chunk(Chunk.uint8Array(d.digest())))
+      }
+
+  @js.native
+  @JSImport("crypto", "createHash")
+  private[fs2] def createHash(algorithm: String): Hash = js.native
+
+  @js.native
+  private[fs2] trait Hash extends js.Object {
+    def update(data: Uint8Array): Unit = js.native
+    def digest(): Uint8Array = js.native
+  }
+}

--- a/core/js/src/test/scala/fs2/HashSuitePlatform.scala
+++ b/core/js/src/test/scala/fs2/HashSuitePlatform.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import scodec.bits.ByteVector
+
+import hash._
+
+trait HashSuitePlatform {
+  def digest(algo: String, str: String): List[Byte] = {
+    val hash = createHash(algo.replace("-", "").toLowerCase())
+    hash.update(ByteVector.view(str.getBytes).toUint8Array)
+    Chunk.uint8Array(hash.digest()).toList
+  }
+}

--- a/core/jvm/src/test/scala/fs2/HashSuitePlatform.scala
+++ b/core/jvm/src/test/scala/fs2/HashSuitePlatform.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import java.security.MessageDigest
+
+trait HashSuitePlatform {
+  def digest(algo: String, str: String): List[Byte] =
+    MessageDigest.getInstance(algo).digest(str.getBytes).toList
+}

--- a/core/native/src/main/scala/fs2/hash.scala
+++ b/core/native/src/main/scala/fs2/hash.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import cats.effect.kernel.Sync
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+/** Provides various cryptographic hashes as pipes. Requires OpenSSL. */
+object hash {
+  import openssl._
+
+  /** Computes an MD2 digest. */
+  def md2[F[_]: Sync]: Pipe[F, Byte, Byte] = digest(EVP_get_digestbyname(c"MD2"))
+
+  /** Computes an MD5 digest. */
+  def md5[F[_]: Sync]: Pipe[F, Byte, Byte] = digest(EVP_get_digestbyname(c"MD5"))
+
+  /** Computes a SHA-1 digest. */
+  def sha1[F[_]: Sync]: Pipe[F, Byte, Byte] =
+    digest(EVP_get_digestbyname(c"SHA1"))
+
+  /** Computes a SHA-256 digest. */
+  def sha256[F[_]: Sync]: Pipe[F, Byte, Byte] =
+    digest(EVP_get_digestbyname(c"SHA256"))
+
+  /** Computes a SHA-384 digest. */
+  def sha384[F[_]: Sync]: Pipe[F, Byte, Byte] =
+    digest(EVP_get_digestbyname(c"SHA384"))
+
+  /** Computes a SHA-512 digest. */
+  def sha512[F[_]: Sync]: Pipe[F, Byte, Byte] =
+    digest(EVP_get_digestbyname(c"SHA512"))
+
+  /** Computes the digest of the source stream, emitting the digest as a chunk
+    * after completion of the source stream.
+    */
+  private[this] def digest[F[_]](digest: => Ptr[EVP_MD])(implicit F: Sync[F]): Pipe[F, Byte, Byte] =
+    in =>
+      Stream
+        .bracket(F.delay {
+          val ctx = EVP_MD_CTX_new()
+          if (ctx == null)
+            throw new RuntimeException(s"EVP_MD_CTX_new: ${getError()}")
+          ctx
+        })(ctx => F.delay(EVP_MD_CTX_free(ctx)))
+        .evalTap { ctx =>
+          F.delay {
+            val `type` = digest
+            if (`type` == null)
+              throw new NullPointerException("digest was null")
+            if (EVP_DigestInit_ex(ctx, `type`, null) != 1)
+              throw new RuntimeException(s"EVP_DigestInit_ex: ${getError()}")
+          }
+        }
+        .flatMap { ctx =>
+          in.chunks
+            .foreach { chunk =>
+              F.delay {
+                val Chunk.ArraySlice(values, offset, size) = chunk.toArraySlice
+                if (EVP_DigestUpdate(ctx, values.at(offset), size.toULong) != 1)
+                  throw new RuntimeException(s"EVP_DigestUpdate: ${getError()}")
+              }
+            } ++ Stream
+            .evalUnChunk {
+              F.delay[Chunk[Byte]] {
+                val md = new Array[Byte](EVP_MAX_MD_SIZE)
+                val size = stackalloc[CUnsignedInt]()
+                if (EVP_DigestFinal_ex(ctx, md.at(0), size) != 1)
+                  throw new RuntimeException(s"EVP_DigestFinal_ex: ${getError()}")
+                Chunk.ArraySlice(md, 0, (!size).toInt)
+              }
+            }
+        }
+
+  private[this] def getError(): String =
+    fromCString(ERR_reason_error_string(ERR_get_error()))
+
+  @link("crypto")
+  @extern
+  private[fs2] object openssl {
+
+    final val EVP_MAX_MD_SIZE = 64
+
+    type EVP_MD
+    type EVP_MD_CTX
+    type ENGINE
+
+    def ERR_get_error(): ULong = extern
+    def ERR_reason_error_string(e: ULong): CString = extern
+
+    def EVP_get_digestbyname(name: Ptr[CChar]): Ptr[EVP_MD] = extern
+
+    def EVP_MD_CTX_new(): Ptr[EVP_MD_CTX] = extern
+    def EVP_MD_CTX_free(ctx: Ptr[EVP_MD_CTX]): Unit = extern
+
+    def EVP_DigestInit_ex(ctx: Ptr[EVP_MD_CTX], `type`: Ptr[EVP_MD], impl: Ptr[ENGINE]): CInt =
+      extern
+    def EVP_DigestUpdate(ctx: Ptr[EVP_MD_CTX], d: Ptr[Byte], cnt: CSize): CInt = extern
+    def EVP_DigestFinal_ex(ctx: Ptr[EVP_MD_CTX], md: Ptr[Byte], s: Ptr[CUnsignedInt]): CInt = extern
+    def EVP_Digest(
+        data: Ptr[Byte],
+        count: CSize,
+        md: Ptr[Byte],
+        size: Ptr[CUnsignedInt],
+        `type`: Ptr[EVP_MD],
+        impl: Ptr[ENGINE]
+    ): CInt = extern
+  }
+}

--- a/core/native/src/test/scala/fs2/HashSuitePlatform.scala
+++ b/core/native/src/test/scala/fs2/HashSuitePlatform.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+import hash.openssl._
+
+trait HashSuitePlatform {
+  def digest(algo: String, str: String): List[Byte] = {
+    val bytes = str.getBytes
+    val md = new Array[Byte](EVP_MAX_MD_SIZE)
+    val size = stackalloc[CUnsignedInt]()
+    val `type` = EVP_get_digestbyname((algo.replace("-", "") + "\u0000").getBytes.at(0))
+    EVP_Digest(
+      if (bytes.length > 0) bytes.at(0) else null,
+      bytes.length.toULong,
+      md.at(0),
+      size,
+      `type`,
+      null
+    )
+    md.take((!size).toInt).toList
+  }
+}

--- a/core/shared/src/test/scala/fs2/HashSuite.scala
+++ b/core/shared/src/test/scala/fs2/HashSuite.scala
@@ -23,15 +23,12 @@ package fs2
 
 import cats.effect.IO
 import cats.syntax.all._
-import java.security.MessageDigest
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
 
 import hash._
 
-class HashSuite extends Fs2Suite {
-  def digest(algo: String, str: String): List[Byte] =
-    MessageDigest.getInstance(algo).digest(str.getBytes).toList
+class HashSuite extends Fs2Suite with HashSuitePlatform with TestPlatform {
 
   def checkDigest[A](h: Pipe[Pure, Byte, Byte], algo: String, str: String) = {
     val n =
@@ -49,7 +46,8 @@ class HashSuite extends Fs2Suite {
   }
 
   group("digests") {
-    test("md2")(forAll((s: String) => checkDigest(md2, "MD2", s)))
+    if (isJVM || isNative)
+      test("md2")(forAll((s: String) => checkDigest(md2, "MD2", s)))
     test("md5")(forAll((s: String) => checkDigest(md5, "MD5", s)))
     test("sha1")(forAll((s: String) => checkDigest(sha1, "SHA-1", s)))
     test("sha256")(forAll((s: String) => checkDigest(sha256, "SHA-256", s)))

--- a/core/shared/src/test/scala/fs2/HashSuite.scala
+++ b/core/shared/src/test/scala/fs2/HashSuite.scala
@@ -24,13 +24,13 @@ package fs2
 import cats.effect.IO
 import cats.syntax.all._
 import org.scalacheck.Gen
-import org.scalacheck.Prop.forAll
+import org.scalacheck.effect.PropF.forAllF
 
 import hash._
 
 class HashSuite extends Fs2Suite with HashSuitePlatform with TestPlatform {
 
-  def checkDigest[A](h: Pipe[Pure, Byte, Byte], algo: String, str: String) = {
+  def checkDigest[A](h: Pipe[IO, Byte, Byte], algo: String, str: String) = {
     val n =
       if (str.length > 0) Gen.choose(1, str.length).sample.getOrElse(1) else 1
     val s =
@@ -42,31 +42,30 @@ class HashSuite extends Fs2Suite with HashSuitePlatform with TestPlatform {
             acc ++ Stream.chunk(Chunk.array(c))
           )
 
-    assertEquals(s.through(h).toList, digest(algo, str))
+    s.through(h).compile.toList.assertEquals(digest(algo, str))
   }
 
   group("digests") {
-    if (isJVM || isNative)
-      test("md2")(forAll((s: String) => checkDigest(md2, "MD2", s)))
-    test("md5")(forAll((s: String) => checkDigest(md5, "MD5", s)))
-    test("sha1")(forAll((s: String) => checkDigest(sha1, "SHA-1", s)))
-    test("sha256")(forAll((s: String) => checkDigest(sha256, "SHA-256", s)))
-    test("sha384")(forAll((s: String) => checkDigest(sha384, "SHA-384", s)))
-    test("sha512")(forAll((s: String) => checkDigest(sha512, "SHA-512", s)))
+    if (isJVM) test("md2")(forAllF((s: String) => checkDigest(md2, "MD2", s)))
+    test("md5")(forAllF((s: String) => checkDigest(md5, "MD5", s)))
+    test("sha1")(forAllF((s: String) => checkDigest(sha1, "SHA-1", s)))
+    test("sha256")(forAllF((s: String) => checkDigest(sha256, "SHA-256", s)))
+    test("sha384")(forAllF((s: String) => checkDigest(sha384, "SHA-384", s)))
+    test("sha512")(forAllF((s: String) => checkDigest(sha512, "SHA-512", s)))
   }
 
   test("empty input") {
-    assertEquals(Stream.empty.through(sha1).toList.size, 20)
+    Stream.empty[IO].through(sha1).compile.count.assertEquals(20L)
   }
 
   test("zero or one output") {
-    forAll { (lb: List[Array[Byte]]) =>
+    forAllF { (lb: List[Array[Byte]]) =>
       val size = lb
         .foldLeft(Stream.empty.covaryOutput[Byte])((acc, b) => acc ++ Stream.chunk(Chunk.array(b)))
-        .through(sha1)
-        .toList
-        .size
-      assertEquals(size, 20)
+        .through(sha1[IO])
+        .compile
+        .count
+      size.assertEquals(20L)
     }
   }
 


### PR DESCRIPTION
- On JS, Node.js only. This is the sole Node.js-only thing in core, but meh. Web Crypto doesn't support streaming hashing yet. Further reading:
  - https://github.com/w3c/webcrypto/issues/73
  - https://github.com/wintercg/proposal-webcrypto-streams

- On Native, requires OpenSSL.