### PR TITLE
Add `Signal#getAndDiscreteUpdates`

### DIFF
--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -643,10 +643,11 @@ private[concurrent] trait SignalInstances extends SignalLowPriorityInstances {
 
           override def getAndDiscreteUpdates(implicit
               ev: Concurrent[F]
-          ): Resource[F, (B, Stream[F, B])] =
-            (ff.getAndDiscreteUpdates(ev), fa.getAndDiscreteUpdates(ev)).mapN {
-              case ((f, fs), (a, as)) =>
-                (f(a), nondeterministicZip(fs, as).map { case (f, a) => f(a) })
+          ): Resource[F, (B, Stream[F, B])] = getAndDiscreteUpdatesImpl
+
+          private[this] def getAndDiscreteUpdatesImpl =
+            (ff.getAndDiscreteUpdates, fa.getAndDiscreteUpdates).mapN { case ((f, fs), (a, as)) =>
+              (f(a), nondeterministicZip(fs, as).map { case (f, a) => f(a) })
             }
         }
     }


### PR DESCRIPTION
The motivation for this comes from Calico, where we want to get the current value of a `Signal` for immediate rendering, and also a handle to a `Stream` of discrete updates, that we can subscribe to _at some later point_ (typically after rendering) (or not at all), without missing any updates.

FWIW I did try the "hack" of `get` followed by `discrete.drop(1)`, and this ended up breaking in some situations.

I also tried inlining the default implementation here in Calico, but there is a noticeable performance difference (where by "noticeable", I mean visible UX latency in a webapp).

Suffice to say, the win comes from the fact that each `Signal` can override this with something more efficient (basically just a `.get`) than the default `uncons1` implementation.

Furthermore, `get` and `discrete` can both be derived from `getAndDiscreteUpdates` much more easily than the other way around.