### PR TITLE
Specialize `Chunk#toArraySlice`

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -801,7 +801,7 @@ object Chunk
       if (n <= 0) this
       else if (n >= size) Chunk.empty
       else {
-        val second = readOnly(buf)
+        val second = duplicate(buf)
         (second: JBuffer).position(n + offset)
         buffer(second)
       }
@@ -810,13 +810,13 @@ object Chunk
       if (n <= 0) Chunk.empty
       else if (n >= size) this
       else {
-        val first = readOnly(buf)
+        val first = duplicate(buf)
         (first: JBuffer).limit(n + offset)
         buffer(first)
       }
 
     def copyToArray[O2 >: C](xs: Array[O2], start: Int): Unit = {
-      val b = readOnly(buf)
+      val b = duplicate(buf)
       (b: JBuffer).position(offset)
       (b: JBuffer).limit(offset + size)
       val arr = new Array[C](size)
@@ -826,9 +826,9 @@ object Chunk
     }
 
     protected def splitAtChunk_(n: Int): (A, A) = {
-      val first = readOnly(buf)
+      val first = duplicate(buf)
       (first: JBuffer).limit(n + offset)
-      val second = readOnly(buf)
+      val second = duplicate(buf)
       (second: JBuffer).position(n + offset)
       (buffer(first), buffer(second))
     }
@@ -907,7 +907,7 @@ object Chunk
     def duplicate(b: JByteBuffer): JByteBuffer = b.duplicate()
 
     override def toByteVector[B >: Byte](implicit ev: B =:= Byte): ByteVector = {
-      val bb = buf.asReadOnlyBuffer()
+      val bb = buf.duplicate()
       (bb: JBuffer).position(offset)
       (bb: JBuffer).limit(offset + size)
       ByteVector.view(bb)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -810,7 +810,7 @@ object Chunk
     }
 
     override def toArray[O2 >: C](implicit o2ct: ClassTag[O2]): Array[O2] =
