### PR TITLE
remove outdated scaladoc comment

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4650,7 +4650,6 @@ object Stream extends StreamLowPriority {
       *      |  }.stream.compile.toVector.unsafeRunSync()
       * res0: Vector[String] = Vector(elem, late!, elem, late!, elem)
       * }}}
-      *
       */
     def timed[O2, R](
         pull: Pull.Timed[F, O] => Pull[F, O2, R]

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4651,7 +4651,6 @@ object Stream extends StreamLowPriority {
       * res0: Vector[String] = Vector(elem, late!, elem, late!, elem)
       * }}}
       *
-      * For a more complex example, look at the implementation of [[Stream.groupWithin]].
       */
     def timed[O2, R](
         pull: Pull.Timed[F, O] => Pull[F, O2, R]


### PR DESCRIPTION
`groupWithin` no longer uses a timed pull.