### PR TITLE
Add .interleaveOrdered to combine sorted streams (i.e. "merge-sort")

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -837,6 +837,7 @@ object Pull extends PullLowPriority {
 
   private final case class GetScope[F[_]]() extends AlgEffect[Nothing, Scope[F]]
 
+  /** Ignores current stepLeg head, goes on with remaining data */
   private[fs2] def stepLeg[F[_], O](
       leg: Stream.StepLeg[F, O]
   ): Pull[F, Nothing, Option[Stream.StepLeg[F, O]]] =

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1980,14 +1980,14 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     that.mergeHaltL(this)
 
   /** Given two sorted streams emits a single sorted stream, like in merge-sort.
-    * For entries that are considered equal by the Order, left stream element is emmitted first.
+    * For entries that are considered equal by the Order, left stream element is emitted first.
     * Note: both this and another streams MUST BE ORDERED already
     * @example {{{
-    * scala> Stream(1, 2, 5, 6).mergeSorted(Stream(0, 2, 3, 4)).toList
+    * scala> Stream(1, 2, 5, 6).interleaveOrdered(Stream(0, 2, 3, 4)).toList
     * res0: List[Int] = List(0, 1, 2, 2, 3, 4, 5, 6)
     * }}}
     */
-  def mergeSorted[F2[x] >: F[x], O2 >: O: Order](that: Stream[F2, O2]): Stream[F2, O2] = {
+  def interleaveOrdered[F2[x] >: F[x], O2 >: O: Order](that: Stream[F2, O2]): Stream[F2, O2] = {
     val order = Order[O2].toOrdering // collections API needs Ordering, not cats.Order
 
     def go(

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1990,44 +1990,25 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   def interleaveOrdered[F2[x] >: F[x], O2 >: O: Order](that: Stream[F2, O2]): Stream[F2, O2] = {
     val order = Order[O2].toOrdering // collections API needs Ordering, not cats.Order
 
-    def go(
-        leftLeg: Stream.StepLeg[F2, O2],
-        rightLeg: Stream.StepLeg[F2, O2]
-    ): Pull[F2, O2, Unit] = {
-      val lChunk = leftLeg.head
-      val rChunk = rightLeg.head
-      if (lChunk.nonEmpty && rChunk.nonEmpty) { // the only case we need chunk merging and sorting
-        val emitUpTo = order.min(lChunk(lChunk.size - 1), rChunk(rChunk.size - 1))
-        val emitLeftCount = lChunk.indexWhere(order.gt(_, emitUpTo)).getOrElse(lChunk.size)
-        val emitRightCount = rChunk.indexWhere(order.gt(_, emitUpTo)).getOrElse(rChunk.size)
-        val (emitLeft, keepLeft) = lChunk.splitAt(emitLeftCount)
-        val (emitRight, keepRight) = rChunk.splitAt(emitRightCount)
-        Pull.output(
-          Chunk.vector((emitLeft ++ emitRight).toVector.sorted(order))
-        ) >> go(leftLeg.setHead(keepLeft), rightLeg.setHead(keepRight))
-      } else { // otherwise, we need to shift leg
-        if (lChunk.isEmpty) {
-          leftLeg.stepLeg.flatMap {
-            case Some(nextLl) => go(nextLl, rightLeg)
-            case None         => Pull.output(rChunk) >> rightLeg.next
+    def go(left: Pull[F2, O2, Unit], right: Pull[F2, O2, Unit]): Pull[F2, O2, Unit] =
+      left.uncons.flatMap {
+        case Some((lChunk, lNext)) =>
+          right.uncons.flatMap {
+            case Some((rChunk, rNext)) =>
+              val emitUpTo = order.min(lChunk(lChunk.size - 1), rChunk(rChunk.size - 1))
+              val emitLeftCount = lChunk.indexWhere(order.gt(_, emitUpTo)).getOrElse(lChunk.size)
+              val emitRightCount = rChunk.indexWhere(order.gt(_, emitUpTo)).getOrElse(rChunk.size)
+              val (emitLeft, keepLeft) = lChunk.splitAt(emitLeftCount)
+              val (emitRight, keepRight) = rChunk.splitAt(emitRightCount)
+              Pull.output(Chunk.vector((emitLeft ++ emitRight).toVector.sorted(order))) >> go(
+                if (keepLeft.isEmpty) lNext else Pull.output(keepLeft) >> lNext,
+                if (keepRight.isEmpty) rNext else Pull.output(keepRight) >> rNext
+              )
+            case None => Pull.output(lChunk) >> lNext
           }
-        } else {
-          rightLeg.stepLeg.flatMap {
-            case Some(nextRl) => go(leftLeg, nextRl)
-            case None         => Pull.output(lChunk) >> leftLeg.next
-          }
-        }
+        case None => right
       }
-    }
-
-    val thisPull = covaryAll[F2, O2].pull
-    val thatPull = that.pull
-
-    (thisPull.stepLeg, thatPull.stepLeg).tupled.flatMap {
-      case (Some(leg1), Some(leg2)) => go(leg1, leg2)
-      case (_, None)                => thisPull.echo
-      case (None, _)                => thatPull.echo
-    }.stream
+    go(this.underlying, that.underlying).stream
   }
 
   /** Emits each output wrapped in a `Some` and emits a `None` at the end of the stream.

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -37,8 +37,6 @@ import scala.concurrent.TimeoutException
 
 class StreamCombinatorsSuite extends Fs2Suite {
 
-  override def scalaCheckInitialSeed = "CGcLMAcUebElb0kzuHuoGp8ZwxhJT9ztcbnWc_4sYHK="
-
   group("awakeEvery") {
     test("basic") {
       Stream

--- a/core/shared/src/test/scala/fs2/StreamMergeSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamMergeSuite.scala
@@ -22,11 +22,10 @@
 package fs2
 
 import scala.concurrent.duration._
+
 import cats.effect.IO
 import cats.effect.kernel.{Deferred, Ref}
 import cats.syntax.all._
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Prop.forAll
 import org.scalacheck.effect.PropF.forAllF
 
 class StreamMergeSuite extends Fs2Suite {
@@ -243,29 +242,4 @@ class StreamMergeSuite extends Fs2Suite {
         }
     }
   }
-
-  test("mergeSorted") {
-    type SortedData = Vector[Chunk[Int]]
-    def mkStream(parts: SortedData): Stream[Pure, Int] = parts.map(Stream.chunk).combineAll
-
-    implicit val arbSortedData: Arbitrary[SortedData] = Arbitrary(
-      for {
-        sortedData <- Arbitrary.arbContainer[Array, Int].arbitrary.map(_.sorted)
-        splitIdxs <- Gen.someOf(sortedData.indices).map(_.sorted)
-        borders = (0 +: splitIdxs).zip(splitIdxs :+ sortedData.length)
-      } yield borders.toVector
-        .map { case (from, to) =>
-          Chunk.array(sortedData, from, to - from)
-        }
-    )
-
-    forAll { (sortedL: SortedData, sortedR: SortedData) =>
-      mkStream(sortedL)
-        .mergeSorted(mkStream(sortedR))
-        .assertEmits(
-          (sortedL ++ sortedR).toList.flatMap(_.toList).sorted
-        )
-    }
-  }
-
 }


### PR DESCRIPTION
An implementation of "merge-sort" merging for two streams of sorted data.
This might be useful in practice when combining streams from different underlying sources.

[Discord conversation](https://discord.com/channels/632277896739946517/632310980449402880/1063932797145849888)

