### PR TITLE
Chunk - Optimise Flatten implementation.

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ChunkFlatten.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChunkFlatten.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import org.openjdk.jmh.annotations.{Benchmark, Param, Scope, Setup, State}
+
+import cats.syntax.all._
+
+@State(Scope.Thread)
+class ChunkFlatten {
+  @Param(Array("8", "32", "128"))
+  var numberChunks: Int = _
+
+  @Param(Array("1", "2", "10", "50"))
+  var chunkSize: Int = _
+
+  case class Obj(dummy: Boolean)
+  object Obj {
+    def create: Obj = Obj(true)
+  }
+
+  var chunkSeq: Seq[Chunk[Obj]] = _
+
+  @Setup
+  def setup() =
+    chunkSeq = Seq.range(0, numberChunks).map(_ => Chunk.seq(Seq.fill(chunkSize)(Obj.create)))
+
+  @Benchmark
+  def flatten(): Unit = {
+    Chunk.seq(chunkSeq).flatten
+    ()
+  }
+
+}

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1187,6 +1187,18 @@ object Chunk
       if (c.isEmpty) empty else new Queue(collection.immutable.Queue(c), c.size)
     def apply[O](chunks: Chunk[O]*): Queue[O] =
       chunks.foldLeft(empty[O])(_ :+ _)
+
+    private[Chunk] def build[O](chunks: Chunk[Chunk[O]]): Queue[O] = {
+      val sqb = SQueue.newBuilder[Chunk[O]]
+      var totalSize = 0
+      chunks.foreach { (ch: Chunk[O]) =>
+        if (!ch.isEmpty) {
+          sqb += ch
+          totalSize += ch.size
+        }
+      }
+      new Chunk.Queue[O](sqb.result(), totalSize)
+    }
   }
 
   def newBuilder[O]: Collector.Builder[O, Chunk[O]] =
@@ -1236,11 +1248,7 @@ object Chunk
       override def flatten[A](ffa: Chunk[Chunk[A]]): Chunk[A] =
         if (ffa.isEmpty) Chunk.empty
         else if (ffa.size == 1) ffa(0) // short-circuit and simply return the first chunk
-        else {
-          var acc = Chunk.Queue.empty[A]
-          ffa.foreach(x => acc = acc :+ x)
-          acc
-        }
+        else Queue.build(ffa)
 
       override def traverse_[F[_], A, B](
           fa: Chunk[A]


### PR DESCRIPTION
The current flatten performs one Chunk.Queue insertion per source chunk, which means it creates a new "Chunk.Queue" object and one "Queue" object for each one. Instead, we can avoid those objects and use a Queue- builder.