### PR TITLE
Mask `getBasicFileAttributes` errors in `Files[F].walk`

### DIFF
--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -470,9 +470,9 @@ object Files extends FilesCompanionPlatform {
           else
             Stream.eval(getBasicFileAttributes(start, followLinks = false)).mask.flatMap { attr =>
               if (attr.isDirectory)
-                list(start).flatMap { path =>
+                list(start).mask.flatMap { path =>
                   go(path, maxDepth - 1, attr.fileKey.toRight(start) :: ancestry)
-                }.mask
+                }
               else if (attr.isSymbolicLink && followLinks)
                 Stream.eval(getBasicFileAttributes(start, followLinks = true)).mask.flatMap {
                   attr =>
@@ -484,9 +484,9 @@ object Files extends FilesCompanionPlatform {
 
                     Stream.eval(isCycle).flatMap { isCycle =>
                       if (!isCycle)
-                        list(start).flatMap { path =>
+                        list(start).mask.flatMap { path =>
                           go(path, maxDepth - 1, attr.fileKey.toRight(start) :: ancestry)
-                        }.mask
+                        }
                       else
                         Stream.raiseError(new FileSystemLoopException(start.toString))
                     }

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -519,6 +519,23 @@ class FilesSuite extends Fs2IoSuite with BaseFileSuite {
         .assertEquals(31) // the root + 5 children + 5 files per child directory
     }
 
+    test("can delete files in a nested tree") {
+      Stream
+        .resource(tempFilesHierarchy)
+        .flatMap { topDir =>
+          Files[IO].walk(topDir).evalMap { path =>
+            Files[IO]
+              .isRegularFile(path)
+              .ifM(
+                Files[IO].deleteIfExists(path).as(1),
+                IO.pure(0)
+              )
+          }
+        }
+        .compile
+        .foldMonoid
+        .assertEquals(25)
+    }
   }
 
   test("writeRotate") {


### PR DESCRIPTION
This shows a problem with `Files[F].walk` where it does not walk the whole file tree if files are deleted during the process.  The added tests fails with:
```
==> X fs2.io.file.FilesSuite.walk - can delete files in a nested tree  0.029s munit.ComparisonFailException: fs2/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala:537
536:        .foldMonoid
537:        .assertEquals(25)
538:    }
values are not the same
=> Obtained
5
=> Diff (- obtained, + expected)
-5
+25
```
Only 5 files out of 25 where deleted. I expected that the whole process deletes 25 files because `tempFilesHierarchy` creates 5 child directories with 5 files in each child directory.

If `Files[IO].deleteIfExists(path).as(1)` is replaced with `IO.pure(1)` the test passes.