### PR TITLE
Added writeUtf8 and writeUtf8Lines

### DIFF
--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -264,6 +264,8 @@ private[fs2] trait FilesCompanionPlatform {
     override def isSameFile(path1: Path, path2: Path): F[Boolean] =
       F.pure(path1.absolute == path2.absolute)
 
+    override val lineSeparator: String = facade.os.EOL()
+
     override def list(path: Path): Stream[F, Path] =
       Stream
         .bracket(F.fromPromise(F.delay(facade.fs.promises.opendir(path.toString))))(dir =>

--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -264,7 +264,7 @@ private[fs2] trait FilesCompanionPlatform {
     override def isSameFile(path1: Path, path2: Path): F[Boolean] =
       F.pure(path1.absolute == path2.absolute)
 
-    override val lineSeparator: String = facade.os.EOL
+    override def lineSeparator: String = facade.os.EOL
 
     override def list(path: Path): Stream[F, Path] =
       Stream

--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -264,7 +264,7 @@ private[fs2] trait FilesCompanionPlatform {
     override def isSameFile(path1: Path, path2: Path): F[Boolean] =
       F.pure(path1.absolute == path2.absolute)
 
-    override val lineSeparator: String = facade.os.EOL()
+    override val lineSeparator: String = facade.os.EOL
 
     override def list(path: Path): Stream[F, Path] =
       Stream

--- a/io/js/src/main/scala/fs2/io/internal/facade/os.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/os.scala
@@ -42,6 +42,10 @@ package object os {
   @JSImport("os", "networkInterfaces")
   private[io] def networkInterfaces(): js.Dictionary[js.Array[NetworkInterfaceInfo]] = js.native
 
+  @js.native
+  @JSImport("os", "EOL")
+  private[io] def EOL(): String = js.native
+
 }
 
 package os {

--- a/io/js/src/main/scala/fs2/io/internal/facade/os.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/os.scala
@@ -44,7 +44,7 @@ package object os {
 
   @js.native
   @JSImport("os", "EOL")
-  private[io] def EOL(): String = js.native
+  private[io] def EOL: String = js.native
 
 }
 

--- a/io/jvm-native/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -291,6 +291,8 @@ private[file] trait FilesCompanionPlatform {
     def isSameFile(path1: Path, path2: Path): F[Boolean] =
       Sync[F].blocking(JFiles.isSameFile(path1.toNioPath, path2.toNioPath))
 
+    val lineSeparator: String = System.lineSeparator()
+
     def list(path: Path): Stream[F, Path] =
       _runJavaCollectionResource[JStream[JPath]](
         Sync[F].blocking(JFiles.list(path.toNioPath)),

--- a/io/jvm-native/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -291,7 +291,7 @@ private[file] trait FilesCompanionPlatform {
     def isSameFile(path1: Path, path2: Path): F[Boolean] =
       Sync[F].blocking(JFiles.isSameFile(path1.toNioPath, path2.toNioPath))
 
-    val lineSeparator: String = System.lineSeparator()
+    def lineSeparator: String = System.lineSeparator()
 
     def list(path: Path): Stream[F, Path] =
       _runJavaCollectionResource[JStream[JPath]](

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -241,7 +241,7 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
   def isSameFile(path1: Path, path2: Path): F[Boolean]
 
   /** Returns the line separator for the specific OS */
-  val lineSeparator: String
+  def lineSeparator: String
 
   /** Gets the contents of the specified directory. */
   def list(path: Path): Stream[F, Path]

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -269,7 +269,10 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
   def readAll(path: Path, chunkSize: Int, flags: Flags): Stream[F, Byte]
 
   /** Returns a `ReadCursor` for the specified path, using the supplied flags when opening the file. */
-  def readCursor(path: Path, flags: Flags): Resource[F, ReadCursor[F]]
+  def readCursor(path: Path, flags: Flags): Resource[F, ReadCursor[F]] =
+    open(path, flags.addIfAbsent(Flag.Read)).map { fileHandle =>
+      ReadCursor(fileHandle, 0L)
+    }
 
   /** Reads a range of data synchronously from the file at the specified path.
     * `start` is inclusive, `end` is exclusive, so when `start` is 0 and `end` is 2,
@@ -278,10 +281,10 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
   def readRange(path: Path, chunkSize: Int, start: Long, end: Long): Stream[F, Byte]
 
   /** Reads all bytes from the file specified and decodes them as a utf8 string. */
-  def readUtf8(path: Path): Stream[F, String]
+  def readUtf8(path: Path): Stream[F, String] = readAll(path).through(text.utf8.decode)
 
   /** Reads all bytes from the file specified and decodes them as utf8 lines. */
-  def readUtf8Lines(path: Path): Stream[F, String]
+  def readUtf8Lines(path: Path): Stream[F, String] = readUtf8(path).through(text.lines)
 
   /** Returns the real path i.e. the actual location of `path`.
     * The precise definition of this method is implementation dependent but in general
@@ -421,7 +424,8 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
   /** Writes to the specified file as an utf8 string using
     * the specified flags to open the file.
     */
-  def writeUtf8(path: Path, flags: Flags): Pipe[F, String, Nothing]
+  def writeUtf8(path: Path, flags: Flags): Pipe[F, String, Nothing] = in =>
+    in.through(text.utf8.encode).through(writeAll(path, flags))
 
   /** Writes each string to the specified file as utf8 lines.
     *
@@ -434,7 +438,8 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
   /** Writes each string to the specified file as utf8 lines
     * using the specified flags to open the file.
     */
-  def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing]
+  def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing] = in =>
+    in.through(text.lines).through(writeUtf8(path, flags))
 }
 
 object Files extends FilesCompanionPlatform {
@@ -445,21 +450,10 @@ object Files extends FilesCompanionPlatform {
         cursor.readAll(chunkSize).void.stream
       }
 
-    def readCursor(path: Path, flags: Flags): Resource[F, ReadCursor[F]] =
-      open(path, flags.addIfAbsent(Flag.Read)).map { fileHandle =>
-        ReadCursor(fileHandle, 0L)
-      }
-
     def readRange(path: Path, chunkSize: Int, start: Long, end: Long): Stream[F, Byte] =
       Stream.resource(readCursor(path, Flags.Read)).flatMap { cursor =>
         cursor.seek(start).readUntil(chunkSize, end).void.stream
       }
-
-    def readUtf8(path: Path): Stream[F, String] =
-      readAll(path).through(text.utf8.decode)
-
-    def readUtf8Lines(path: Path): Stream[F, String] =
-      readUtf8(path).through(text.lines)
 
     def tail(
         path: Path,
@@ -599,12 +593,6 @@ object Files extends FilesCompanionPlatform {
             }
           }
     }
-
-    def writeUtf8(path: Path, flags: Flags): Pipe[F, String, Nothing] =
-      _.through(text.utf8.encode).through(writeAll(path, flags))
-
-    def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing] =
-      _.through(text.lines).through(writeUtf8(path, flags))
   }
 
   def apply[F[_]](implicit F: Files[F]): Files[F] = F

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -240,6 +240,9 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
   /** Returns true if the supplied paths reference the same file. */
   def isSameFile(path1: Path, path2: Path): F[Boolean]
 
+  /** Returns the line separator for the specific OS */
+  val lineSeparator: String
+
   /** Gets the contents of the specified directory. */
   def list(path: Path): Stream[F, Path]
 
@@ -439,7 +442,7 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
     * using the specified flags to open the file.
     */
   def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing] = in =>
-    in.intersperse("\n").through(writeUtf8(path, flags))
+    in.intersperse(lineSeparator).through(writeUtf8(path, flags))
 }
 
 object Files extends FilesCompanionPlatform {

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -433,13 +433,13 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
     * Use `writeUtf8Lines(path, Flags.Append)` to append to the end
     * of the file, or pass other flags to further customize behavior.
     */
-  def writeUtf8Lines(path: Path): Pipe[F, String, Nothing] = writeUtf8(path, Flags.Write)
+  def writeUtf8Lines(path: Path): Pipe[F, String, Nothing] = writeUtf8Lines(path, Flags.Write)
 
   /** Writes each string to the specified file as utf8 lines
     * using the specified flags to open the file.
     */
   def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing] = in =>
-    in.through(text.lines).through(writeUtf8(path, flags))
+    in.intersperse("\n").through(writeUtf8(path, flags))
 }
 
 object Files extends FilesCompanionPlatform {

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -409,6 +409,32 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
       limit: Long,
       flags: Flags
   ): Pipe[F, Byte, Nothing]
+
+  /** Writes to the specified file as an utf8 string.
+    *
+    * The file is created if it does not exist and is truncated.
+    * Use `writeUtf8(path, Flags.Append)` to append to the end of
+    * the file, or pass other flags to further customize behavior.
+    */
+  def writeUtf8(path: Path): Pipe[F, String, Nothing] = writeUtf8(path, Flags.Write)
+
+  /** Writes to the specified file as an utf8 string using
+    * the specified flags to open the file.
+    */
+  def writeUtf8(path: Path, flags: Flags): Pipe[F, String, Nothing]
+
+  /** Writes each string to the specified file as utf8 lines.
+    *
+    * The file is created if it does not exist and is truncated.
+    * Use `writeUtf8Lines(path, Flags.Append)` to append to the end
+    * of the file, or pass other flags to further customize behavior.
+    */
+  def writeUtf8Lines(path: Path): Pipe[F, String, Nothing] = writeUtf8(path, Flags.Write)
+
+  /** Writes each string to the specified file as utf8 lines
+    * using the specified flags to open the file.
+    */
+  def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing]
 }
 
 object Files extends FilesCompanionPlatform {
@@ -573,6 +599,12 @@ object Files extends FilesCompanionPlatform {
             }
           }
     }
