### PR TITLE
Fix interop.reactivestreams.StreamUnicastPublisher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,12 +178,7 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.readBytesFromInputStream"),
   ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.readInputStreamGeneric"),
-  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.<clinit>"),
-  // Private cosntructor.
-  // Added in #3107
-  ProblemFilters.exclude[DirectMissingMethodProblem](
-    "fs2.interop.reactivestreams.StreamUnicastPublisher.this"
-  )
+  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.<clinit>")
 )
 
 lazy val root = tlCrossRootProject

--- a/build.sbt
+++ b/build.sbt
@@ -174,6 +174,11 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[DirectMissingMethodProblem](
     "fs2.io.net.tls.S2nConnection#RecvCallbackContext.readBuffer"
+  ),
+  // Private cosntructor.
+  // Added in #3107
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "fs2.interop.reactivestreams.StreamUnicastPublisher.this"
   )
 )
 

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -123,7 +123,7 @@ private[reactivestreams] object StreamSubscription {
   /** Represents a downstream subscriber's request to publish elements */
   private sealed trait Request
   private case object Infinite extends Request
-  private final case class Finite(n: Long) extends Request
+  private case class Finite(n: Long) extends Request
 
   // Mostly for testing purposes.
   def apply[F[_], A](stream: Stream[F, A], subscriber: Subscriber[A])(implicit

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean
   *
   * @see [[https://github.com/reactive-streams/reactive-streams-jvm#3-subscription-code]]
   */
-private[reactivestreams] final class StreamSubscription[F[_], A](
+private[reactivestreams] final class StreamSubscription[F[_], A] private (
     requests: Queue[F, StreamSubscription.Request],
     cancelled: SignallingRef[F, Boolean],
     sub: Subscriber[A],

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
@@ -51,11 +51,11 @@ final class StreamUnicastPublisher[F[_]: Async, A] private (
 
   def subscribe(subscriber: Subscriber[_ >: A]): Unit = {
     nonNull(subscriber)
-    try {
+    try
       startDispatcher.unsafeRunAndForget(
         StreamSubscription.subscribe(stream, subscriber)
       )
-    } catch {
+    catch {
       case _: IllegalStateException =>
         subscriber.onSubscribe(new Subscription {
           override def cancel(): Unit = ()

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
@@ -38,17 +38,10 @@ import scala.util.control.NoStackTrace
   *
   * @see [[https://github.com/reactive-streams/reactive-streams-jvm#1-publisher-code]]
   */
-final class StreamUnicastPublisher[F[_]: Async, A] private (
+final class StreamUnicastPublisher[F[_]: Async, A](
     val stream: Stream[F, A],
     startDispatcher: Dispatcher[F]
 ) extends Publisher[A] {
-
-  /** Constructor is defined twice
-    *  @deprecated("Use StreamUnicastPublisher.apply", "3.4.0")
-    *  def this(stream: Stream[F, A], dispatcher: Dispatcher[F]) =
-    *    this(stream, dispatcher)
-    */
-
   def subscribe(subscriber: Subscriber[_ >: A]): Unit = {
     nonNull(subscriber)
     try

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala
@@ -92,14 +92,14 @@ package object reactivestreams {
       fromPublisher(publisher)
   }
 
-  /** Allows subscribing a [[Subscriber]] to a [[Stream]].
+  /** Allows subscribing a `org.reactivestreams.Subscriber` to a [[Stream]].
     *
     * The returned program will run until
     * all the stream elements were consumed.
     * Cancelling this program will gracefully shutdown the subscription.
     *
     * @param stream the [[Stream]] that will be consumed by the subscriber.
-    * @param subscriber the [[Subscriber]] that will receive the elements of the stream.
+    * @param subscriber the Subscriber that will receive the elements of the stream.
     */
   def subscribeStream[F[_], A](stream: Stream[F, A], subscriber: Subscriber[A])(implicit
       F: Async[F]
@@ -117,9 +117,9 @@ package object reactivestreams {
     ): Resource[F, StreamUnicastPublisher[F, A]] =
       StreamUnicastPublisher(stream)
 
-    /** Subscribes the provided [[Subscriber]] to this stream.
+    /** Subscribes the provided `org.reactivestreams.Subscriber` to this stream.
       *
-      * @param subscriber the [[Subscriber]] that will receive the elements of the stream.
+      * @param subscriber the Subscriber that will receive the elements of the stream.
       */
     def subscribe(subscriber: Subscriber[A])(implicit F: Async[F]): F[Unit] =
       reactivestreams.subscribeStream(stream, subscriber)

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala
@@ -108,9 +108,12 @@ package object reactivestreams {
 
   implicit final class StreamOps[F[_], A](val stream: Stream[F, A]) {
 
-    /** Creates a [[StreamUnicastPublisher]] from a stream.
+    /** Creates a [[StreamUnicastPublisher]] from a [[Stream]].
       *
       * The stream is only ran when elements are requested.
+      *
+      * @note Not longer unicast, this Publisher can be reused for multiple Subscribers:
+      *       each subscription will re-run the [[Stream]] from the beginning.
       */
     def toUnicastPublisher(implicit
         F: Async[F]

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala
@@ -92,16 +92,36 @@ package object reactivestreams {
       fromPublisher(publisher)
   }
 
+  /** Allows subscribing a [[Subscriber]] to a [[Stream]].
+    *
+    * The returned program will run until
+    * all the stream elements were consumed.
+    * Cancelling this program will gracefully shutdown the subscription.
+    *
+    * @param stream the [[Stream]] that will be consumed by the subscriber.
+    * @param subscriber the [[Subscriber]] that will receive the elements of the stream.
+    */
+  def subscribeStream[F[_], A](stream: Stream[F, A], subscriber: Subscriber[A])(implicit
+      F: Async[F]
+  ): F[Unit] =
+    StreamSubscription.subscribe(stream, subscriber)
+
   implicit final class StreamOps[F[_], A](val stream: Stream[F, A]) {
 
     /** Creates a [[StreamUnicastPublisher]] from a stream.
       *
-      * This publisher can only have a single subscription.
       * The stream is only ran when elements are requested.
       */
     def toUnicastPublisher(implicit
         F: Async[F]
     ): Resource[F, StreamUnicastPublisher[F, A]] =
       StreamUnicastPublisher(stream)
+
+    /** Subscribes the provided [[Subscriber]] to this stream.
+      *
+      * @param subscriber the [[Subscriber]] that will receive the elements of the stream.
+      */
+    def subscribe(subscriber: Subscriber[A])(implicit F: Async[F]): F[Unit] =
+      reactivestreams.subscribeStream(stream, subscriber)
   }
 }

--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/CancellationSpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/CancellationSpec.scala
@@ -59,8 +59,8 @@ class CancellationSpec extends Fs2Suite {
       }
       .replicateA_(attempts)
 
-  test("After subscription is cancelled request must be noOps") {
-    testStreamSubscription(clue = "onNext was called after the subscription was cancelled") { sub =>
+  test("After subscription is canceled request must be NOOPs") {
+    testStreamSubscription(clue = "onNext was called after the subscription was canceled") { sub =>
       sub.cancel()
       sub.request(1)
       sub.request(1)
@@ -68,8 +68,8 @@ class CancellationSpec extends Fs2Suite {
     }
   }
 
-  test("after subscription is cancelled additional cancelations must be noOps") {
-    testStreamSubscription(clue = "onComplete was called after the subscription was cancelled") {
+  test("after subscription is canceled additional cancellations must be NOOPs") {
+    testStreamSubscription(clue = "onComplete was called after the subscription was canceled") {
       sub =>
         sub.cancel()
         sub.cancel()

--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/CancellationSpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/CancellationSpec.scala
@@ -44,7 +44,7 @@ class CancellationSpec extends Fs2Suite {
 
   val s = Stream.range(0, 5).covary[IO]
 
-  val attempts = 5000
+  val attempts = 1000
 
   def testStreamSubscription(clue: String)(program: Subscription => Unit): IO[Unit] =
     IO(new AtomicBoolean(false))

--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/CancellationSpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/CancellationSpec.scala
@@ -23,10 +23,9 @@ package fs2
 package interop
 package reactivestreams
 
-import org.reactivestreams._
-import cats.effect._
-import cats.effect.std.Dispatcher
+import cats.effect.IO
 import cats.syntax.all._
+import org.reactivestreams.{Subscriber, Subscription}
 
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -36,54 +35,44 @@ import java.util.concurrent.atomic.AtomicBoolean
   * failures due to race conditions more repeatable
   */
 class CancellationSpec extends Fs2Suite {
-
-  case class Sub[A](b: AtomicBoolean) extends Subscriber[A] {
+  final class Sub[A](b: AtomicBoolean) extends Subscriber[A] {
     def onNext(t: A) = b.set(true)
     def onComplete() = b.set(true)
     def onError(e: Throwable) = b.set(true)
-    def onSubscribe(s: Subscription) = b.set(true)
+    def onSubscribe(s: Subscription) = ()
   }
 
   val s = Stream.range(0, 5).covary[IO]
 
-  val attempts = 10000
+  val attempts = 5000
 
-  def withDispatchers(f: (Dispatcher[IO], Dispatcher[IO]) => Unit): Unit =
-    (Dispatcher.sequential[IO], Dispatcher.sequential[IO]).tupled
-      .use { case (d1, d2) => IO(f(d1, d2)) }
-      .unsafeRunSync()
-
-  test("after subscription is cancelled request must be noOps") {
-    withDispatchers { (startDispatcher, requestDispatcher) =>
-      var i = 0
-      val b = new AtomicBoolean(false)
-      while (i < attempts) {
-        val sub =
-          StreamSubscription(Sub[Int](b), s, startDispatcher, requestDispatcher).unsafeRunSync()
-        sub.unsafeStart()
-        sub.cancel()
-        sub.request(1)
-        sub.request(1)
-        sub.request(1)
-        i = i + 1
+  def testStreamSubscription(clue: String)(program: Subscription => Unit): IO[Unit] =
+    IO(new AtomicBoolean(false))
+      .flatMap { flag =>
+        StreamSubscription(s, new Sub(flag)).use { subscription =>
+          (
+            subscription.run,
+            IO(program(subscription))
+          ).parTupled
+        } >>
+          IO(flag.get()).assertEquals(false, clue)
       }
-      if (b.get) fail("onNext was called after the subscription was cancelled")
+      .replicateA_(attempts)
+
+  test("After subscription is cancelled request must be noOps") {
+    testStreamSubscription(clue = "onNext was called after the subscription was cancelled") { sub =>
+      sub.cancel()
+      sub.request(1)
+      sub.request(1)
+      sub.request(1)
     }
   }
 
   test("after subscription is cancelled additional cancelations must be noOps") {
-    withDispatchers { (startDispatcher, requestDispatcher) =>
-      var i = 0
-      val b = new AtomicBoolean(false)
-      while (i < attempts) {
-        val sub =
-          StreamSubscription(Sub[Int](b), s, startDispatcher, requestDispatcher).unsafeRunSync()
-        sub.unsafeStart()
+    testStreamSubscription(clue = "onComplete was called after the subscription was cancelled") {
+      sub =>
         sub.cancel()
         sub.cancel()
-        i = i + 1
-      }
-      if (b.get) fail("onCancel was called after the subscription was cancelled")
     }
   }
 }

--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/StreamUnicastPublisherSpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/StreamUnicastPublisherSpec.scala
@@ -23,35 +23,27 @@ package fs2
 package interop
 package reactivestreams
 
-import cats.effect._
-import cats.effect.unsafe.implicits._
-import org.reactivestreams._
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import org.reactivestreams.tck.{PublisherVerification, TestEnvironment}
 import org.scalatestplus.testng._
-
-final class FailedSubscription extends Subscription {
-  def cancel(): Unit = {}
-  def request(n: Long): Unit = {}
-}
-
-final class FailedPublisher extends Publisher[Int] {
-  def subscribe(subscriber: Subscriber[_ >: Int]): Unit = {
-    subscriber.onSubscribe(new FailedSubscription)
-    subscriber.onError(new Error("BOOM"))
-  }
-}
 
 final class StreamUnicastPublisherSpec
     extends PublisherVerification[Int](new TestEnvironment(1000L))
     with TestNGSuiteLike {
 
-  def createPublisher(n: Long): StreamUnicastPublisher[IO, Int] = {
-    val s =
-      if (n == java.lang.Long.MAX_VALUE) Stream.range(1, 20).repeat
-      else Stream(1).repeat.scan(1)(_ + _).map(i => if (i > n) None else Some(i)).unNoneTerminate
+  override def createPublisher(n: Long): StreamUnicastPublisher[IO, Int] = {
+    val nums = Stream.constant(3)
 
-    StreamUnicastPublisher[IO, Int](s).allocated.unsafeRunSync()._1
+    StreamUnicastPublisher[IO, Int](
+      if (n == Long.MaxValue) nums else nums.take(n)
+    ).allocated.unsafeRunSync()._1
   }
 
-  def createFailedPublisher(): FailedPublisher = new FailedPublisher()
+  override def createFailedPublisher(): StreamUnicastPublisher[IO, Int] = {
+    val (publisher, close) =
+      StreamUnicastPublisher[IO, Int](Stream.empty).allocated.unsafeRunSync()
+    close.unsafeRunSync() // If the resource is closed then the publisher is failed.
+    publisher
+  }
 }

--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/StreamUnicastPublisherSpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/StreamUnicastPublisherSpec.scala
@@ -41,9 +41,8 @@ final class StreamUnicastPublisherSpec
   }
 
   override def createFailedPublisher(): StreamUnicastPublisher[IO, Int] = {
-    val (publisher, close) =
-      StreamUnicastPublisher[IO, Int](Stream.empty).allocated.unsafeRunSync()
-    close.unsafeRunSync() // If the resource is closed then the publisher is failed.
+    val publisher = // If the resource is closed then the publisher is failed.
+      StreamUnicastPublisher[IO, Int](Stream.empty).use(IO.pure).unsafeRunSync()
     publisher
   }
 }


### PR DESCRIPTION
Improves the current implementation of `interop.reactivestreams.StreamUnicastPublisher` to allow it to be subscribed by multiple `Publishers` and gracefully cancel active `Subscriptions` when the `Resource` is closed.

-----

**Roadmap**.

- [x] Base implementation.
- [x] Fix tests.
- [x] Backport to the **Java** `Flow` PR.
- [x] Fix MiMa.

-----

Related to #3102
