### PR TITLE
Update to Cats Effect v3.5.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.tools.mima.core._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion := "3.6"
+ThisBuild / tlBaseVersion := "3.7"
 
 ThisBuild / organization := "co.fs2"
 ThisBuild / organizationName := "Functional Streams for Scala"
@@ -213,9 +213,9 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     libraryDependencies ++= Seq(
       "org.scodec" %%% "scodec-bits" % "1.1.35",
       "org.typelevel" %%% "cats-core" % "2.9.0",
-      "org.typelevel" %%% "cats-effect" % "3.4.6",
-      "org.typelevel" %%% "cats-effect-laws" % "3.4.6" % Test,
-      "org.typelevel" %%% "cats-effect-testkit" % "3.4.6" % Test,
+      "org.typelevel" %%% "cats-effect" % "3.5.0-RC1",
+      "org.typelevel" %%% "cats-effect-laws" % "3.5.0-RC1" % Test,
+      "org.typelevel" %%% "cats-effect-testkit" % "3.5.0-RC1" % Test,
       "org.typelevel" %%% "cats-laws" % "2.9.0" % Test,
       "org.typelevel" %%% "discipline-munit" % "2.0.0-M3" % Test,
       "org.typelevel" %%% "munit-cats-effect" % "2.0.0-M3" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,8 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.readBytesFromInputStream"),
   ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.readInputStreamGeneric"),
-  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.<clinit>")
+  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.<clinit>"),
+  ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.io.net.Socket.forAsync")
 )
 
 lazy val root = tlCrossRootProject

--- a/build.sbt
+++ b/build.sbt
@@ -179,7 +179,13 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.readBytesFromInputStream"),
   ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.readInputStreamGeneric"),
   ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.package.<clinit>"),
-  ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.io.net.Socket.forAsync")
+  ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.io.net.Socket.forAsync"),
+  ProblemFilters.exclude[IncompatibleMethTypeProblem](
+    "fs2.io.net.SocketCompanionPlatform#AsyncSocket.this"
+  ),
+  ProblemFilters.exclude[IncompatibleMethTypeProblem](
+    "fs2.io.net.unixsocket.UnixSocketsCompanionPlatform#AsyncSocket.this"
+  )
 )
 
 lazy val root = tlCrossRootProject

