### PR TITLE
Use `UndefOr` for Node.js file `Flag`s not supported on windows

### DIFF
--- a/io/js/src/main/scala/fs2/io/file/Flag.scala
+++ b/io/js/src/main/scala/fs2/io/file/Flag.scala
@@ -40,8 +40,8 @@ object Flag extends FlagCompanionApi {
   val Create = Flag(facade.fs.constants.O_CREAT)
   val CreateNew = Flag(facade.fs.constants.O_CREAT.toLong | facade.fs.constants.O_EXCL.toLong)
 
-  val Sync = Flag(facade.fs.constants.O_SYNC)
-  val Dsync = Flag(facade.fs.constants.O_DSYNC)
+  val Sync = Flag(facade.fs.constants.O_SYNC.getOrElse(0.0))
+  val Dsync = Flag(facade.fs.constants.O_DSYNC.getOrElse(0.0))
 
   private[file] implicit val monoid: Monoid[Flag] = new Monoid[Flag] {
     override def combine(x: Flag, y: Flag): Flag = Flag(x.bits | y.bits)

--- a/io/js/src/main/scala/fs2/io/internal/facade/fs.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/fs.scala
@@ -118,9 +118,11 @@ package fs {
 
     val O_EXCL: Double = js.native
 
-    val O_SYNC: Double = js.native
+    // UndefOr, because windows (:
 
-    val O_DSYNC: Double = js.native
+    val O_SYNC: js.UndefOr[Double] = js.native
+
+    val O_DSYNC: js.UndefOr[Double] = js.native
 
   }
 


### PR DESCRIPTION
Thanks to @sherpal for reporting! Update: they confirmed the fix works ✅ 

Stack trace:

<details>

```
<ref *2> $c_Lorg_scalajs_linker_runtime_UndefinedBehaviorError [org.scalajs.linker.runtime.UndefinedBehaviorError]: java.lang.ClassCastException: undefined cannot be cast to java.lang.Double
    at $throwClassCastException (file:///C:/Users/antoi/IdeaProjects/Ejoti/server/target/scala-3.2.0/server-fastopt/main.js:55:9)
    at $uD (file:///C:/Users/antoi/IdeaProjects/Ejoti/server/target/scala-3.2.0/server-fastopt/main.js:532:73)
    at $c_Lfs2_io_file_Flag$ (https://raw.githubusercontent.com/typelevel/fs2/v3.5.0/io/js/src/main/scala/fs2/io/file/Flag.scala:43:19)
    at $m_Lfs2_io_file_Flag$ (https://raw.githubusercontent.com/typelevel/fs2/v3.5.0/io/js/src/main/scala/fs2/io/file/Flag.scala:31:8)
    at $c_Lfs2_io_file_Flags$ (https://raw.githubusercontent.com/typelevel/fs2/v3.5.0/io/shared/src/main/scala/fs2/io/file/Flags.scala:42:20)
      at $m_Lfs2_io_file_Flag$ (https://raw.githubusercontent.com/typelevel/fs2/v3.5.0/io/js/src/main/scala/fs2/io/file/Flag.scala:31:8)
      at $c_Lfs2_io_file_Flags$ (https://raw.githubusercontent.com/typelevel/fs2/v3.5.0/io/shared/src/main/scala/fs2/io/file/Flags.scala:42:20)      at $m_Lfs2_io_file_Flags$ (https://raw.githubusercontent.com/typelevel/fs2/v3.5.0/io/shared/src/main/scala/fs2/io/file/Flags.scala:38:8)
      at $c_Lfs2_io_file_FilesCompanionPlatform$AsyncFiles.readUtf8__Lfs2_io_file_Path__Lfs2_Stream (https://raw.githubusercontent.com/typelevel/fs2/v3.5.0/io/shared/src/main/scala/fs2/io/file/Files.scala:264:71)
      at $c_Lfs2_io_file_FilesCompanionPlatform$AsyncFiles.readUtf8Lines__Lfs2_io_file_Path__Lfs2_Stream (https://raw.githubusercontent.com/typelevel/fs2/v3.5.0/io/shared/src/main/scala/fs2/io/file/Files.scala:436:15)
      at $c_Lserver_reproducer$package$.run__V (C:\Users\antoi\IdeaProjects\Ejoti\server\src\main\scala\server\reproducer.scala:13:21)
      at $s_Lserver_run__main__AT__V (C:\Users\antoi\IdeaProjects\Ejoti\server\src\main\scala\server\reproducer.scala:6:1) {
    jl_Throwable__f_s: 'undefined cannot be cast to java.lang.Double',
    jl_Throwable__f_e: null,
    jl_Throwable__f_enableSuppression: false,
    jl_Throwable__f_writableStackTrace: true,
    jl_Throwable__f_jsErrorForStackTrace: [Circular *1],
    jl_Throwable__f_stackTrace: null,
    jl_Throwable__f_suppressed: null  },
  jl_Throwable__f_enableSuppression: false,  jl_Throwable__f_writableStackTrace: true,
  jl_Throwable__f_jsErrorForStackTrace: [Circular *2],
  jl_Throwable__f_stackTrace: null,
  jl_Throwable__f_suppressed: null
}
```

</details>

I considered using a `lazy val` to defer the exception (instead of at init), but it seems that the JDK offers equivalent flags on all platforms (I assume by no-opping). So we just fallback to 0 bits set. Anyway, this saves users from having to condition use of this flag per-OS.