+
+    def writeUtf8(path: Path, flags: Flags): Pipe[F, String, Nothing] =
+      _.through(text.utf8.encode).through(writeAll(path, flags))
+
+    def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing] =
+      _.through(text.lines).through(writeUtf8(path, flags))
   }
 
   def apply[F[_]](implicit F: Files[F]): Files[F] = F

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -442,7 +442,7 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
     * using the specified flags to open the file.
     */
   def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing] = in =>
-    in.intersperse(lineSeparator).through(writeUtf8(path, flags))
+    in.flatMap(s => Stream[F, String](s, lineSeparator)).through(writeUtf8(path, flags))
 }
 
 object Files extends FilesCompanionPlatform {

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -138,6 +138,36 @@ class FilesSuite extends Fs2IoSuite with BaseFileSuite {
         .compile
         .drain
     }
+
+    test("writeUtf8") {
+      Stream
+        .resource(tempFile)
+        .flatMap { path =>
+          Stream("Hello", " world!")
+            .covary[IO]
+            .through(Files[IO].writeUtf8(path)) ++ Files[IO]
+            .readAll(path)
+            .through(text.utf8.decode)
+        }
+        .compile
+        .foldMonoid
+        .assertEquals("Hello world!")
+    }
+
+    test("writeUtf8Lines") {
+      Stream
+        .resource(tempFile)
+        .flatMap { path =>
+          Stream("foo", "bar")
+            .covary[IO]
+            .through(Files[IO].writeUtf8Lines(path)) ++ Files[IO]
+            .readUtf8(path)
+        }
+        .compile
+        .foldMonoid
+        .assertEquals("""|foo
+                         |bar""".stripMargin)
+    }
   }
 
   group("tail") {

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -166,7 +166,8 @@ class FilesSuite extends Fs2IoSuite with BaseFileSuite {
         .compile
         .foldMonoid
         .assertEquals("""|foo
-                         |bar""".stripMargin)
+                         |bar
+                         |""".stripMargin)
     }
   }
 


### PR DESCRIPTION
Hello!
That's my first contribution to fs2, so I hope everything is where it should be.
I added two helpers to `Files[F]` that mirror the ones already present for `readUtf8` and `readUtf8Lines`, shamelessly stealing the idea from [this](https://github.com/typelevel/toolkit/issues/15#issuecomment-1464156091) @armanbilge comment.
I haven't found any unit tests for `readUtf8` and `readUtf8Lines` but for their components, and since `writeUtf8` and `writeUtf8Lines` are built on the same ones, I haven't added any.

It may be worth adding these new combinators to fs2 2.5.x and adding an example like `Stream.emit("foo").through(Files[IO].writeUtf8Lines(Path(...)))` to the documentation.