### PR TITLE
Add limit combinator to Stream

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1764,8 +1764,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       .flatMap {
         case Some(s) =>
           s.pull.uncons.flatMap {
-            case Some(_) => Pull.raiseError(new IllegalStateException)
-            case None    => Pull.done
+            case Some(_) =>
+              Pull.raiseError(new IllegalStateException(s"limit($n) emitted more than $n elements"))
+            case None => Pull.done
           }
         case _ => Pull.done
       }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1755,6 +1755,22 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       case None    => Pull.output1(fallback)
     }.stream
 
+  /** Emits the first `n` elements of this stream,
+    * raising an IllegalStateException if there are more elements.
+    */
+  def limit[F2[x] >: F[x]](n: Long)(implicit rt: RaiseThrowable[F2]): Stream[F2, O] =
+    this.pull
+      .take(n)
+      .flatMap {
+        case Some(s) =>
+          s.pull.uncons.flatMap {
+            case Some(_) => Pull.raiseError(new IllegalStateException)
+            case None    => Pull.done
+          }
+        case _ => Pull.done
+      }
+      .stream
+
   /** Applies the specified pure function to each input and emits the result.
     *
     * @example {{{


### PR DESCRIPTION
# What

Adds a `limit` combinator to `Stream`, which emits the first n elements and raises an error if there are more elements.

# Why

I've implemented this a few times recently, and it seems to be sufficiently general to be worth implementing efficiently as a canoncial combinator. Example use case might be a middleware which enforces size limits on streams.

I'm not sure what the desired approach is to combinator generality - so it's completely fine if the consensus here is that it's not useful enough to warrant being included in the `Stream` API. Also hppy to rework the naming if desired, alternatives might be `limitOrError` or something like `maxSize`.

---

Thanks for opening a PR!

Target the `main` branch if this PR is targeted for the 3.x series and the `series/2.5.x` branch if targeted for the 2.5.x series.

If the CI build fails due to Scalafmt, run `sbt scalafmtAll` and push the changes (generally a good idea to run this prior to opening the PR).

Feel free to ask questions on the fs2 and fs2-dev channels on the [Typelevel Discord server](https://discord.gg/9V8FZTVZ9R).
