### PR TITLE
Add fs2-aes to the ecosystem.

### DIFF
--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -19,6 +19,7 @@ If you have a project you'd like to include in this list, either [click here](ht
 * [chromaprint](https://github.com/mgdigital/Chromaprint.scala): A Scala implementation of the Chromaprint/AcoustID audio fingerprinting algorithm, built with fs2 streams / Cats Effect.
 * [circe-fs2](https://github.com/circe/circe-fs2): Streaming JSON manipulation with [circe](https://github.com/circe/circe).
 * [doobie](https://github.com/tpolecat/doobie): Pure functional JDBC built on fs2.
+* [fs2-aes](https://github.com/jwojnowski/fs2-aes): AES encryption for fs2.
 * [fs2-aws](https://github.com/saksdirect/fs2-aws): FS2 streams to interact with AWS utilities
 * [fs2-blobstore](https://github.com/fs2-blobstore/fs2-blobstore): Minimal, idiomatic, stream-based Scala interface for S3, GCS, SFTP and other key/value store implementations.
 * [fs2-cassandra](https://github.com/Spinoco/fs2-cassandra): Cassandra bindings for fs2.


### PR DESCRIPTION
Hi! I've made a micro library for AES encryption pipes for fs2: [`jwojnowski/fs2-aes`](https://github.com/jwojnowski/fs2-aes).

It would be awesome to have it mentioned on the fs2 ecosystem page 🙂 