### PR TITLE
Fix `Signal#ap` bug in `getAndDiscreteUpdates`

### DIFF
--- a/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
@@ -283,6 +283,17 @@ class SignalSuite extends Fs2Suite {
     }
   }
 
+  test("ap getAndDiscreteUpdates propagates changes from either signal".only) {
+    TestControl.executeEmbed {
+      (SignallingRef[IO].of((i: Int) => i + 1), SignallingRef[IO].of(0)).flatMapN {
+        case (ffs, fus) =>
+          (ffs: Signal[IO, Int => Int]).ap(fus).getAndDiscreteUpdates.use { case (_, updates) =>
+            fus.set(1) *> updates.head.compile.lastOrError.assertEquals(2) // should not hang
+          }
+      }
+    }
+  }
+
   test("waitUntil") {
     val target = 5
     val expected = 1

--- a/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/SignalSuite.scala
@@ -283,7 +283,7 @@ class SignalSuite extends Fs2Suite {
     }
   }
 
-  test("ap getAndDiscreteUpdates propagates changes from either signal".only) {
+  test("ap getAndDiscreteUpdates propagates changes from either signal") {
     TestControl.executeEmbed {
       (SignallingRef[IO].of((i: Int) => i + 1), SignallingRef[IO].of(0)).flatMapN {
         case (ffs, fus) =>


### PR DESCRIPTION
Fixes a bug where `getAndDiscreteUpdates` for a `Signal` created via `Signal#ap` was not emitting updates until both of its upstream signals emitted at least one change.

The new implementation delegates to `getAndDiscreteUpdates` of the upstream signals, which both simplifies it and will be more performant for `Signal`s that override that method.

h/t @noelwelsh for reporting in https://github.com/creativescala/gooey/commit/34173c61257fb7f91c3d2fbbf62553f442d5f2d7