### PR TITLE
Suppress errors in socket read/write canceler

### DIFF
--- a/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -117,10 +117,7 @@ private[net] trait SocketCompanionPlatform {
           null,
           new IntCompletionHandler(cb)
         )
-        F.delay(Some(F.delay {
-          ch.shutdownInput()
-          ()
-        }))
+        F.delay(Some(endOfInput.voidError))
       }
 
     def write(bytes: Chunk[Byte]): F[Unit] = {
@@ -131,10 +128,7 @@ private[net] trait SocketCompanionPlatform {
             null,
             new IntCompletionHandler(cb)
           )
-          F.delay(Some(F.delay {
-            ch.shutdownOutput()
-            ()
-          }))
+          F.delay(Some(endOfOutput.voidError))
         }.flatMap { written =>
           if (written >= 0 && buff.remaining() > 0)
             go(buff)

--- a/io/jvm/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -39,7 +39,7 @@ import java.util.concurrent.Executors
 class IoPlatformSuite extends Fs2Suite {
 
   // This suite runs for a long time, this avoids timeouts in CI.
-  override def munitIOTimeout: Duration = 1.minute
+  override def munitIOTimeout: Duration = 2.minutes
 
   group("readOutputStream") {
     test("writes data and terminates when `f` returns") {


### PR DESCRIPTION
Sometimes the socket is already closed by the time the read/write canceler is invoked, causing an annoying error log via Cats Effect's unhandled error reporter. So we suppress the error.

Closes https://github.com/disneystreaming/weaver-test/issues/668.