### PR TITLE
Run `fs2.io.stdin` on dedicated single-threaded pool

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.tools.mima.core._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion := "3.4"
+ThisBuild / tlBaseVersion := "3.5"
 
 ThisBuild / organization := "co.fs2"
 ThisBuild / organizationName := "Functional Streams for Scala"

--- a/build.sbt
+++ b/build.sbt
@@ -174,7 +174,10 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[DirectMissingMethodProblem](
     "fs2.io.net.tls.S2nConnection#RecvCallbackContext.readBuffer"
-  )
+  ),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.readBytesFromInputStream"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.readInputStreamGeneric"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.<clinit>")
 )
 
 lazy val root = tlCrossRootProject

--- a/io/jvm-native/src/main/scala/fs2/io/iojvmnative.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/iojvmnative.scala
@@ -84,7 +84,7 @@ private[fs2] trait iojvmnative {
 
   /** Stream of `String` read asynchronously from standard input decoded in UTF-8.
     *
-    * @note see caveats documented at [[stdin]].
+    * @note see caveats documented at [[[[stdin[F[_]](bufSize:Int)*]]]].
     */
   def stdinUtf8[F[_]: Async](bufSize: Int): Stream[F, String] =
     stdin(bufSize).through(text.utf8.decode)

--- a/io/jvm-native/src/main/scala/fs2/io/iojvmnative.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/iojvmnative.scala
@@ -23,11 +23,9 @@ package fs2
 package io
 
 import cats._
-import cats.effect.kernel.Async
 import cats.effect.kernel.Sync
 import cats.effect.kernel.implicits._
 import cats.syntax.all._
-import fs2.concurrent.Channel
 
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
@@ -39,32 +37,6 @@ private[fs2] trait iojvmnative {
 
   //
   // STDIN/STDOUT Helpers
-
-  /** Stream of bytes read asynchronously from standard input.
-    *
-    * @note this stream may leak a blocking thread on cancelation because it is not
-    * possible to interrupt a blocked read from `System.in`.
-    *
-    * Ideally this stream should be compiled at most once in a program to avoid
-    * losing bytes and unboundedly leaking threads.
-    */
-  def stdin[F[_]](bufSize: Int)(implicit F: Async[F]): Stream[F, Byte] =
-    Stream.eval(Channel.synchronous[F, Chunk[Byte]]).flatMap { ch =>
-      Stream.bracket {
-        readInputStream(F.blocking(System.in), bufSize, false).chunks
-          .through(ch.sendAll)
-          .compile
-          .drain
-          .start
-      } { fiber =>
-        // cancelation may hang so we leak :(
-        fiber.cancel.start.void
-      } >> ch.stream.unchunks
-    }
-
-  @deprecated("Use overload with Async, which is cancelable", "3.5.0")
-  def stdin[F[_]](bufSize: Int, F: Sync[F]): Stream[F, Byte] =
-    readInputStream(F.blocking(System.in), bufSize, false)(F)
 
   /** Pipe of bytes that writes emitted values to standard output asynchronously. */
   def stdout[F[_]: Sync]: Pipe[F, Byte, Nothing] =
@@ -81,17 +53,6 @@ private[fs2] trait iojvmnative {
       charset: Charset = StandardCharsets.UTF_8
   ): Pipe[F, O, Nothing] =
     _.map(_.show).through(text.encode(charset)).through(stdout)
-
-  /** Stream of `String` read asynchronously from standard input decoded in UTF-8.
-    *
-    * @note see caveats documented at [[[[stdin[F[_]](bufSize:Int)*]]]].
-    */
-  def stdinUtf8[F[_]: Async](bufSize: Int): Stream[F, String] =
-    stdin(bufSize).through(text.utf8.decode)
-
-  @deprecated("Use overload with Async, which is cancelable", "3.5.0")
-  def stdinUtf8[F[_]](bufSize: Int, F: Sync[F]): Stream[F, String] =
-    stdin(bufSize, F).through(text.utf8.decode)
 
   /** Stream of bytes read asynchronously from the specified resource relative to the class `C`.
     * @see [[readClassLoaderResource]] for a resource relative to a classloader.

--- a/io/jvm/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/ioplatform.scala
@@ -26,6 +26,7 @@ import cats.effect.kernel.{Async, Outcome, Resource, Sync}
 import cats.effect.kernel.implicits._
 import cats.effect.kernel.Deferred
 import cats.syntax.all._
+import fs2.internal.ThreadFactories
 import fs2.io.internal.PipedStreamBuffer
 
 import java.io.{InputStream, OutputStream}
@@ -33,7 +34,8 @@ import java.util.concurrent.Executors
 
 private[fs2] trait ioplatform extends iojvmnative {
 
-  private[this] lazy val stdinExecutor = Executors.newSingleThreadExecutor()
+  private[this] lazy val stdinExecutor =
+    Executors.newSingleThreadExecutor(ThreadFactories.named("fs2-stdin", true))
 
   /** Stream of bytes read asynchronously from standard input. */
   def stdin[F[_]](bufSize: Int)(implicit F: Async[F]): Stream[F, Byte] =

--- a/io/jvm/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/ioplatform.scala
@@ -50,6 +50,8 @@ private[fs2] trait ioplatform extends iojvmnative {
           stdinExecutor.submit(task)
         }.map { fut =>
           Some(F.delay {
+            // if the read has not started, cancelation will succeed
+            // if it has started, we cannot interrupt it, so we just leak
             fut.cancel(false)
             ()
           })

--- a/io/jvm/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/ioplatform.scala
@@ -35,14 +35,7 @@ private[fs2] trait ioplatform extends iojvmnative {
 
   private[this] lazy val stdinExecutor = Executors.newSingleThreadExecutor()
 
-  /** Stream of bytes read asynchronously from standard input.
-    *
-    * @note this stream may leak a blocking thread on cancelation because it is not
-    * possible to interrupt a blocked read from `System.in`.
-    *
-    * Ideally this stream should be compiled at most once in a program to avoid
-    * losing bytes and unboundedly leaking threads.
-    */
+  /** Stream of bytes read asynchronously from standard input. */
   def stdin[F[_]](bufSize: Int)(implicit F: Async[F]): Stream[F, Byte] =
     readInputStreamGeneric(
       F.pure(System.in),
@@ -66,10 +59,7 @@ private[fs2] trait ioplatform extends iojvmnative {
   def stdin[F[_]](bufSize: Int, F: Sync[F]): Stream[F, Byte] =
     readInputStream(F.blocking(System.in), bufSize, false)(F)
 
-  /** Stream of `String` read asynchronously from standard input decoded in UTF-8.
-    *
-    * @note see caveats documented at [[[[stdin[F[_]](bufSize:Int)*]]]].
-    */
+  /** Stream of `String` read asynchronously from standard input decoded in UTF-8. */
   def stdinUtf8[F[_]: Async](bufSize: Int): Stream[F, String] =
     stdin(bufSize).through(text.utf8.decode)
 

--- a/io/native/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/native/src/main/scala/fs2/io/ioplatform.scala
@@ -22,4 +22,14 @@
 package fs2
 package io
 
-private[fs2] trait ioplatform extends iojvmnative
+import cats.effect.kernel.Sync
+
+private[fs2] trait ioplatform extends iojvmnative {
+
+  def stdin[F[_]](bufSize: Int, F: Sync[F]): Stream[F, Byte] =
+    readInputStream(F.blocking(System.in), bufSize, false)(F)
+
+  def stdinUtf8[F[_]](bufSize: Int, F: Sync[F]): Stream[F, String] =
+    stdin(bufSize, F).through(text.utf8.decode)
+
+}

--- a/io/native/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/native/src/main/scala/fs2/io/ioplatform.scala
@@ -26,10 +26,10 @@ import cats.effect.kernel.Sync
 
 private[fs2] trait ioplatform extends iojvmnative {
 
-  def stdin[F[_]](bufSize: Int, F: Sync[F]): Stream[F, Byte] =
+  def stdin[F[_]](bufSize: Int)(implicit F: Sync[F]): Stream[F, Byte] =
     readInputStream(F.blocking(System.in), bufSize, false)(F)
 
-  def stdinUtf8[F[_]](bufSize: Int, F: Sync[F]): Stream[F, String] =
-    stdin(bufSize, F).through(text.utf8.decode)
+  def stdinUtf8[F[_]](bufSize: Int)(implicit F: Sync[F]): Stream[F, String] =
+    stdin(bufSize).through(text.utf8.decode)
 
 }


### PR DESCRIPTION
See updated description in https://github.com/typelevel/fs2/pull/3093#issuecomment-1366256942.

---

This "fixes" the FS2 manifestation of https://github.com/typelevel/cats-effect/issues/3077 where canceling the `stdin` stream hangs, because you cannot interrupt a blocking read from stdin.

"Fixes" because this is a cantfix: we just leak the blocked thread. The docs are updated to recommend you only compile the `stdin` stream at most once in a program, to mitigate this.

Couldn't think how to test this without setting up lots of infrastructure like we do in Cats Effect to test `IOApp`.
