### PR TITLE
Add redirect for API docs

### DIFF
--- a/site/api/index.html
+++ b/site/api/index.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0; URL=https://www.javadoc.io/doc/co.fs2/fs2-docs_2.13/latest/">
+<link rel="canonical" href="https://www.javadoc.io/doc/co.fs2/fs2-docs_2.13/latest/">


### PR DESCRIPTION
So that https://fs2.io/api/ will redirect to the API unidocs.