### PR TITLE
Relax status check for google TLS tests

### DIFF
--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -55,7 +55,7 @@ class TLSSocketSuite extends TLSSuite {
         } yield tlsSocket
 
       val googleDotCom = "GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n"
-      val httpOk = "HTTP/1.1 200 OK"
+      val httpOk = "HTTP/1.1"
 
       def writesBeforeReading(protocol: SecureContext.SecureVersion) =
         test(s"$protocol - client writes before reading") {
@@ -74,6 +74,7 @@ class TLSSocketSuite extends TLSSuite {
             .head
             .compile
             .string
+            .map(_.take(httpOk.length))
             .assertEquals(httpOk)
         }
 
@@ -94,6 +95,7 @@ class TLSSocketSuite extends TLSSuite {
             .head
             .compile
             .string
+            .map(_.take(httpOk.length))
             .assertEquals(httpOk)
         }
 

--- a/io/jvm/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -56,7 +56,7 @@ class TLSSocketSuite extends TLSSuite {
         } yield tlsSocket
 
       val googleDotCom = "GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n"
-      val httpOk = "HTTP/1.1 200 OK"
+      val httpOk = "HTTP/1.1"
 
       def writesBeforeReading(protocol: String) =
         test(s"$protocol - client writes before reading") {
@@ -75,6 +75,7 @@ class TLSSocketSuite extends TLSSuite {
             .head
             .compile
             .string
+            .map(_.take(httpOk.length))
             .assertEquals(httpOk)
         }
 
@@ -95,6 +96,7 @@ class TLSSocketSuite extends TLSSuite {
             .head
             .compile
             .string
+            .map(_.take(httpOk.length))
             .assertEquals(httpOk)
         }
 

--- a/io/native/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/native/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -51,7 +51,7 @@ class TLSSocketSuite extends TLSSuite {
         } yield tlsSocket
 
       val googleDotCom = "GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n"
-      val httpOk = "HTTP/1.1 200 OK"
+      val httpOk = "HTTP/1.1"
 
       def writesBeforeReading(protocol: String) =
         test(s"$protocol - client writes before reading") {
@@ -70,6 +70,7 @@ class TLSSocketSuite extends TLSSuite {
             .head
             .compile
             .string
+            .map(_.take(httpOk.length))
             .assertEquals(httpOk)
         }
 
@@ -90,6 +91,7 @@ class TLSSocketSuite extends TLSSuite {
             .head
             .compile
             .string
+            .map(_.take(httpOk.length))
             .assertEquals(httpOk)
         }
 


### PR DESCRIPTION
Receiving any HTTP response, regardless of status code, indicates that we've successfully established a TLS connection, right?