### PR TITLE
Implicit instances for `IO` only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -188,7 +188,8 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[DirectMissingMethodProblem](
     "fs2.io.net.DatagramSocketGroupCompanionPlatform#AsyncDatagramSocketGroup.this"
-  )
+  ),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.file.Watcher#DefaultWatcher.this")
 )
 
 lazy val root = tlCrossRootProject

--- a/core/jvm-native/src/main/scala/fs2/compression/CompressionPlatform.scala
+++ b/core/jvm-native/src/main/scala/fs2/compression/CompressionPlatform.scala
@@ -118,7 +118,13 @@ private[compression] trait CompressionPlatform[F[_]] { self: Compression[F] =>
 
 }
 
-private[compression] trait CompressionCompanionPlatform {
+private trait CompressionCompanionPlatformLowPriority { this: CompressionCompanionPlatform =>
+  @deprecated("Add Compression constraint or use forSync", "3.7.0")
+  implicit def implicitForSync[F[_]: Sync]: Compression[F] = forSync
+}
+
+private[compression] trait CompressionCompanionPlatform
+    extends CompressionCompanionPlatformLowPriority {
 
   implicit def forIO: Compression[IO] = forSync
 

--- a/core/jvm-native/src/main/scala/fs2/compression/CompressionPlatform.scala
+++ b/core/jvm-native/src/main/scala/fs2/compression/CompressionPlatform.scala
@@ -22,6 +22,7 @@
 package fs2
 package compression
 
+import cats.effect.IO
 import cats.effect.kernel.Sync
 
 import java.io.EOFException
@@ -119,7 +120,9 @@ private[compression] trait CompressionPlatform[F[_]] { self: Compression[F] =>
 
 private[compression] trait CompressionCompanionPlatform {
 
-  implicit def forSync[F[_]](implicit F: Sync[F]): Compression[F] =
+  implicit def forIO: Compression[IO] = forSync
+
+  def forSync[F[_]](implicit F: Sync[F]): Compression[F] =
     new Compression.UnsealedCompression[F] {
 
       def deflate(deflateParams: DeflateParams): Pipe[F, Byte, Byte] =

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -36,6 +36,7 @@ import scala.concurrent.duration._
 import scala.concurrent.TimeoutException
 
 class StreamCombinatorsSuite extends Fs2Suite {
+  override def munitIOTimeout = 1.minute
 
   group("awakeEvery") {
     test("basic") {

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -1005,72 +1005,86 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   test("metered should not start immediately") {
-    Stream
-      .emit[IO, Int](1)
-      .repeatN(10)
-      .metered(1.second)
-      .interruptAfter(500.milliseconds)
-      .assertEmpty()
+    TestControl.executeEmbed {
+      Stream
+        .emit[IO, Int](1)
+        .repeatN(10)
+        .metered(1.second)
+        .interruptAfter(500.milliseconds)
+        .assertEmpty()
+    }
   }
 
   test("meteredStartImmediately should start immediately") {
-    Stream
-      .emit[IO, Int](1)
-      .repeatN(10)
-      .meteredStartImmediately(1.second)
-      .interruptAfter(500.milliseconds)
-      .assertEmits(List(1))
+    TestControl.executeEmbed {
+      Stream
+        .emit[IO, Int](1)
+        .repeatN(10)
+        .meteredStartImmediately(1.second)
+        .interruptAfter(500.milliseconds)
+        .assertEmits(List(1))
+    }
   }
 
   test("spaced should start immediately if startImmediately is not set") {
-    Stream
-      .emit[IO, Int](1)
-      .repeatN(10)
-      .spaced(1.second)
-      .interruptAfter(500.milliseconds)
-      .assertEmits(List(1))
+    TestControl.executeEmbed {
+      Stream
+        .emit[IO, Int](1)
+        .repeatN(10)
+        .spaced(1.second)
+        .interruptAfter(500.milliseconds)
+        .assertEmits(List(1))
+    }
   }
 
   test("spaced should not start immediately if startImmediately is set to false") {
-    Stream
-      .emit[IO, Int](1)
-      .repeatN(10)
-      .spaced(1.second, startImmediately = false)
-      .interruptAfter(500.milliseconds)
-      .assertEmpty()
+    TestControl.executeEmbed {
+      Stream
+        .emit[IO, Int](1)
+        .repeatN(10)
+        .spaced(1.second, startImmediately = false)
+        .interruptAfter(500.milliseconds)
+        .assertEmpty()
+    }
   }
 
   test("metered should not wait between events that last longer than the rate") {
-    Stream
-      .eval[IO, Int](IO.sleep(1.second).as(1))
-      .repeatN(10)
-      .metered(1.second)
-      .interruptAfter(4500.milliseconds)
-      .compile
-      .toList
-      .map(results => assert(results.size == 3))
+    TestControl.executeEmbed {
+      Stream
+        .eval[IO, Int](IO.sleep(1.second).as(1))
+        .repeatN(10)
+        .metered(1.second)
+        .interruptAfter(4500.milliseconds)
+        .compile
+        .toList
+        .map(results => assert(results.size == 3))
+    }
   }
 
   test("meteredStartImmediately should not wait between events that last longer than the rate") {
-    Stream
-      .eval[IO, Int](IO.sleep(1.second).as(1))
-      .repeatN(10)
-      .meteredStartImmediately(1.second)
-      .interruptAfter(4500.milliseconds)
-      .compile
-      .toList
-      .map(results => assert(results.size == 4))
+    TestControl.executeEmbed {
+      Stream
+        .eval[IO, Int](IO.sleep(1.second).as(1))
+        .repeatN(10)
+        .meteredStartImmediately(1.second)
+        .interruptAfter(4500.milliseconds)
+        .compile
+        .toList
+        .map(results => assert(results.size == 4))
+    }
   }
 
   test("spaced should wait between events") {
-    Stream
-      .eval[IO, Int](IO.sleep(1.second).as(1))
-      .repeatN(10)
-      .spaced(1.second)
-      .interruptAfter(4500.milliseconds)
-      .compile
-      .toList
-      .map(results => assert(results.size == 2))
+    TestControl.executeEmbed {
+      Stream
+        .eval[IO, Int](IO.sleep(1.second).as(1))
+        .repeatN(10)
+        .spaced(1.second)
+        .interruptAfter(4500.milliseconds)
+        .compile
+        .toList
+        .map(results => assert(results.size == 2))
+    }
   }
 
   test("mapAsyncUnordered") {

--- a/io/js-jvm/src/main/scala/fs2/io/net/Network.scala
+++ b/io/js-jvm/src/main/scala/fs2/io/net/Network.scala
@@ -23,7 +23,6 @@ package fs2
 package io
 package net
 
-import cats.effect.kernel.Async
 import fs2.io.net.tls.TLSContext
 
 /** Provides the ability to work with TCP, UDP, and TLS.
@@ -59,13 +58,8 @@ sealed trait Network[F[_]]
   def tlsContext: TLSContext.Builder[F]
 }
 
-object Network extends NetworkCompanionPlatform with NetworkLowPriority {
+object Network extends NetworkCompanionPlatform {
   private[fs2] trait UnsealedNetwork[F[_]] extends Network[F]
 
   def apply[F[_]](implicit F: Network[F]): F.type = F
-}
-
-private[fs2] trait NetworkLowPriority { this: Network.type =>
-  @deprecated("Add Network constraint or use forAsync", "3.7.0")
-  implicit def implicitForAsync[F[_]: Async]: Network[F] = forAsync
 }

--- a/io/js-jvm/src/main/scala/fs2/io/net/Network.scala
+++ b/io/js-jvm/src/main/scala/fs2/io/net/Network.scala
@@ -23,6 +23,7 @@ package fs2
 package io
 package net
 
+import cats.effect.kernel.Async
 import fs2.io.net.tls.TLSContext
 
 /** Provides the ability to work with TCP, UDP, and TLS.
@@ -58,8 +59,13 @@ sealed trait Network[F[_]]
   def tlsContext: TLSContext.Builder[F]
 }
 
-object Network extends NetworkCompanionPlatform {
+object Network extends NetworkCompanionPlatform with NetworkLowPriority {
   private[fs2] trait UnsealedNetwork[F[_]] extends Network[F]
 
   def apply[F[_]](implicit F: Network[F]): F.type = F
+}
+
+private[fs2] trait NetworkLowPriority { this: Network.type =>
+  @deprecated("Add Network constraint or use forAsync", "3.7.0")
+  implicit def implicitForAsync[F[_]: Async]: Network[F] = forAsync
 }

--- a/io/js/src/main/scala/fs2/io/compressionplatform.scala
+++ b/io/js/src/main/scala/fs2/io/compressionplatform.scala
@@ -22,6 +22,7 @@
 package fs2
 package io
 
+import cats.effect.IO
 import cats.effect.kernel.Async
 import cats.syntax.all._
 import fs2.compression.Compression
@@ -35,7 +36,10 @@ private[io] trait compressionplatform {
 
   class ZipException(msg: String) extends IOException(msg)
 
-  implicit def fs2ioCompressionForAsync[F[_]](implicit F: Async[F]): Compression[F] =
+  implicit def fs2ioCompressionForIO: Compression[IO] =
+    fs2ioCompressionForAsync
+
+  def fs2ioCompressionForAsync[F[_]](implicit F: Async[F]): Compression[F] =
     new Compression.UnsealedCompression[F] {
 
       def deflate(deflateParams: DeflateParams): Pipe[F, Byte, Byte] =

--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -36,7 +36,7 @@ private[file] trait FilesPlatform[F[_]]
 
 private[fs2] trait FilesCompanionPlatform {
 
-  implicit def forAsync[F[_]: Async]: Files[F] = new AsyncFiles[F]
+  def forAsync[F[_]: Async]: Files[F] = new AsyncFiles[F]
 
   private final class AsyncFiles[F[_]](implicit F: Async[F]) extends UnsealedFiles[F] {
     private def combineFlags(flags: Flags): Double =

--- a/io/js/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -23,6 +23,7 @@ package fs2
 package io
 package net
 
+import cats.effect.IO
 import cats.effect.kernel.Async
 import cats.effect.kernel.Resource
 import com.comcast.ip4s.Host
@@ -34,7 +35,9 @@ import fs2.io.net.tls.TLSContext
 private[net] trait NetworkPlatform[F[_]]
 
 private[net] trait NetworkCompanionPlatform { self: Network.type =>
-  implicit def forAsync[F[_]](implicit F: Async[F]): Network[F] =
+  implicit def forIO: Network[IO] = forAsync
+
+  def forAsync[F[_]](implicit F: Async[F]): Network[F] =
     new UnsealedNetwork[F] {
 
       private lazy val socketGroup = SocketGroup.forAsync[F]

--- a/io/js/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -34,7 +34,7 @@ import fs2.io.net.tls.TLSContext
 
 private[net] trait NetworkPlatform[F[_]]
 
-private[net] trait NetworkCompanionPlatform { self: Network.type =>
+private[net] trait NetworkCompanionPlatform extends NetworkLowPriority { self: Network.type =>
   implicit def forIO: Network[IO] = forAsync
 
   def forAsync[F[_]](implicit F: Async[F]): Network[F] =

--- a/io/js/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -22,6 +22,7 @@
 package fs2
 package io.net.unixsocket
 
+import cats.effect.IO
 import cats.effect.kernel.Async
 import cats.effect.kernel.Resource
 import cats.effect.std.Dispatcher
@@ -35,8 +36,9 @@ import fs2.io.internal.facade
 import scala.scalajs.js
 
 private[unixsocket] trait UnixSocketsCompanionPlatform {
+  implicit def forIO: UnixSockets[IO] = forAsync
 
-  implicit def forAsync[F[_]](implicit F: Async[F]): UnixSockets[F] =
+  def forAsync[F[_]](implicit F: Async[F]): UnixSockets[F] =
     new UnixSockets[F] {
 
       override def client(address: UnixSocketAddress): Resource[F, Socket[F]] =

--- a/io/js/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -36,9 +36,12 @@ import fs2.io.internal.facade
 import scala.scalajs.js
 
 private[unixsocket] trait UnixSocketsCompanionPlatform {
-  implicit def forIO: UnixSockets[IO] = forAsync
+  implicit def forIO: UnixSockets[IO] = forAsyncAndFiles
 
   def forAsync[F[_]](implicit F: Async[F]): UnixSockets[F] =
+    forAsyncAndFiles(Files.forAsync(F), F)
+
+  def forAsyncAndFiles[F[_]: Files](implicit F: Async[F]): UnixSockets[F] =
     new UnixSockets[F] {
 
       override def client(address: UnixSocketAddress): Resource[F, Socket[F]] =

--- a/io/jvm-native/src/main/scala/fs2/io/compressionplatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/compressionplatform.scala
@@ -22,6 +22,7 @@
 package fs2
 package io
 
+import cats.effect.IO
 import cats.effect.kernel.Sync
 import fs2.compression.Compression
 
@@ -29,5 +30,7 @@ private[io] trait compressionplatform {
 
   type ZipException = java.util.zip.ZipException
 
-  implicit def fs2ioCompressionForSync[F[_]: Sync]: Compression[F] = Compression.forSync
+  implicit def fs2ioCompressionForIO: Compression[IO] = Compression.forSync
+
+  def fs2ioCompressionForSync[F[_]: Sync]: Compression[F] = Compression.forSync
 }

--- a/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -70,11 +70,11 @@ private[file] trait FileHandlePlatform[F[_]] {
 private[file] trait FileHandleCompanionPlatform {
   @deprecated("Use Files[F].open", "3.0.0")
   def fromPath[F[_]: Async](path: JPath, flags: Seq[OpenOption]): Resource[F, FileHandle[F]] =
-    Files[F].open(path, flags)
+    Files.forAsync[F].open(path, flags)
 
   @deprecated("Use Files[F].openFileChannel", "3.0.0")
   def fromFileChannel[F[_]: Async](channel: F[FileChannel]): Resource[F, FileHandle[F]] =
-    Files[F].openFileChannel(channel)
+    Files.forAsync[F].openFileChannel(channel)
 
   /** Creates a `FileHandle[F]` from a `java.nio.channels.FileChannel`. */
   private[file] def make[F[_]](

--- a/io/jvm-native/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -80,7 +80,7 @@ private[file] trait FilesPlatform[F[_]] extends DeprecatedFilesApi[F] { self: Fi
 
 private[file] trait FilesCompanionPlatform {
 
-  implicit def forAsync[F[_]: Async]: Files[F] = new AsyncFiles[F]
+  def forAsync[F[_]: Async]: Files[F] = new AsyncFiles[F]
 
   private case class NioFileKey(value: AnyRef) extends FileKey
 
@@ -369,7 +369,7 @@ private[file] trait FilesCompanionPlatform {
         .resource(Resource.fromAutoCloseable(javaCollection))
         .flatMap(ds => Stream.fromBlockingIterator[F](collectionIterator(ds), pathStreamChunkSize))
 
-    def createWatcher: Resource[F, Watcher[F]] = Watcher.default
+    def createWatcher: Resource[F, Watcher[F]] = Watcher.default(this, F)
 
     def watch(
         path: Path,
@@ -378,7 +378,7 @@ private[file] trait FilesCompanionPlatform {
         pollTimeout: FiniteDuration
     ): Stream[F, Watcher.Event] =
       Stream
-        .resource(Watcher.default)
+        .resource(createWatcher)
         .evalTap(_.watch(path, types, modifiers))
         .flatMap(_.events(pollTimeout))
   }

--- a/io/jvm-native/src/main/scala/fs2/io/file/ReadCursorPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/ReadCursorPlatform.scala
@@ -32,5 +32,5 @@ private[file] trait ReadCursorCompanionPlatform {
       path: JPath,
       flags: Seq[OpenOption] = Nil
   ): Resource[F, ReadCursor[F]] =
-    Files[F].readCursor(path, flags)
+    Files.forAsync[F].readCursor(path, flags)
 }

--- a/io/jvm-native/src/main/scala/fs2/io/file/WriteCursorPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/WriteCursorPlatform.scala
@@ -33,13 +33,13 @@ private[file] trait WriteCursorCompanionPlatform {
       file: FileHandle[F],
       append: Boolean
   ): F[WriteCursor[F]] =
-    Files[F].writeCursorFromFileHandle(file, append)
+    Files.forAsync[F].writeCursorFromFileHandle(file, append)
 
   @deprecated("Use Files[F].writeCursor", "3.0.0")
   def fromPath[F[_]: Async](
       path: JPath,
       flags: Seq[OpenOption] = List(StandardOpenOption.CREATE)
   ): Resource[F, WriteCursor[F]] =
-    Files[F].writeCursor(path, flags)
+    Files.forAsync[F].writeCursor(path, flags)
 
 }

--- a/io/jvm-native/src/main/scala/fs2/io/file/file.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/file.scala
@@ -47,7 +47,7 @@ package object file {
   def readAll[F[_]: Async](
       path: JPath,
       chunkSize: Int
-  ): Stream[F, Byte] = Files[F].readAll(path, chunkSize)
+  ): Stream[F, Byte] = Files.forAsync[F].readAll(path, chunkSize)
 
   /** Reads a range of data synchronously from the file at the specified `java.nio.file.Path`.
     * `start` is inclusive, `end` is exclusive, so when `start` is 0 and `end` is 2,
@@ -59,7 +59,7 @@ package object file {
       chunkSize: Int,
       start: Long,
       end: Long
-  ): Stream[F, Byte] = Files[F].readRange(path, chunkSize, start, end)
+  ): Stream[F, Byte] = Files.forAsync[F].readRange(path, chunkSize, start, end)
 
   /** Returns an infinite stream of data from the file at the specified path.
     * Starts reading from the specified offset and upon reaching the end of the file,
@@ -76,7 +76,7 @@ package object file {
       chunkSize: Int,
       offset: Long = 0L,
       pollDelay: FiniteDuration = 1.second
-  ): Stream[F, Byte] = Files[F].tail(path, chunkSize, offset, pollDelay)
+  ): Stream[F, Byte] = Files.forAsync[F].tail(path, chunkSize, offset, pollDelay)
 
   /** Writes all data to the file at the specified `java.nio.file.Path`.
     *
@@ -86,7 +86,7 @@ package object file {
   def writeAll[F[_]: Async](
       path: JPath,
       flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
-  ): Pipe[F, Byte, Nothing] = Files[F].writeAll(path, flags)
+  ): Pipe[F, Byte, Nothing] = Files.forAsync[F].writeAll(path, flags)
 
   /** Writes all data to a sequence of files, each limited in size to `limit`.
     *
@@ -101,7 +101,7 @@ package object file {
       limit: Long,
       flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
   )(implicit F: Async[F]): Pipe[F, Byte, Nothing] =
-    Files[F].writeRotate(computePath, limit, flags)
+    Files.forAsync[F].writeRotate(computePath, limit, flags)
 
   /** Creates a [[Watcher]] for the default file system.
     *
@@ -110,7 +110,7 @@ package object file {
     */
   @deprecated("Use Files[F].watcher", "3.0.0")
   def watcher[F[_]](implicit F: Async[F]): Resource[F, DeprecatedWatcher[F]] =
-    Files[F].watcher
+    Files.forAsync[F].watcher
 
   /** Watches a single path.
     *
@@ -123,7 +123,7 @@ package object file {
       modifiers: Seq[WatchEvent.Modifier] = Nil,
       pollTimeout: FiniteDuration = 1.second
   )(implicit F: Async[F]): Stream[F, DeprecatedWatcher.Event] =
-    Files[F].watch(path, types, modifiers, pollTimeout)
+    Files.forAsync[F].watch(path, types, modifiers, pollTimeout)
 
   /** Checks if a file exists
     *
@@ -137,7 +137,7 @@ package object file {
       path: JPath,
       flags: Seq[LinkOption] = Seq.empty
   ): F[Boolean] =
-    Files[F].exists(path, flags)
+    Files.forAsync[F].exists(path, flags)
 
   /** Get file permissions as set of `PosixFilePermission`.
     *
@@ -148,7 +148,7 @@ package object file {
       path: JPath,
       flags: Seq[LinkOption] = Seq.empty
   ): F[Set[PosixFilePermission]] =
-    Files[F].permissions(path, flags)
+    Files.forAsync[F].permissions(path, flags)
 
   /** Set file permissions from set of `PosixFilePermission`.
     *
@@ -159,7 +159,7 @@ package object file {
       path: JPath,
       permissions: Set[PosixFilePermission]
   ): F[JPath] =
-    Files[F].setPermissions(path, permissions)
+    Files.forAsync[F].setPermissions(path, permissions)
 
   /** Copies a file from the source to the target path,
     *
@@ -171,7 +171,7 @@ package object file {
       target: JPath,
       flags: Seq[CopyOption] = Seq.empty
   ): F[JPath] =
-    Files[F].copy(source, target, flags)
+    Files.forAsync[F].copy(source, target, flags)
 
   /** Deletes a file.
     *
@@ -180,13 +180,13 @@ package object file {
     */
   @deprecated("Use Files[F].delete", "3.0.0")
   def delete[F[_]: Async](path: JPath): F[Unit] =
-    Files[F].delete(path)
+    Files.forAsync[F].delete(path)
 
   /** Like `delete`, but will not fail when the path doesn't exist.
     */
   @deprecated("Use Files[F].deleteIfExists", "3.0.0")
   def deleteIfExists[F[_]: Async](path: JPath): F[Boolean] =
-    Files[F].deleteIfExists(path)
+    Files.forAsync[F].deleteIfExists(path)
 
   /** Recursively delete a directory
     */
@@ -195,13 +195,13 @@ package object file {
       path: JPath,
       options: Set[FileVisitOption] = Set.empty
   ): F[Unit] =
-    Files[F].deleteDirectoryRecursively(path, options)
+    Files.forAsync[F].deleteDirectoryRecursively(path, options)
 
   /** Returns the size of a file (in bytes).
     */
   @deprecated("Use Files[F].size", "3.0.0")
   def size[F[_]: Async](path: JPath): F[Long] =
-    Files[F].size(path)
+    Files.forAsync[F].size(path)
 
   /** Moves (or renames) a file from the source to the target path.
     *
@@ -213,7 +213,7 @@ package object file {
       target: JPath,
       flags: Seq[CopyOption] = Seq.empty
   ): F[JPath] =
-    Files[F].move(source, target, flags)
+    Files.forAsync[F].move(source, target, flags)
 
   /** Creates a stream containing the path of a temporary file.
     *
@@ -226,7 +226,7 @@ package object file {
       suffix: String = ".tmp",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Stream[F, JPath] =
-    Stream.resource(Files[F].tempFile(Some(dir), prefix, suffix, attributes))
+    Stream.resource(Files.forAsync[F].tempFile(Some(dir), prefix, suffix, attributes))
 
   /** Creates a resource containing the path of a temporary file.
     *
@@ -239,7 +239,7 @@ package object file {
       suffix: String = ".tmp",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, JPath] =
-    Files[F].tempFile(Some(dir), prefix, suffix, attributes)
+    Files.forAsync[F].tempFile(Some(dir), prefix, suffix, attributes)
 
   /** Creates a stream containing the path of a temporary directory.
     *
@@ -251,7 +251,7 @@ package object file {
       prefix: String = "",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Stream[F, JPath] =
-    Stream.resource(Files[F].tempDirectory(Some(dir), prefix, attributes))
+    Stream.resource(Files.forAsync[F].tempDirectory(Some(dir), prefix, attributes))
 
   /** Creates a resource containing the path of a temporary directory.
     *
@@ -263,7 +263,7 @@ package object file {
       prefix: String = "",
       attributes: Seq[FileAttribute[_]] = Seq.empty
   ): Resource[F, JPath] =
-    Files[F].tempDirectory(Some(dir), prefix, attributes)
+    Files.forAsync[F].tempDirectory(Some(dir), prefix, attributes)
 
   /** Creates a new directory at the given path
     */
@@ -272,7 +272,7 @@ package object file {
       path: JPath,
       flags: Seq[FileAttribute[_]] = Seq.empty
   ): F[JPath] =
-    Files[F].createDirectory(path, flags)
+    Files.forAsync[F].createDirectory(path, flags)
 
   /** Creates a new directory at the given path and creates all nonexistent parent directories beforehand.
     */
@@ -281,13 +281,13 @@ package object file {
       path: JPath,
       flags: Seq[FileAttribute[_]] = Seq.empty
   ): F[JPath] =
-    Files[F].createDirectories(path, flags)
+    Files.forAsync[F].createDirectories(path, flags)
 
   /** Creates a stream of `Path`s inside a directory.
     */
   @deprecated("Use Files[F].directoryStream", "3.0.0")
   def directoryStream[F[_]: Async](path: JPath): Stream[F, JPath] =
-    Files[F].directoryStream(path)
+    Files.forAsync[F].directoryStream(path)
 
   /** Creates a stream of `Path`s inside a directory, filtering the results by the given predicate.
     */
@@ -296,7 +296,7 @@ package object file {
       path: JPath,
       filter: JPath => Boolean
   ): Stream[F, JPath] =
-    Files[F].directoryStream(path, filter)
+    Files.forAsync[F].directoryStream(path, filter)
 
   /** Creates a stream of `Path`s inside a directory which match the given glob.
     */
@@ -305,13 +305,13 @@ package object file {
       path: JPath,
       glob: String
   ): Stream[F, JPath] =
-    Files[F].directoryStream(path, glob)
+    Files.forAsync[F].directoryStream(path, glob)
 
   /** Creates a stream of `Path`s contained in a given file tree. Depth is unlimited.
     */
   @deprecated("Use Files[F].walk", "3.0.0")
   def walk[F[_]: Async](start: JPath): Stream[F, JPath] =
-    Files[F].walk(start)
+    Files.forAsync[F].walk(start)
 
   /** Creates a stream of `Path`s contained in a given file tree, respecting the supplied options. Depth is unlimited.
     */
@@ -320,7 +320,7 @@ package object file {
       start: JPath,
       options: Seq[FileVisitOption]
   ): Stream[F, JPath] =
-    Files[F].walk(start, options)
+    Files.forAsync[F].walk(start, options)
 
   /** Creates a stream of `Path`s contained in a given file tree down to a given depth.
     */
@@ -330,5 +330,5 @@ package object file {
       maxDepth: Int,
       options: Seq[FileVisitOption] = Seq.empty
   ): Stream[F, JPath] =
-    Files[F].walk(start, maxDepth, options)
+    Files.forAsync[F].walk(start, maxDepth, options)
 }

--- a/io/jvm/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -23,6 +23,7 @@ package fs2
 package io
 package net
 
+import cats.effect.IO
 import cats.effect.kernel.{Async, Resource}
 
 import com.comcast.ip4s.{Dns, Host, IpAddress, Port, SocketAddress}
@@ -74,10 +75,12 @@ private[net] trait NetworkCompanionPlatform { self: Network.type =>
   private lazy val globalAdsg =
     AsynchronousDatagramSocketGroup.unsafe(ThreadFactories.named("fs2-global-udp", true))
 
+  implicit def forIO: Network[IO] = forAsyncAndDns
+
   def forAsync[F[_]](implicit F: Async[F]): Network[F] =
     forAsyncAndDns(F, Dns.forAsync(F))
 
-  implicit def forAsyncAndDns[F[_]](implicit F: Async[F], dns: Dns[F]): Network[F] =
+  def forAsyncAndDns[F[_]](implicit F: Async[F], dns: Dns[F]): Network[F] =
     new UnsealedNetwork[F] {
       private lazy val globalSocketGroup = SocketGroup.unsafe[F](globalAcg)
       private lazy val globalDatagramSocketGroup = DatagramSocketGroup.unsafe[F](globalAdsg)

--- a/io/jvm/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -67,7 +67,7 @@ private[net] trait NetworkPlatform[F[_]] {
 
 }
 
-private[net] trait NetworkCompanionPlatform { self: Network.type =>
+private[net] trait NetworkCompanionPlatform extends NetworkLowPriority { self: Network.type =>
   private lazy val globalAcg = AsynchronousChannelGroup.withFixedThreadPool(
     1,
     ThreadFactories.named("fs2-global-tcp", true)

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/JdkUnixSockets.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/JdkUnixSockets.scala
@@ -23,6 +23,7 @@ package fs2.io.net.unixsocket
 
 import cats.effect.kernel.{Async, Resource}
 import cats.effect.syntax.all._
+import fs2.io.file.Files
 import java.net.{StandardProtocolFamily, UnixDomainSocketAddress}
 import java.nio.channels.{ServerSocketChannel, SocketChannel}
 
@@ -30,11 +31,14 @@ object JdkUnixSockets {
 
   def supported: Boolean = StandardProtocolFamily.values.size > 2
 
-  def forAsync[F[_]: Async]: UnixSockets[F] =
+  def forAsyncAndFiles[F[_]: Async: Files]: UnixSockets[F] =
     new JdkUnixSocketsImpl[F]
+
+  def forAsync[F[_]](implicit F: Async[F]): UnixSockets[F] =
+    forAsyncAndFiles(F, Files.forAsync[F])
 }
 
-private[unixsocket] class JdkUnixSocketsImpl[F[_]](implicit F: Async[F])
+private[unixsocket] class JdkUnixSocketsImpl[F[_]: Files](implicit F: Async[F])
     extends UnixSockets.AsyncUnixSockets[F] {
   protected def openChannel(address: UnixSocketAddress) =
     Resource

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/JdkUnixSockets.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/JdkUnixSockets.scala
@@ -30,7 +30,7 @@ object JdkUnixSockets {
 
   def supported: Boolean = StandardProtocolFamily.values.size > 2
 
-  implicit def forAsync[F[_]: Async]: UnixSockets[F] =
+  def forAsync[F[_]: Async]: UnixSockets[F] =
     new JdkUnixSocketsImpl[F]
 }
 

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/JnrUnixSockets.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/JnrUnixSockets.scala
@@ -40,7 +40,7 @@ object JnrUnixSockets {
       case _: ClassNotFoundException => false
     }
 
-  implicit def forAsync[F[_]: Async]: UnixSockets[F] =
+  def forAsync[F[_]: Async]: UnixSockets[F] =
     new JnrUnixSocketsImpl[F]
 }
 

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -21,6 +21,7 @@
 
 package fs2.io.net.unixsocket
 
+import cats.effect.IO
 import cats.effect.kernel.{Async, Resource}
 import cats.effect.std.Mutex
 import cats.effect.syntax.all._
@@ -33,7 +34,9 @@ import java.nio.ByteBuffer
 import java.nio.channels.SocketChannel
 
 private[unixsocket] trait UnixSocketsCompanionPlatform {
-  implicit def forAsync[F[_]](implicit F: Async[F]): UnixSockets[F] =
+  implicit def forIO: UnixSockets[IO] = forAsync
+
+  def forAsync[F[_]](implicit F: Async[F]): UnixSockets[F] =
     if (JdkUnixSockets.supported) JdkUnixSockets.forAsync
     else if (JnrUnixSockets.supported) JnrUnixSockets.forAsync
     else

--- a/io/native/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/native/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -32,7 +32,7 @@ import fs2.io.net.tls.TLSContext
 
 private[net] trait NetworkPlatform[F[_]]
 
-private[net] trait NetworkCompanionPlatform { self: Network.type =>
+private[net] trait NetworkCompanionPlatform extends NetworkLowPriority { self: Network.type =>
 
   implicit def forIO: Network[IO] = forAsyncAndDns
 

--- a/io/native/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/native/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -23,6 +23,7 @@ package fs2
 package io
 package net
 
+import cats.effect.IO
 import cats.effect.kernel.{Async, Resource}
 
 import com.comcast.ip4s.{Dns, Host, IpAddress, Port, SocketAddress}
@@ -33,10 +34,12 @@ private[net] trait NetworkPlatform[F[_]]
 
 private[net] trait NetworkCompanionPlatform { self: Network.type =>
 
+  implicit def forIO: Network[IO] = forAsyncAndDns
+
   def forAsync[F[_]](implicit F: Async[F]): Network[F] =
     forAsyncAndDns(F, Dns.forAsync(F))
 
-  implicit def forAsyncAndDns[F[_]](implicit F: Async[F], dns: Dns[F]): Network[F] =
+  def forAsyncAndDns[F[_]](implicit F: Async[F], dns: Dns[F]): Network[F] =
     new UnsealedNetwork[F] {
       private lazy val globalSocketGroup = SocketGroup.unsafe[F](null)
 

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -446,7 +446,12 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
     in.flatMap(s => Stream[F, String](s, lineSeparator)).through(writeUtf8(path, flags))
 }
 
-object Files extends FilesCompanionPlatform {
+private[fs2] trait FilesLowPriority { this: Files.type =>
+  @deprecated("Add Files constraint or use forAsync", "3.7.0")
+  implicit def implicitForAsync[F[_]: Async]: Files[F] = forAsync
+}
+
+object Files extends FilesCompanionPlatform with FilesLowPriority {
   implicit def forIO: Files[IO] = forAsync
 
   private[fs2] abstract class UnsealedFiles[F[_]](implicit F: Async[F]) extends Files[F] {

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -23,6 +23,7 @@ package fs2
 package io
 package file
 
+import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.kernel.Async
 import cats.effect.std.Hotswap
@@ -446,6 +447,8 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
 }
 
 object Files extends FilesCompanionPlatform {
+  implicit def forIO: Files[IO] = forAsync
+
   private[fs2] abstract class UnsealedFiles[F[_]](implicit F: Async[F]) extends Files[F] {
 
     def readAll(path: Path, chunkSize: Int, flags: Flags): Stream[F, Byte] =

--- a/io/shared/src/main/scala/fs2/io/net/NetworkLowPriority.scala
+++ b/io/shared/src/main/scala/fs2/io/net/NetworkLowPriority.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.io.net
+
+import cats.effect.Async
+
+private[fs2] trait NetworkLowPriority { this: Network.type =>
+  @deprecated("Add Network constraint or use forAsync", "3.7.0")
+  implicit def implicitForAsync[F[_]: Async]: Network[F] = forAsync
+}

--- a/site/faq.md
+++ b/site/faq.md
@@ -41,3 +41,19 @@ Note that this pattern is also used for `Stream.pull`
 ### What is the difference between Stream and Pull?
 
 ![Stream and Pull](_media/stream-and-pull.png)
+
+### Why are implicit instances of `Network`, `Files`, etc. only available for `IO`?
+
+When you are writing tagless final code in a generic effect `F[_]`, it is good practice to explicitly declare the granular constraints that you actually need.
+
+For example instead of:
+
+```scala
+def impl[F[_]: Async]: FooService[F] = ???
+```
+
+you should prefer:
+
+```scala
+def impl[F[_]: Concurrent: Network: Files]: FooService[F] = ???
+```


### PR DESCRIPTION
Discord thread: https://discord.com/channels/632277896739946517/839257183782436945/1087761519477014644

Continuing from https://github.com/Comcast/ip4s/pull/475.

**tl;dr**: The motivation for removing the implicit implementation for generic `F[_]` is to force tagless final libs to declare _all_ of their constraints (e.g. `Network`) instead of deriving them on-the-spot from e.g. `Async`. Meanwhile, this change will be completely transparent to code written in concrete `IO`.

This is source-breaking but binary-compatible.

Changes were made to:
- `Compression`
- `Network`
- `UnixSockets`
- `Files`, which impacted internal code