### PR TITLE
Correctly handle TLS empty writes in `S2nConnection`

### DIFF
--- a/io/native/src/main/scala/fs2/io/net/tls/S2nConnection.scala
+++ b/io/native/src/main/scala/fs2/io/net/tls/S2nConnection.scala
@@ -164,7 +164,7 @@ private[tls] object S2nConnection {
         go(0)
       }
 
-      def write(bytes: Chunk[Byte]) = {
+      def write(bytes: Chunk[Byte]) = if (bytes.nonEmpty) {
         val Chunk.ArraySlice(buf, offset, n) = bytes.toArraySlice
 
         def go(i: Int): F[Unit] =
@@ -180,7 +180,7 @@ private[tls] object S2nConnection {
             }
 
         go(0)
-      }
+      } else F.unit
 
       def shutdown =
         F.delay {

--- a/io/native/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/native/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -136,7 +136,7 @@ class TLSSocketSuite extends TLSSuite {
         .assertEquals(msg)
     }
 
-    test("empty") {
+    test("empty write") {
       val setup = for {
         tlsContext <- testTlsContext
         addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))

--- a/io/native/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/native/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -136,7 +136,7 @@ class TLSSocketSuite extends TLSSuite {
         .assertEquals(msg)
     }
 
-    test("empty".only) {
+    test("empty") {
       val setup = for {
         tlsContext <- testTlsContext
         addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))


### PR DESCRIPTION
Ember H2 in particular was tripping on it here:

https://github.com/http4s/http4s/blob/91adfbc3f998085b22f8b45354d8d56c3d14099e/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala#L144

It uses an empty write as a hack to trigger handshaking on the JVM, which is not relevant to the Native implementation. But it's still a legit bug :)

H/t @bishabosha, thanks!