### PR TITLE
fixing assertion in parEval test

### DIFF
--- a/core/shared/src/test/scala/fs2/ParEvalMapSuite.scala
+++ b/core/shared/src/test/scala/fs2/ParEvalMapSuite.scala
@@ -66,13 +66,17 @@ class ParEvalMapSuite extends Fs2Suite {
     }
 
     test("may not be preserved in parEvalMapUnordered") {
+      run(_.parEvalMapUnorderedUnbounded(identity)).assertEquals(List(1, 2, 3))
+    }
+
+    def run(pipe: Pipe[IO, IO[Int], Int]) =
       Stream
         .emits(List(3, 2, 1))
         .map(i => IO.sleep(50.millis * i.toLong).as(i))
         .covary[IO]
-        .through(_.parEvalMapUnorderedUnbounded(identity))
-        .assertEmitsUnordered(List(1, 2, 3))
-    }
+        .through(pipe)
+        .compile
+        .toList
   }
 
   group("should limit concurrency in") {

--- a/core/shared/src/test/scala/fs2/ParEvalMapSuite.scala
+++ b/core/shared/src/test/scala/fs2/ParEvalMapSuite.scala
@@ -67,7 +67,9 @@ class ParEvalMapSuite extends Fs2Suite {
     }
 
     test("may not be preserved in parEvalMapUnordered") {
-      TestControl.executeEmbed(run(_.parEvalMapUnorderedUnbounded(identity)).assertEquals(List(1, 2, 3)))
+      TestControl.executeEmbed(
+        run(_.parEvalMapUnorderedUnbounded(identity)).assertEquals(List(1, 2, 3))
+      )
     }
 
     def run(pipe: Pipe[IO, IO[Int], Int]) =

--- a/core/shared/src/test/scala/fs2/ParEvalMapSuite.scala
+++ b/core/shared/src/test/scala/fs2/ParEvalMapSuite.scala
@@ -66,17 +66,13 @@ class ParEvalMapSuite extends Fs2Suite {
     }
 
     test("may not be preserved in parEvalMapUnordered") {
-      run(_.parEvalMapUnorderedUnbounded(identity)).assertEquals(List(1, 2, 3))
-    }
-
-    def run(pipe: Pipe[IO, IO[Int], Int]) =
       Stream
         .emits(List(3, 2, 1))
         .map(i => IO.sleep(50.millis * i.toLong).as(i))
         .covary[IO]
-        .through(pipe)
-        .compile
-        .toList
+        .through(_.parEvalMapUnorderedUnbounded(identity))
+        .assertEmitsUnordered(List(1, 2, 3))
+    }
   }
 
   group("should limit concurrency in") {

--- a/core/shared/src/test/scala/fs2/ParEvalMapSuite.scala
+++ b/core/shared/src/test/scala/fs2/ParEvalMapSuite.scala
@@ -22,6 +22,7 @@
 package fs2
 
 import cats.effect.std.CountDownLatch
+import cats.effect.testkit.TestControl
 import cats.effect.{Deferred, IO}
 import cats.syntax.all._
 import org.scalacheck.effect.PropF.forAllF
@@ -66,7 +67,7 @@ class ParEvalMapSuite extends Fs2Suite {
     }
 
     test("may not be preserved in parEvalMapUnordered") {
-      run(_.parEvalMapUnorderedUnbounded(identity)).assertEquals(List(1, 2, 3))
+      TestControl.executeEmbed(run(_.parEvalMapUnorderedUnbounded(identity)).assertEquals(List(1, 2, 3)))
     }
 
     def run(pipe: Pipe[IO, IO[Int], Int]) =


### PR DESCRIPTION
## Summary

According to the test spec the result may not be in the correct order, but the assertion check for exact equality. 

## Changes
- adjusting `parEvalMapUnordered` test to reflect spec, by using assertion that does not check for ordering
- removing no longer used `run` helper method

