### PR TITLE
Guarantee blinding on s2n shutdown error

### DIFF
--- a/io/native/src/main/scala/fs2/io/net/tls/S2nConnection.scala
+++ b/io/native/src/main/scala/fs2/io/net/tls/S2nConnection.scala
@@ -189,6 +189,8 @@ private[tls] object S2nConnection {
           val blocked = stackalloc[s2n_blocked_status]()
           guard_(s2n_shutdown(conn, blocked))
           !blocked
+        }.guaranteeCase { oc =>
+          blindingSleep.whenA(oc.isError)
         }.productL {
           val reads = F.delay(readTasks.get).flatten
           val writes = F.delay(writeTasks.get).flatten


### PR DESCRIPTION
A similar fix was recently applied to the s2n Tokio integration.
- https://github.com/aws/s2n-tls/pull/3700.