### PR TITLE
Refactor JVM unixsockets

### DIFF
--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/JnrUnixSockets.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/JnrUnixSockets.scala
@@ -21,7 +21,9 @@
 
 package fs2.io.net.unixsocket
 
-import cats.effect.kernel.Async
+import cats.effect.kernel.{Async, Resource}
+import cats.effect.syntax.all._
+import java.nio.channels.SocketChannel
 import jnr.unixsocket.{
   UnixServerSocketChannel,
   UnixSocketAddress => JnrUnixSocketAddress,
@@ -45,13 +47,21 @@ object JnrUnixSockets {
 private[unixsocket] class JnrUnixSocketsImpl[F[_]](implicit F: Async[F])
     extends UnixSockets.AsyncUnixSockets[F] {
   protected def openChannel(address: UnixSocketAddress) =
-    F.delay(UnixSocketChannel.open(new JnrUnixSocketAddress(address.path)))
+    Resource.make(F.blocking(UnixSocketChannel.open(new JnrUnixSocketAddress(address.path))))(ch =>
+      F.blocking(ch.close())
+    )
 
-  protected def openServerChannel(address: UnixSocketAddress) = F.blocking {
-    val serverChannel = UnixServerSocketChannel.open()
-    serverChannel.configureBlocking(false)
-    val sock = serverChannel.socket()
-    sock.bind(new JnrUnixSocketAddress(address.path))
-    (F.blocking(serverChannel.accept()), F.blocking(serverChannel.close()))
-  }
+  protected def openServerChannel(address: UnixSocketAddress) =
+    Resource
+      .make(F.blocking(UnixServerSocketChannel.open()))(ch => F.blocking(ch.close()))
+      .evalTap { sch =>
+        F.blocking(sch.socket().bind(new JnrUnixSocketAddress(address.path)))
+          .cancelable(F.blocking(sch.close()))
+      }
+      .map { sch =>
+        Resource.makeFull[F, SocketChannel] { poll =>
+          F.widen(poll(F.blocking(sch.accept).cancelable(F.blocking(sch.close()))))
+        }(ch => F.blocking(ch.close()))
+      }
+
 }

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -23,6 +23,7 @@ package fs2.io.net.unixsocket
 
 import cats.effect.kernel.{Async, Resource}
 import cats.effect.std.Mutex
+import cats.effect.syntax.all._
 import cats.syntax.all._
 import com.comcast.ip4s.{IpAddress, SocketAddress}
 import fs2.{Chunk, Stream}
@@ -42,57 +43,43 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
 
   private[unixsocket] abstract class AsyncUnixSockets[F[_]](implicit F: Async[F])
       extends UnixSockets[F] {
-    protected def openChannel(address: UnixSocketAddress): F[SocketChannel]
-    protected def openServerChannel(address: UnixSocketAddress): F[(F[SocketChannel], F[Unit])]
+    protected def openChannel(address: UnixSocketAddress): Resource[F, SocketChannel]
+    protected def openServerChannel(
+        address: UnixSocketAddress
+    ): Resource[F, Resource[F, SocketChannel]]
 
     def client(address: UnixSocketAddress): Resource[F, Socket[F]] =
-      Resource
-        .eval(openChannel(address))
-        .flatMap(makeSocket[F](_))
+      openChannel(address).evalMap(makeSocket[F](_))
 
     def server(
         address: UnixSocketAddress,
         deleteIfExists: Boolean,
         deleteOnClose: Boolean
     ): Stream[F, Socket[F]] = {
-      def setup =
-        Files[F].deleteIfExists(Path(address.path)).whenA(deleteIfExists) *>
-          openServerChannel(address)
-
-      def cleanup(closeChannel: F[Unit]): F[Unit] =
-        closeChannel *>
-          Files[F].deleteIfExists(Path(address.path)).whenA(deleteOnClose)
-
-      def acceptIncoming(accept: F[SocketChannel]): Stream[F, Socket[F]] = {
-        def go: Stream[F, Socket[F]] = {
-          def acceptChannel: F[SocketChannel] =
-            accept.map { ch =>
-              ch.configureBlocking(false)
-              ch
-            }
-
-          Stream.eval(acceptChannel.attempt).flatMap {
-            case Left(_)         => Stream.empty[F]
-            case Right(accepted) => Stream.resource(makeSocket(accepted))
-          } ++ go
-        }
-        go
+      val delete = Resource.make {
+        Files[F].deleteIfExists(Path(address.path)).whenA(deleteIfExists)
+      } { _ =>
+        Files[F].deleteIfExists(Path(address.path)).whenA(deleteOnClose)
       }
 
-      Stream
-        .resource(Resource.make(setup) { case (_, closeChannel) => cleanup(closeChannel) })
-        .flatMap { case (accept, _) => acceptIncoming(accept) }
+      Stream.resource(delete *> openServerChannel(address)).flatMap { accept =>
+        Stream
+          .resource(accept.attempt)
+          .flatMap {
+            case Left(_)         => Stream.empty[F]
+            case Right(accepted) => Stream.eval(makeSocket(accepted))
+          }
+          .repeat
+      }
     }
   }
 
   private def makeSocket[F[_]: Async](
       ch: SocketChannel
-  ): Resource[F, Socket[F]] =
-    Resource.make {
-      (Mutex[F], Mutex[F]).mapN { (readMutex, writeMutex) =>
-        new AsyncSocket[F](ch, readMutex, writeMutex)
-      }
-    }(_ => Async[F].delay(if (ch.isOpen) ch.close else ()))
+  ): F[Socket[F]] =
+    (Mutex[F], Mutex[F]).mapN { (readMutex, writeMutex) =>
+      new AsyncSocket[F](ch, readMutex, writeMutex)
+    }
 
   private final class AsyncSocket[F[_]](
       ch: SocketChannel,
@@ -102,14 +89,13 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
       extends Socket.BufferedReads[F](readMutex) {
 
     def readChunk(buff: ByteBuffer): F[Int] =
-      F.blocking(ch.read(buff))
+      F.blocking(ch.read(buff)).cancelable(close)
 
     def write(bytes: Chunk[Byte]): F[Unit] = {
       def go(buff: ByteBuffer): F[Unit] =
-        F.blocking(ch.write(buff)) >> {
-          if (buff.remaining <= 0) F.unit
-          else go(buff)
-        }
+        F.blocking(ch.write(buff)).cancelable(close) *>
+          F.delay(buff.remaining <= 0).ifM(F.unit, go(buff))
+
       writeMutex.lock.surround {
         F.delay(bytes.toByteBuffer).flatMap(go)
       }
@@ -120,7 +106,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
     private def raiseIpAddressError[A]: F[A] =
       F.raiseError(new UnsupportedOperationException("UnixSockets do not use IP addressing"))
 
-    def isOpen: F[Boolean] = F.blocking(ch.isOpen)
+    def isOpen: F[Boolean] = F.blocking(ch.isOpen())
     def close: F[Unit] = F.blocking(ch.close())
     def endOfOutput: F[Unit] =
       F.blocking {


### PR DESCRIPTION
I'm working on supporting HTTP/2 over unix sockets in Ember and was experiencing a lot of strange issues e.g. non-deterministic behavior, reads returning empty chunks, hanging.

The bad news was that I was unable to replicate these issues as unit tests 🤔 this is where I started from, focused on just the empty read issue, before I gave up and went for the refactor.

The good news is that I published a snapshot and (spoiler alert) was surprised to discover that this refactor somehow fixed everything 😅 wasn't really expecting that.

This refactor mostly addresses these three issues:

1. Not switching the sockets to non-blocking mode. I suspect that this was what was causing the empty reads bug in Ember. Non-blocking mode is only useful if you are using a selector to poll for events on the socket. Otherwise, you have no way of knowing when there _are_ bytes available on the socket, so you may get empty reads / no-op writes, and be forced to degrade to a busy-loop, which is much worse than doing a blocking read (or write) to begin with.

    Note that when the Cats Effect polling system stuff lands, we will be able to register the JDK unix sockets with the polling system and thus have non-blocking reads/writes, so that's something to look forward to.

2. Carefully wrapping a socket in a resource as soon as it is opened, so that it is guaranteed to be closed in all instances. Attempting to tack on other side-effects as part of the `acquire` phase (e.g., binding or connecting) may lead to a resource leak if those actions fail, because then the socket is never returned, which means it can never be closed, etc.

3. Properly suspending side-effects e.g. interactions with `ByteBuffers`, `blocking`, etc.