### PR TITLE
Fixing interruption behaviour

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1471,7 +1471,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
         }
 
         def endSupply(result: Either[Throwable, Unit]): F2[Unit] =
-          buffer.update(_.copy(endOfSupply = Some(result))) *> supply.releaseN(Int.MaxValue)
+          buffer.update(_.copy(endOfSupply = Some(result))) *> supply.releaseN(Int.MaxValue + outputLong)
 
         def endDemand(result: Either[Throwable, Unit]): F2[Unit] =
           buffer.update(_.copy(endOfDemand = Some(result))) *> demand.releaseN(Int.MaxValue)

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1472,7 +1472,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
 
         def endSupply(result: Either[Throwable, Unit]): F2[Unit] =
           buffer.update(_.copy(endOfSupply = Some(result))) *> supply.releaseN(
-            Int.MaxValue + outputLong
+            // enough supply for 2 iterations of the race loop in case of upstream
+            // interruption: so that downstream can terminate immediately
+            outputLong * 2
           )
 
         def endDemand(result: Either[Throwable, Unit]): F2[Unit] =

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1471,7 +1471,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
         }
 
         def endSupply(result: Either[Throwable, Unit]): F2[Unit] =
-          buffer.update(_.copy(endOfSupply = Some(result))) *> supply.releaseN(Int.MaxValue + outputLong)
+          buffer.update(_.copy(endOfSupply = Some(result))) *> supply.releaseN(
+            Int.MaxValue + outputLong
+          )
 
         def endDemand(result: Either[Throwable, Unit]): F2[Unit] =
           buffer.update(_.copy(endOfDemand = Some(result))) *> demand.releaseN(Int.MaxValue)

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -837,17 +837,18 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
 
     test("upstream failures are propagated downstream") {
+      TestControl.executeEmbed {
+        case object SevenNotAllowed extends NoStackTrace
 
-      case object SevenNotAllowed extends NoStackTrace
+        val source = Stream
+          .iterate(0)(_ + 1)
+          .covary[IO]
+          .evalMap(n => if (n == 7) IO.raiseError(SevenNotAllowed) else IO.pure(n))
 
-      val source = Stream
-        .unfold(0)(s => Some((s, s + 1)))
-        .covary[IO]
-        .evalMap(n => if (n == 7) IO.raiseError(SevenNotAllowed) else IO.pure(n))
+        val downstream = source.groupWithin(100, 2.seconds)
 
-      val downstream = source.groupWithin(100, 2.seconds)
-
-      downstream.compile.lastOrError.intercept[SevenNotAllowed.type]
+        downstream.intercept[SevenNotAllowed.type]
+      }
     }
 
     test(
@@ -864,7 +865,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
             .flatMap { ref =>
               val source: Stream[IO, Int] =
                 Stream
-                  .unfold(0)(s => Some((s, s + 1)))
+                  .iterate(0)(_ + 1)
                   .covary[IO]
                   .meteredStartImmediately(1.second)
                   .interruptAfter(sourceTimeout)

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -874,6 +874,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
             source.groupWithin(Int.MaxValue, 1.day)
 
           downstream.compile.lastOrError
+            .timeout(downstreamTimeout)
             .map(_.toList)
             .timed
         }

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -891,8 +891,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
 
     test("stress test: all elements are processed") {
-
-      val rangeLength = 100000
+      val rangeLength = 10000
 
       Stream
         .eval(Ref.of[IO, Int](0))

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -845,9 +845,11 @@ class StreamCombinatorsSuite extends Fs2Suite {
           .covary[IO]
           .evalTap(n => IO.raiseError(SevenNotAllowed).whenA(n == 7))
 
-        val downstream = source.groupWithin(100, 2.seconds)
+        val downstream = source.groupWithin(100, 2.seconds).map(_.toList)
 
-        downstream.intercept[SevenNotAllowed.type]
+        val expected = List(List(1, 2, 3, 4, 5, 6))
+
+        downstream.assertEmits(expected).intercept[SevenNotAllowed.type]
       }
     }
 

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -890,7 +890,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
     test("stress test: all elements are processed") {
 
-      val rangeLength = 1000000
+      val rangeLength = 100000
 
       Stream
         .eval(Ref.of[IO, Int](0))

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -843,7 +843,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
         val source = Stream
           .iterate(0)(_ + 1)
           .covary[IO]
-          .evalMap(n => if (n == 7) IO.raiseError(SevenNotAllowed) else IO.pure(n))
+          .evalTap(n => IO.raiseError(SevenNotAllowed).whenA(n == 7))
 
         val downstream = source.groupWithin(100, 2.seconds)
 

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -878,9 +878,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
               downstream.compile.lastOrError
                 .map(_.toList)
-                .timeout(downstreamTimeout)
-                .flatTap(_ => IO.monotonic.flatMap(ref.set))
-                .flatMap(emit => ref.get.map(timeLapsed => (timeLapsed, emit)))
+                .timed
             }
         )
         .assertEquals(

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -23,7 +23,7 @@ package fs2
 
 import cats.effect.kernel.Deferred
 import cats.effect.kernel.Ref
-import cats.effect.std.{Semaphore, Queue}
+import cats.effect.std.{Queue, Semaphore}
 import cats.effect.testkit.TestControl
 import cats.effect.{IO, SyncIO}
 import cats.syntax.all._
@@ -34,6 +34,7 @@ import org.scalacheck.Prop.forAll
 
 import scala.concurrent.duration._
 import scala.concurrent.TimeoutException
+import scala.util.control.NoStackTrace
 
 class StreamCombinatorsSuite extends Fs2Suite {
 
@@ -832,6 +833,77 @@ class StreamCombinatorsSuite extends Fs2Suite {
             }
         )
         .assertEquals(0.millis)
+    }
+
+    test("upstream failures are propagated downstream") {
+
+      case object SevenNotAllowed extends NoStackTrace
+
+      val source = Stream
+        .unfold(0)(s => Some((s, s + 1)))
+        .covary[IO]
+        .evalMap(n => if (n == 7) IO.raiseError(SevenNotAllowed) else IO.pure(n))
+
+      val downstream = source.groupWithin(100, 2.seconds)
+
+      downstream.compile.lastOrError.intercept[SevenNotAllowed.type]
+    }
+
+    test(
+      "upstream interruption causes immediate downstream termination with all elements being emitted"
+    ) {
+
+      val sourceTimeout = 5.5.seconds
+      val downstreamTimeout = sourceTimeout + 2.seconds
+
+      TestControl
+        .executeEmbed(
+          Ref[IO]
+            .of(0.millis)
+            .flatMap { ref =>
+              val source: Stream[IO, Int] =
+                Stream
+                  .unfold(0)(s => Some((s, s + 1)))
+                  .covary[IO]
+                  .meteredStartImmediately(1.second)
+                  .interruptAfter(sourceTimeout)
+
+              // large chunkSize and timeout (no emissions expected in the window
+              // specified, unless source ends, due to interruption or
+              // natural termination (i.e runs out of elements)
+              val downstream: Stream[IO, Chunk[Int]] =
+                source.groupWithin(Int.MaxValue, 1.day)
+
+              downstream.compile.lastOrError
+                .map(_.toList)
+                .timeout(downstreamTimeout)
+                .flatTap(_ => IO.monotonic.flatMap(ref.set))
+                .flatMap(emit => ref.get.map(timeLapsed => (timeLapsed, emit)))
+            }
+        )
+        .assertEquals(
+          // downstream ended immediately (i.e timeLapsed = sourceTimeout)
+          // emitting whatever was accumulated at the time of interruption
+          (sourceTimeout, List(0, 1, 2, 3, 4, 5))
+        )
+    }
+
+    test("stress test: all elements are processed") {
+
+      val rangeLength = 1000000
+
+      Stream
+        .eval(Ref.of[IO, Int](0))
+        .flatMap { counter =>
+          Stream
+            .range(0, rangeLength)
+            .covary[IO]
+            .groupWithin(4096, 100.micros)
+            .evalTap(ch => counter.update(_ + ch.size)) *> Stream.eval(counter.get)
+        }
+        .compile
+        .lastOrError
+        .assertEquals(rangeLength)
     }
   }
 


### PR DESCRIPTION
## Summary

- Fixes #3169
- Adding missing tests around error/interruption propagation
- Adding stress/integrity test

## Changes

increasing supply by `Int.MaxValue + chunkSize` on upstream `finalization` to prevent the supply semaphore from blocking when upstream is interrupted while downstream is waiting for the timeout to expire or to have enough elements

## Notes

- the `stress test: all elements are processed` test is nothing but a copy of the benchmark with and integrity check at the end. While it may seem redundant (i.e. `should never lose any elements` should cover it), in reality it is possible to write an [implementation](https://github.com/typelevel/fs2/pull/3162) that passes that test but fails this one. (~on a side note, that explains the big performance gain of the implementation linked earlier, so~ having this test in place could prevent being misled when looking at benchmark results, while working on a new implementation 🙏🏾 )
