### PR TITLE
Groupwithin improvements

### DIFF
--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -23,7 +23,7 @@ package fs2
 
 import cats.effect.kernel.Deferred
 import cats.effect.kernel.Ref
-import cats.effect.std.{Semaphore, Queue}
+import cats.effect.std.{Queue, Semaphore}
 import cats.effect.testkit.TestControl
 import cats.effect.{IO, SyncIO}
 import cats.syntax.all._
@@ -34,6 +34,7 @@ import org.scalacheck.Prop.forAll
 
 import scala.concurrent.duration._
 import scala.concurrent.TimeoutException
+import scala.util.control.NoStackTrace
 
 class StreamCombinatorsSuite extends Fs2Suite {
 
@@ -747,7 +748,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
       }
     }
 
-    test("accumulation and splitting".flaky) {
+    test("accumulation and splitting") {
       val t = 200.millis
       val size = 5
       val sleep = Stream.sleep_[IO](2 * t)
@@ -769,6 +770,36 @@ class StreamCombinatorsSuite extends Fs2Suite {
         List(9, 10, 11, 12, 13),
         List(14, 15, 16, 17, 18),
         List(19, 20, 21, 22)
+      )
+
+      source.groupWithin(size, t).map(_.toList).assertEmits(expected)
+    }
+
+    test("accumulation and splitting 2") {
+      val t = 200.millis
+      val size = 5
+      val sleep = Stream.sleep_[IO](2 * t)
+      val longSleep = Stream.sleep_[IO](10 * t)
+
+      def chunk(from: Int, size: Int) =
+        Stream.range(from, from + size).chunkAll.unchunks
+
+      // this test example is designed to have good coverage of
+      // the chunk manipulation logic in groupWithin
+      val source =
+      chunk(from = 1, size = 3) ++
+        sleep ++
+        chunk(from = 4, size = 1) ++ longSleep ++
+        chunk(from = 5, size = 11) ++
+        chunk(from = 16, size = 7)
+
+      val expected = List(
+        List(1, 2, 3),
+        List(4),
+        List(5, 6, 7, 8, 9),
+        List(10, 11, 12, 13, 14),
+        List(15, 16, 17, 18, 19),
+        List(20, 21, 22)
       )
 
       source.groupWithin(size, t).map(_.toList).assertEmits(expected)
@@ -832,6 +863,78 @@ class StreamCombinatorsSuite extends Fs2Suite {
             }
         )
         .assertEquals(0.millis)
+    }
+
+    test("stress test: all elements are processed") {
+
+      val rangeLength = 100000
+
+      Stream
+        .eval(Ref.of[IO, Int](0))
+        .flatMap { counter =>
+          Stream
+            .range(0, rangeLength)
+            .covary[IO]
+            .groupWithin(4096, 100.micros)
+            .evalTap(ch => counter.update(_ + ch.size)) *> Stream.eval(counter.get)
+        }
+        .compile
+        .lastOrError
+        .assertEquals(rangeLength)
+
+    }
+
+    test("upstream failures are propagated downstream") {
+
+      case object SevenNotAllowed extends NoStackTrace
+
+      val source = Stream
+        .unfold(0)(s => Some((s, s + 1)))
+        .covary[IO]
+        .evalMap(n => if (n == 7) IO.raiseError(SevenNotAllowed) else IO.pure(n))
+
+      val downstream = source.groupWithin(100, 2.seconds)
+
+      downstream.compile.lastOrError.intercept[SevenNotAllowed.type]
+    }
+
+    test(
+      "upstream interruption causes immediate downstream termination with all elements being emitted"
+    ) {
+
+      val sourceTimeout = 5.5.seconds
+      val downstreamTimeout = sourceTimeout + 2.seconds
+
+      TestControl
+        .executeEmbed(
+          Ref[IO]
+            .of(0.millis)
+            .flatMap { ref =>
+              val source: Stream[IO, Int] =
+                Stream
+                  .unfold(0)(s => Some((s, s + 1)))
+                  .covary[IO]
+                  .meteredStartImmediately(1.second)
+                  .interruptAfter(sourceTimeout)
+
+              // large chunkSize and timeout (no emissions expected in the window
+              // specified, unless source ends, due to interruption or
+              // natural termination (i.e runs out of elements)
+              val downstream: Stream[IO, Chunk[Int]] =
+                source.groupWithin(Int.MaxValue, 1.day)
+
+              downstream.compile.lastOrError
+                .map(_.toList)
+                .timeout(downstreamTimeout)
+                .flatTap(_ => IO.monotonic.flatMap(ref.set))
+                .flatMap(emit => ref.get.map(timeLapsed => (timeLapsed, emit)))
+            }
+        )
+        .assertEquals(
+          // downstream ended immediately (i.e timeLapsed = sourceTimeout)
+          // emitting whatever was accumulated at the time of interruption
+          (sourceTimeout, List(0, 1, 2, 3, 4, 5))
+        )
     }
   }
 

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -787,11 +787,11 @@ class StreamCombinatorsSuite extends Fs2Suite {
       // this test example is designed to have good coverage of
       // the chunk manipulation logic in groupWithin
       val source =
-      chunk(from = 1, size = 3) ++
-        sleep ++
-        chunk(from = 4, size = 1) ++ longSleep ++
-        chunk(from = 5, size = 11) ++
-        chunk(from = 16, size = 7)
+        chunk(from = 1, size = 3) ++
+          sleep ++
+          chunk(from = 4, size = 1) ++ longSleep ++
+          chunk(from = 5, size = 11) ++
+          chunk(from = 16, size = 7)
 
       val expected = List(
         List(1, 2, 3),


### PR DESCRIPTION
## Summary

This PR is a followup from #3162 (thanks all for the feedback), and a possible alternative to that approach in terms of timeout behaviour

### Goals:
- improving timeout behaviour (NEW)
- fixing `interruption` propagation misbehaviour (PREVIOUS PR)
- improving performance (PREVIOUS PR)
- simplifying logic (PREVIOUS PR)

### Timeout behaviour

The current implementation has a small flaw in the timeout logic: when entering the timeout state the stream waits for the first element then tries to calculate how many elements are available using the supply semaphore. It finally uses that figure to decide where to split the buffer.

The problem is that even if the buffer has collected enough elements to make up a chunk, these won’t  always be part of the emitted chunk. I suspect this is what’s happening in the "accumulation and splitting" test, which is more flaky than it should probably be (some level of flakiness is probably acceptable since it’s fundamentally a time based test, but with the current logic it’s very easy to get a 50%, or even higher, failure rate). 

When running the test below (a slightly modified version of the original test that includes an additional `sleep`) the situation is even worse: it’s nearly impossible to get the test passing)

```scala
test("accumulation and splitting 2".only) {
  val t = 200.millis
  val size = 5
  val sleep = Stream.sleep_[IO](2 * t)
  val longSleep = Stream.sleep_[IO](10 * t)

  def chunk(from: Int, size: Int) =
    Stream.range(from, from + size).chunkAll.unchunks

  // this test example is designed to have good coverage of
  // the chunk manipulation logic in groupWithin
  val source =
  chunk(from = 1, size = 3) ++
    sleep ++
    chunk(from = 4, size = 1) ++ longSleep ++
    chunk(from = 5, size = 11) ++
    chunk(from = 16, size = 7)

  val expected = List(
    List(1, 2, 3),
    List(4),
    List(5, 6, 7, 8, 9),
    List(10, 11, 12, 13, 14),
    List(15, 16, 17, 18, 19),
    List(20, 21, 22)
  )

  source.groupWithin(size, t).map(_.toList).assertEmits(expected)
}
```

This PR builds on top of #3162 introducing a new mechanism to improve the accuracy of the timeout logic.
The trick is to wait for a whole chunk to be there, and to achieve that we run a stream within a stream, allowing us to reuse the fs2 api to interact with the stream in terms of `chunks`.

The result is a more accurate behaviour

I've run both "accumulation and splitting" tests a number of times and had zero failures so far

<img width="904" alt="Screenshot 2023-03-25 at 18 38 29" src="https://user-images.githubusercontent.com/16281580/227735501-7027983b-8eec-4b09-9f90-bdd730a6cd44.png">

### Performance

benchmarks figures are similar to the other suggested [implementation](https://github.com/typelevel/fs2/pull/3162#issuecomment-1477075048) (I won't attach them again, but let me know if you get different results), better than the existing implementation and up to 100% faster on large streams (ops/sec), with even better `gc` stats, (assuming a lower score is better) I've run them only once though

### Simpler logic 

Like the previous PR this one removes the custom error propagation (relies on `concurrently`) and limits the use of `Semaphore` to what's needed, (`demand` is gone in favour of a bounded queue) piggybacking on the streams api to await a chunk

### Considerations

I haven't yet experienced the issue reported [here](https://github.com/typelevel/fs2/pull/3162#discussion_r1145009634). So I haven't included the change suggested to prevent that edge case. I'd like to understand how that can happen first. Let me know what you think about the suggestion to address it (see previous PR) and if you have a better idea.

### Notes

- may be a fix for #2432 (let me know what's your experience, I haven't seen a failure yet)
- fixes #3169 (unless #3183 gets merged first)

