### PR TITLE
Don't test TLSv1, v1.1 on Node.js, fix JVM TLS error test

### DIFF
--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -97,7 +97,7 @@ class TLSSocketSuite extends TLSSuite {
             .assertEquals(httpOk)
         }
 
-      List(TLSv1, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`).foreach { protocol =>
+      List(`TLSv1.2`, `TLSv1.3`).foreach { protocol =>
         writesBeforeReading(protocol)
         readsBeforeWriting(protocol)
       }

--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -231,7 +231,7 @@ class TLSSocketSuite extends TLSSuite {
         .intercept[SSLException]
     }
 
-    List(TLSv1, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`).foreach { protocol =>
+    List(`TLSv1.2`, `TLSv1.3`).foreach { protocol =>
       test(s"$protocol - applicationProtocol and session") {
         val msg = Chunk.array(("Hello, world! " * 20000).getBytes)
 

--- a/io/jvm/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -172,7 +172,8 @@ class TLSSocketSuite extends TLSSuite {
             Stream.exec(clientSocket.write(msg)).onFinalize(clientSocket.endOfOutput) ++
               clientSocket.reads.take(msg.size.toLong)
 
-          client.concurrently(echoServer)
+          // client gets closed pipe error when server gets handshake ex
+          client.mask.concurrently(echoServer)
         }
         .compile
         .to(Chunk)


### PR DESCRIPTION
Seems that these are failing in CI now.