### PR TITLE
Stream - expand evalMapChunk, evalTapChunk.

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -353,6 +353,7 @@ object Pull extends PullLowPriority {
         case _               => Uncons(self)
       }
 
+    private[fs2] def scoped: Pull[F, O, Unit] = Pull.scope(self)
   }
 
   private[this] val unit: Terminal[Unit] = Succeeded(())


### PR DESCRIPTION
In `evalTapChunk`, instead of `traverse` we can use `traverse_` (which discards outputs), and just keep emitting same input chunk, without allocating a new entire output chunk.