--- a/build.sbt
+++ b/build.sbt
@@ -214,9 +214,9 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     libraryDependencies ++= Seq(
       "org.scodec" %%% "scodec-bits" % "1.1.35",
       "org.typelevel" %%% "cats-core" % "2.9.0",
-      "org.typelevel" %%% "cats-effect" % "3.5.0-RC1",
-      "org.typelevel" %%% "cats-effect-laws" % "3.5.0-RC1" % Test,
-      "org.typelevel" %%% "cats-effect-testkit" % "3.5.0-RC1" % Test,
+      "org.typelevel" %%% "cats-effect" % "3.5-e3fbc49",
+      "org.typelevel" %%% "cats-effect-laws" % "3.5-e3fbc49" % Test,
+      "org.typelevel" %%% "cats-effect-testkit" % "3.5-e3fbc49" % Test,
       "org.typelevel" %%% "cats-laws" % "2.9.0" % Test,
       "org.typelevel" %%% "discipline-munit" % "2.0.0-M3" % Test,
       "org.typelevel" %%% "munit-cats-effect" % "2.0.0-M3" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -220,9 +220,9 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     libraryDependencies ++= Seq(
       "org.scodec" %%% "scodec-bits" % "1.1.35",
       "org.typelevel" %%% "cats-core" % "2.9.0",
-      "org.typelevel" %%% "cats-effect" % "3.5-e3fbc49",
-      "org.typelevel" %%% "cats-effect-laws" % "3.5-e3fbc49" % Test,
-      "org.typelevel" %%% "cats-effect-testkit" % "3.5-e3fbc49" % Test,
+      "org.typelevel" %%% "cats-effect" % "3.5.0-RC2",
+      "org.typelevel" %%% "cats-effect-laws" % "3.5.0-RC2" % Test,
+      "org.typelevel" %%% "cats-effect-testkit" % "3.5.0-RC2" % Test,
       "org.typelevel" %%% "cats-laws" % "2.9.0" % Test,
       "org.typelevel" %%% "discipline-munit" % "2.0.0-M3" % Test,
       "org.typelevel" %%% "munit-cats-effect" % "2.0.0-M3" % Test,

--- a/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -141,7 +141,7 @@ private[net] trait SocketCompanionPlatform {
           else F.unit
         }
       writeMutex.lock.surround {
-        go(bytes.toByteBuffer)
+        F.delay(bytes.toByteBuffer).flatMap(go)
       }
     }
 

--- a/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -24,7 +24,7 @@ package io
 package net
 
 import com.comcast.ip4s.{IpAddress, SocketAddress}
-import cats.effect.{Async, Resource}
+import cats.effect.Async
 import cats.effect.std.Semaphore
 import cats.syntax.all._
 
@@ -35,12 +35,10 @@ import java.nio.{Buffer, ByteBuffer}
 private[net] trait SocketCompanionPlatform {
   private[net] def forAsync[F[_]: Async](
       ch: AsynchronousSocketChannel
-  ): Resource[F, Socket[F]] =
-    Resource.make {
-      (Semaphore[F](1), Semaphore[F](1)).mapN { (readSemaphore, writeSemaphore) =>
-        new AsyncSocket[F](ch, readSemaphore, writeSemaphore)
-      }
-    }(_ => Async[F].delay(if (ch.isOpen) ch.close else ()))
+  ): F[Socket[F]] =
+    (Semaphore[F](1), Semaphore[F](1)).mapN { (readSemaphore, writeSemaphore) =>
+      new AsyncSocket[F](ch, readSemaphore, writeSemaphore)
+    }
 
   private[net] abstract class BufferedReads[F[_]](
       readSemaphore: Semaphore[F]

--- a/io/jvm/src/main/scala/fs2/io/net/tls/TLSEngine.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/tls/TLSEngine.scala
@@ -28,7 +28,7 @@ import javax.net.ssl.{SSLEngine, SSLEngineResult}
 
 import cats.Applicative
 import cats.effect.kernel.{Async, Sync}
-import cats.effect.std.Semaphore
+import cats.effect.std.Mutex
 import cats.syntax.all._
 
 /** Provides the ability to establish and communicate over a TLS session.
@@ -65,9 +65,9 @@ private[tls] object TLSEngine {
         engine.getSession.getPacketBufferSize,
         engine.getSession.getApplicationBufferSize
       )
-      readSemaphore <- Semaphore[F](1)
-      writeSemaphore <- Semaphore[F](1)
-      handshakeSemaphore <- Semaphore[F](1)
+      readMutex <- Mutex[F]
+      writeMutex <- Mutex[F]
+      handshakeMutex <- Mutex[F]
       sslEngineTaskRunner = SSLEngineTaskRunner[F](engine)
     } yield new TLSEngine[F] {
       private val doLog: (() => String) => F[Unit] =
@@ -85,7 +85,7 @@ private[tls] object TLSEngine {
       def stopUnwrap = Sync[F].delay(engine.closeInbound()).attempt.void
 
       def write(data: Chunk[Byte]): F[Unit] =
-        writeSemaphore.permit.use(_ => write0(data))
+        writeMutex.lock.surround(write0(data))
 
       private def write0(data: Chunk[Byte]): F[Unit] =
         wrapBuffer.input(data) >> wrap
@@ -104,8 +104,8 @@ private[tls] object TLSEngine {
                       wrapBuffer.inputRemains
                         .flatMap(x => wrap.whenA(x > 0 && result.bytesConsumed > 0))
                     case _ =>
-                      handshakeSemaphore.permit
-                        .use(_ => stepHandshake(result, true)) >> wrap
+                      handshakeMutex.lock
+                        .surround(stepHandshake(result, true)) >> wrap
                   }
                 }
               case SSLEngineResult.Status.BUFFER_UNDERFLOW =>
@@ -124,7 +124,7 @@ private[tls] object TLSEngine {
         }
 
       def read(maxBytes: Int): F[Option[Chunk[Byte]]] =
-        readSemaphore.permit.use(_ => read0(maxBytes))
+        readMutex.lock.surround(read0(maxBytes))
 
       private def initialHandshakeDone: F[Boolean] =
         Sync[F].delay(engine.getSession.getCipherSuite != "SSL_NULL_WITH_NULL_NULL")
@@ -168,8 +168,8 @@ private[tls] object TLSEngine {
                   case SSLEngineResult.HandshakeStatus.FINISHED =>
                     unwrap(maxBytes)
                   case _ =>
-                    handshakeSemaphore.permit
-                      .use(_ => stepHandshake(result, false)) >> unwrap(
+                    handshakeMutex.lock
+                      .surround(stepHandshake(result, false)) >> unwrap(
                       maxBytes
                     )
                 }

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -22,7 +22,7 @@
 package fs2.io.net.unixsocket
 
 import cats.effect.kernel.{Async, Resource}
-import cats.effect.std.Semaphore
+import cats.effect.std.Mutex
 import cats.syntax.all._
 import com.comcast.ip4s.{IpAddress, SocketAddress}
 import fs2.{Chunk, Stream}
@@ -89,17 +89,17 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
       ch: SocketChannel
   ): Resource[F, Socket[F]] =
     Resource.make {
-      (Semaphore[F](1), Semaphore[F](1)).mapN { (readSemaphore, writeSemaphore) =>
-        new AsyncSocket[F](ch, readSemaphore, writeSemaphore)
+      (Mutex[F], Mutex[F]).mapN { (readMutex, writeMutex) =>
+        new AsyncSocket[F](ch, readMutex, writeMutex)
       }
     }(_ => Async[F].delay(if (ch.isOpen) ch.close else ()))
 
   private final class AsyncSocket[F[_]](
       ch: SocketChannel,
-      readSemaphore: Semaphore[F],
-      writeSemaphore: Semaphore[F]
+      readMutex: Mutex[F],
+      writeMutex: Mutex[F]
   )(implicit F: Async[F])
-      extends Socket.BufferedReads[F](readSemaphore) {
+      extends Socket.BufferedReads[F](readMutex) {
 
     def readChunk(buff: ByteBuffer): F[Int] =
       F.blocking(ch.read(buff))
@@ -110,7 +110,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
           if (buff.remaining <= 0) F.unit
           else go(buff)
         }
-      writeSemaphore.permit.use { _ =>
+      writeMutex.lock.surround {
         go(bytes.toByteBuffer)
       }
     }

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -111,7 +111,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
           else go(buff)
         }
       writeMutex.lock.surround {
-        go(bytes.toByteBuffer)
+        F.delay(bytes.toByteBuffer).flatMap(go)
       }
     }
 


### PR DESCRIPTION
1. Fixes for new `async` cancellation semantics. Also plug some resource leaks.
2. Prefer performance-enhanced `Mutex` to `Semaphore(1)`
3. Prefer `flatModify` to `modify(...).flatten`, fixes at least a few cancellation-related bugs