-      if (o2ct == ct) {
+      if (o2ct.runtimeClass == ct.runtimeClass) {
         val bs = new Array[O2](size)
         val b = duplicate(buf)
         (b: JBuffer).position(offset)
@@ -846,7 +846,7 @@ object Chunk
       throw new UnsupportedOperationException
 
     override def toArraySlice[O2 >: Char](implicit ct: ClassTag[O2]): Chunk.ArraySlice[O2] =
-      if (ct == ClassTag.Char && buf.hasArray)
+      if (ct.runtimeClass == classOf[Char] && buf.hasArray)
         Chunk
           .ArraySlice(buf.array, buf.arrayOffset + offset, size)
           .asInstanceOf[Chunk.ArraySlice[O2]]
@@ -897,7 +897,7 @@ object Chunk
     }
 
     override def toArraySlice[O2 >: Byte](implicit ct: ClassTag[O2]): Chunk.ArraySlice[O2] =
-      if (ct == ClassTag.Byte && buf.hasArray)
+      if (ct.runtimeClass == classOf[Byte] && buf.hasArray)
         Chunk
           .ArraySlice(buf.array, buf.arrayOffset + offset, size)
           .asInstanceOf[Chunk.ArraySlice[O2]]
@@ -958,7 +958,7 @@ object Chunk
     def toByteVector() = bv
 
     override def toArraySlice[O2 >: Byte](implicit ct: ClassTag[O2]): Chunk.ArraySlice[O2] =
-      if (ct == ClassTag.Byte)
+      if (ct.runtimeClass == classOf[Byte])
         Chunk.ArraySlice[Byte](bv.toArrayUnsafe, 0, size).asInstanceOf[Chunk.ArraySlice[O2]]
       else super.toArraySlice
 

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -27,7 +27,10 @@ import cats.kernel.laws.discipline.EqTests
 import cats.laws.discipline.{AlternativeTests, MonadTests, TraverseFilterTests, TraverseTests}
 import org.scalacheck.{Arbitrary, Cogen, Gen, Test}
 import org.scalacheck.Prop.forAll
+import scodec.bits.ByteVector
 
+import java.nio.ByteBuffer
+import java.nio.CharBuffer
 import scala.reflect.ClassTag
 
 class ChunkSuite extends Fs2Suite {
@@ -225,11 +228,44 @@ class ChunkSuite extends Fs2Suite {
     Chunk.ArraySlice(Array[Any](0.toByte)).asInstanceOf[Chunk[Byte]].toByteVector
   }
 
-  test("ArraySlice does not copy when chunk is already an ArraySlice instance") {
+  test("toArraySlice does not copy when chunk is already an ArraySlice instance") {
     val chunk: Chunk[Int] = Chunk.ArraySlice(Array(0))
     assert(chunk eq chunk.toArraySlice)
     val chunk2: Chunk[Any] = Chunk.ArraySlice(Array(new Object))
     assert(chunk2 eq chunk2.toArraySlice)
+  }
+
+  test("toArraySlice does not copy when chunk is an array-backed bytevector") {
+    val arr = Array[Byte](0)
+    val chunk: Chunk[Byte] = Chunk.byteVector(ByteVector.view(arr))
+    assert(chunk.toArraySlice.values eq arr)
+  }
+
+  test("ByteVectorChunk#toArraySlice does not throw class cast exception") {
+    val chunk: Chunk[Byte] = Chunk.byteVector(ByteVector.view(Array[Byte](0)))
+    assertEquals(chunk.toArraySlice[Any].values.apply(0), 0)
+  }
+
+  test("toArraySlice does not copy when chunk is an array-backed bytebuffer") {
+    val bb = ByteBuffer.allocate(1)
+    val chunk: Chunk[Byte] = Chunk.byteBuffer(bb)
+    assert(chunk.toArraySlice.values eq bb.array)
+  }
+
+  test("ByteBuffer#toArraySlice does not throw class cast exception") {
+    val chunk: Chunk[Byte] = Chunk.byteBuffer(ByteBuffer.allocate(1))
+    assertEquals(chunk.toArraySlice[Any].values.apply(0), 0)
+  }
+
+  test("toArraySlice does not copy when chunk is an array-backed charbuffer") {
+    val cb = CharBuffer.allocate(1)
+    val chunk: Chunk[Char] = Chunk.charBuffer(cb)
+    assert(chunk.toArraySlice.values eq cb.array)
+  }
+
+  test("CharBuffer#toArraySlice does not throw class cast exception") {
+    val chunk: Chunk[Char] = Chunk.charBuffer(CharBuffer.allocate(1))
+    assertEquals(chunk.toArraySlice[Any].values.apply(0), 0)
   }
 
   test("compactUntagged - regression #2679") {

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -236,35 +236,35 @@ class ChunkSuite extends Fs2Suite {
   }
 
   test("toArraySlice does not copy when chunk is an array-backed bytevector") {
-    val arr = Array[Byte](0)
+    val arr = Array[Byte](0, 1, 2, 3)
     val chunk: Chunk[Byte] = Chunk.byteVector(ByteVector.view(arr))
     assert(chunk.toArraySlice.values eq arr)
   }
 
   test("ByteVectorChunk#toArraySlice does not throw class cast exception") {
-    val chunk: Chunk[Byte] = Chunk.byteVector(ByteVector.view(Array[Byte](0)))
+    val chunk: Chunk[Byte] = Chunk.byteVector(ByteVector.view(Array[Byte](0, 1, 2, 3)))
     assertEquals(chunk.toArraySlice[Any].values.apply(0), 0)
   }
 
   test("toArraySlice does not copy when chunk is an array-backed bytebuffer") {
-    val bb = ByteBuffer.allocate(1)
+    val bb = ByteBuffer.allocate(4)
     val chunk: Chunk[Byte] = Chunk.byteBuffer(bb)
     assert(chunk.toArraySlice.values eq bb.array)
   }
 
   test("ByteBuffer#toArraySlice does not throw class cast exception") {
-    val chunk: Chunk[Byte] = Chunk.byteBuffer(ByteBuffer.allocate(1))
+    val chunk: Chunk[Byte] = Chunk.byteBuffer(ByteBuffer.allocate(4))
     assertEquals(chunk.toArraySlice[Any].values.apply(0), 0)
   }
 
   test("toArraySlice does not copy when chunk is an array-backed charbuffer") {
-    val cb = CharBuffer.allocate(1)
+    val cb = CharBuffer.allocate(4)
     val chunk: Chunk[Char] = Chunk.charBuffer(cb)
     assert(chunk.toArraySlice.values eq cb.array)
   }
 
   test("CharBuffer#toArraySlice does not throw class cast exception") {
-    val chunk: Chunk[Char] = Chunk.charBuffer(CharBuffer.allocate(1))
+    val chunk: Chunk[Char] = Chunk.charBuffer(CharBuffer.allocate(4))
     assertEquals(chunk.toArraySlice[Any].values.apply(0), 0)
   }
 


### PR DESCRIPTION
1. Specializes `Chunk#toArraySlice` for `ByteVector` and `{Byte,Char}Buffer` to avoid array copies.
2. Fix class cast exceptions in `Chunk.{Byte,Char}Buffer#toArray`.
3. Avoid converting buffers to read-only, since this prevents access to underlying array.
4. Use `toArraySlice` to implement `to{Byte,Char}Buffer`