### PR TITLE
Fix last-update tracking in `SignallingMapRef`

### DIFF
--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -392,12 +392,14 @@ object SignallingMapRef {
   /** Builds a `SignallingMapRef` for effect `F`, initialized to the supplied value.
     *
     * Update semantics for `discrete` are the same as `SignallingRef`, with one exception:
-    * if you delete a key by setting its value to `None`, this will only notify once per listener
-    * i.e. setting it to `None` again will not trigger another update. Furthermore, if a listener's
-    * last pull returned `None`, and by the time it pulls again the current value is `None`,
-    * then it will not be notified regardless of any non-`None` updates that may have happened
-    * between the pulls. This special semantic for `None` is necessary to prevent memory leaks at
-    * keys with no values and no listeners.
+    * it cannot distinguish updates that remove a key (by setting its value to `None`).
+    *
+    * More specifically: if you remove a key, this will only notify once per listener
+    * i.e. setting it to `None` again will not trigger another update.
+    * Furthermore, if a listener's last pull returned `None`, and by the time it pulls again the
+    * current value is `None`, then it will not be notified regardless of any non-`None` updates
+    * that may have happened between the pulls. This special semantic for `None` is necessary to
+    * prevent memory leaks at keys with no values and no listeners.
     */
   def ofSingleImmutableMap[F[_], K, V](
       initial: Map[K, V] = Map.empty[K, V]


### PR DESCRIPTION
This refactoring of `SignallingMapRef` fixes a bug with the `lastUpdate` counter that caused "spurious" updates to be emitted at keys that had not actually been updated.

This could be observed as a sort of race condition, when a listener at one key was unable to resubscribe before there was an update at another key. For example:
1. a listener on key `k1` is notified of an update. it records the `lastUpdate`
2. key `k2` is updated, and `lastUpdate` is incremented
3. the listener on `k1` attempts to resubscribe and sees that `lastUpdate` does not match its records. So it assumes there was an update (there wasn't, at least not at `k1`) and emits a duplicate value. Woops.

To fix this, we need to have a separate `lastUpdate` counter for each key. But that will quickly become a memory leak. 

Specifically, we are concerned with the case where a key has no value in the map and has no listeners. In that case, it should have no memory footprint, which means we cannot keep a `lastUpdate` counter for that key.

The proposed workaround is to ~~fudge~~ relax the semantics for these "deleted" keys.
- For a vanilla `SignallingRef` setting the same value twice-in-a-row will emit two updates, thanks to the `lastUpdate` counter.
- For a `SignallingMapRef`, if a key has no value (i.e. its value is `None`), its `lastUpdate` is fixed at `-1`. This means that deleting a key twice-in-a-row will only issue one update. It also means that if the last value a listener observed at a key was `None`, and by the time it resubscribes the current value is also `None`, it will not receive an update, even if there were several non-`None` updates in the window before it was able to resubscribe. Small price to pay.

  Of course, if a key _does_ have a value, semantics are exactly like `SignallingRef`.