### PR TITLE
Offer implicits for any `LiftIO`

### DIFF
--- a/core/jvm-native/src/main/scala/fs2/compression/CompressionPlatform.scala
+++ b/core/jvm-native/src/main/scala/fs2/compression/CompressionPlatform.scala
@@ -23,6 +23,7 @@ package fs2
 package compression
 
 import cats.effect.IO
+import cats.effect.LiftIO
 import cats.effect.kernel.Sync
 
 import java.io.EOFException
@@ -126,7 +127,12 @@ private trait CompressionCompanionPlatformLowPriority { this: CompressionCompani
 private[compression] trait CompressionCompanionPlatform
     extends CompressionCompanionPlatformLowPriority {
 
-  implicit def forIO: Compression[IO] = forSync
+  def forIO: Compression[IO] = forLiftIO
+
+  implicit def forLiftIO[F[_]: Sync: LiftIO]: Compression[F] = {
+    val _ = LiftIO[F]
+    forSync
+  }
 
   def forSync[F[_]](implicit F: Sync[F]): Compression[F] =
     new Compression.UnsealedCompression[F] {

--- a/io/js/src/main/scala/fs2/io/compressionplatform.scala
+++ b/io/js/src/main/scala/fs2/io/compressionplatform.scala
@@ -23,6 +23,7 @@ package fs2
 package io
 
 import cats.effect.IO
+import cats.effect.LiftIO
 import cats.effect.kernel.Async
 import cats.syntax.all._
 import fs2.compression.Compression
@@ -36,8 +37,13 @@ private[io] trait compressionplatform {
 
   class ZipException(msg: String) extends IOException(msg)
 
-  implicit def fs2ioCompressionForIO: Compression[IO] =
+  def fs2ioCompressionForIO: Compression[IO] =
+    fs2ioCompressionForLiftIO
+
+  implicit def fs2ioCompressionForLiftIO[F[_]: Async: LiftIO]: Compression[F] = {
+    val _ = LiftIO[F]
     fs2ioCompressionForAsync
+  }
 
   def fs2ioCompressionForAsync[F[_]](implicit F: Async[F]): Compression[F] =
     new Compression.UnsealedCompression[F] {

--- a/io/js/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -24,6 +24,7 @@ package io
 package net
 
 import cats.effect.IO
+import cats.effect.LiftIO
 import cats.effect.kernel.Async
 import cats.effect.kernel.Resource
 import com.comcast.ip4s.Host
@@ -35,7 +36,12 @@ import fs2.io.net.tls.TLSContext
 private[net] trait NetworkPlatform[F[_]]
 
 private[net] trait NetworkCompanionPlatform extends NetworkLowPriority { self: Network.type =>
-  implicit def forIO: Network[IO] = forAsync
+  def forIO: Network[IO] = forLiftIO
+
+  implicit def forLiftIO[F[_]: Async: LiftIO]: Network[F] = {
+    val _ = LiftIO[F]
+    forAsync
+  }
 
   def forAsync[F[_]](implicit F: Async[F]): Network[F] =
     new UnsealedNetwork[F] {

--- a/io/js/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -39,7 +39,7 @@ import scala.scalajs.js
 private[unixsocket] trait UnixSocketsCompanionPlatform {
   def forIO: UnixSockets[IO] = forLiftIO
 
-  implicit def forLiftIO[F[_]: Async: LiftIO]: UnixSockets[IO] = {
+  implicit def forLiftIO[F[_]: Async: LiftIO]: UnixSockets[F] = {
     val _ = LiftIO[F]
     forAsyncAndFiles
   }

--- a/io/js/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -23,6 +23,7 @@ package fs2
 package io.net.unixsocket
 
 import cats.effect.IO
+import cats.effect.LiftIO
 import cats.effect.kernel.Async
 import cats.effect.kernel.Resource
 import cats.effect.std.Dispatcher
@@ -36,7 +37,12 @@ import fs2.io.internal.facade
 import scala.scalajs.js
 
 private[unixsocket] trait UnixSocketsCompanionPlatform {
-  implicit def forIO: UnixSockets[IO] = forAsyncAndFiles
+  def forIO: UnixSockets[IO] = forLiftIO
+
+  implicit def forLiftIO[F[_]: Async: LiftIO]: UnixSockets[IO] = {
+    val _ = LiftIO[F]
+    forAsyncAndFiles
+  }
 
   def forAsync[F[_]](implicit F: Async[F]): UnixSockets[F] =
     forAsyncAndFiles(Files.forAsync(F), F)

--- a/io/jvm-native/src/main/scala/fs2/io/compressionplatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/compressionplatform.scala
@@ -23,6 +23,7 @@ package fs2
 package io
 
 import cats.effect.IO
+import cats.effect.kernel.Async
 import cats.effect.kernel.Sync
 import fs2.compression.Compression
 
@@ -33,4 +34,6 @@ private[io] trait compressionplatform {
   implicit def fs2ioCompressionForIO: Compression[IO] = Compression.forSync
 
   def fs2ioCompressionForSync[F[_]: Sync]: Compression[F] = Compression.forSync
+
+  def fs2ioCompressionForAsync[F[_]: Async]: Compression[F] = Compression.forSync
 }

--- a/io/jvm/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -80,8 +80,7 @@ private[net] trait NetworkCompanionPlatform extends NetworkLowPriority { self: N
 
   implicit def forLiftIO[F[_]: Async: LiftIO]: Network[F] = {
     val _ = LiftIO[F]
-    implicit val dns = Dns.forAsync[F]
-    forAsyncAndDns
+    forAsync
   }
 
   def forAsync[F[_]](implicit F: Async[F]): Network[F] =

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -22,6 +22,7 @@
 package fs2.io.net.unixsocket
 
 import cats.effect.IO
+import cats.effect.LiftIO
 import cats.effect.kernel.{Async, Resource}
 import cats.effect.std.Mutex
 import cats.effect.syntax.all._
@@ -34,7 +35,12 @@ import java.nio.ByteBuffer
 import java.nio.channels.SocketChannel
 
 private[unixsocket] trait UnixSocketsCompanionPlatform {
-  implicit def forIO: UnixSockets[IO] = forAsyncAndFiles
+  def forIO: UnixSockets[IO] = forLiftIO
+
+  implicit def forLiftIO[F[_]: Async: LiftIO]: UnixSockets[F] = {
+    val _ = LiftIO[F]
+    forAsyncAndFiles
+  }
 
   def forAsyncAndFiles[F[_]: Async: Files]: UnixSockets[F] =
     if (JdkUnixSockets.supported) JdkUnixSockets.forAsyncAndFiles

--- a/io/native/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/native/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -39,8 +39,7 @@ private[net] trait NetworkCompanionPlatform extends NetworkLowPriority { self: N
 
   implicit def forLiftIO[F[_]: Async: LiftIO]: Network[F] = {
     val _ = LiftIO[F]
-    implicit val dns = Dns.forAsync[F]
-    forAsyncAndDns
+    forAsync
   }
 
   def forAsync[F[_]](implicit F: Async[F]): Network[F] =

--- a/io/native/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/native/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -39,8 +39,8 @@ private[net] trait NetworkCompanionPlatform extends NetworkLowPriority { self: N
 
   implicit def forLiftIO[F[_]: Async: LiftIO]: Network[F] = {
     val _ = LiftIO[F]
-    val dns = Dns.forAsync[F]
-    forAsync
+    implicit val dns = Dns.forAsync[F]
+    forAsyncAndDns
   }
 
   def forAsync[F[_]](implicit F: Async[F]): Network[F] =

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -24,6 +24,7 @@ package io
 package file
 
 import cats.effect.IO
+import cats.effect.LiftIO
 import cats.effect.Resource
 import cats.effect.kernel.Async
 import cats.effect.std.Hotswap
@@ -452,7 +453,12 @@ private[fs2] trait FilesLowPriority { this: Files.type =>
 }
 
 object Files extends FilesCompanionPlatform with FilesLowPriority {
-  implicit def forIO: Files[IO] = forAsync
+  def forIO: Files[IO] = forLiftIO
+
+  implicit def forLiftIO[F[_]: Async: LiftIO]: Files[F] = {
+    val _ = LiftIO[F]
+    forAsync
+  }
 
   private[fs2] abstract class UnsealedFiles[F[_]](implicit F: Async[F]) extends Files[F] {
 

--- a/io/shared/src/main/scala/fs2/io/process/Processes.scala
+++ b/io/shared/src/main/scala/fs2/io/process/Processes.scala
@@ -22,6 +22,8 @@
 package fs2.io.process
 
 import cats.effect.IO
+import cats.effect.LiftIO
+import cats.effect.kernel.Async
 import cats.effect.kernel.Resource
 
 sealed trait Processes[F[_]] {
@@ -35,5 +37,10 @@ private[fs2] trait UnsealedProcesses[F[_]] extends Processes[F]
 object Processes extends ProcessesCompanionPlatform {
   def apply[F[_]: Processes]: Processes[F] = implicitly
 
-  implicit val forIO: Processes[IO] = forAsync
+  def forIO: Processes[IO] = forLiftIO
+
+  implicit def forLiftIO[F[_]: Async: LiftIO]: Processes[F] = {
+    val _ = LiftIO[F]
+    forAsync
+  }
 }


### PR DESCRIPTION
Follow-up to https://github.com/typelevel/fs2/pull/3179, where we relax from implicits only for `IO` to implicits for any `LiftIO`. This makes instances available for transformers in `IO` e.g. `Kleisli[IO, ...]`.

I would have preferred to follow https://github.com/Comcast/ip4s/pull/478 and implicitly derive instances for transformers from an implicit instance of the underlying effect. This is more challenging in FS2, because any API which exposes a `Pipe` can no longer be trivially `mapK`ed / `translate`d with just an `F ~> G` function. Still I was determined enough to explore this in https://github.com/typelevel/fs2/commit/c894c5bb16e23e4343aa5fb9a45cf6055ed3a67b which demonstrates that with re-architecting it is possible to implement a `mapK`/`translate` for these APIs. But the work / complexity is just not worth it.

