### PR TITLE
Add String to Char and Char to String conversion

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -22,6 +22,7 @@
 package fs2
 
 import cats.ApplicativeThrow
+import cats.syntax.foldable._
 import java.nio.{Buffer, ByteBuffer, CharBuffer}
 import java.nio.charset.{
   CharacterCodingException,
@@ -559,6 +560,13 @@ object text {
 
     s => Stream.suspend(go(s, new StringBuilder(), first = true).stream)
   }
+
+  /** Transforms a stream of `String` to a stream of `Char`. */
+  def string2char[F[_]]: Pipe[F, String, Char] =
+    _.map(s => Chunk.charBuffer(CharBuffer.wrap(s))).flatMap(Stream.chunk)
+
+  /** Transforms a stream of `Char` to a stream of `String`. */
+  def char2string[F[_]]: Pipe[F, Char, String] = _.chunks.map(_.mkString_(""))
 
   class LineTooLongException(val length: Int, val max: Int)
       extends RuntimeException(

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -326,6 +326,23 @@ class TextSuite extends Fs2Suite {
     }
   }
 
+  group("string2char / char2string") {
+
+    property("string to char conversion") {
+      forAll { (strings: Stream[Pure, String]) =>
+        val chars = strings.through(text.string2char)
+        assertEquals(chars.toList.mkString, strings.toList.mkString)
+      }
+    }
+
+    property("char to string conversion") {
+      forAll { (chars: Stream[Pure, Char]) =>
+        val strings = chars.through(text.char2string)
+        assertEquals(strings.toList.mkString, chars.toList.mkString)
+      }
+    }
+  }
+
   property("base64.encode") {
     forAll { (bs: List[Array[Byte]]) =>
       assertEquals(


### PR DESCRIPTION
The methods in the `text` package operate on `String`s. This is the optimal choice for most of the use cases. In some scenarios, however, a stream of `Char`acters may be required (at least I needed it). Although the conversion is a one-liner, it is not apparent how to do it at first (at least it wasn't to me). I think these simple conversion methods may be of use to others and nicely fit to the purpose of `text` package.
I'm not fully sure if the proposed naming is correct - maybe `stringToChar` is a preferred one?
As a comment to the reviewer, both methods may be implemented at least one more way:
```Scala
  def string2char[F[_]]: Pipe[F, String, Char] = _.map(s => Chunk.array(s.toCharArray)).flatMap(Stream.chunk)
  def char2string[F[_]]: Pipe[F, Char, String] = _.chunks.map(c => new String(c.toArray))
```
They do not differ in performance from the proposed implementation.