### PR TITLE
Fix skunk doc link in cover page

### DIFF
--- a/site/_coverpage.md
+++ b/site/_coverpage.md
@@ -7,6 +7,6 @@
 - I/O (networking, files) computations in constant memory
 - Stateful transformations
 - Resource safety and effect evaluation
-- Built on [Cats Effect](https://typelevel.org/cats-effect/) and powers [http4s](https://http4s.org), [skunk](https://tpolecat.github.io/skunk/), and [doobie](https://tpolecat.github.io/doobie/)
+- Built on [Cats Effect](https://typelevel.org/cats-effect/) and powers [http4s](https://http4s.org), [skunk](https://typelevel.org/skunk/), and [doobie](https://tpolecat.github.io/doobie/)
 
 [Get Started](getstarted/install.md)

--- a/site/documentation.md
+++ b/site/documentation.md
@@ -74,5 +74,3 @@ Since Haskell is the purely functional lazily-evaluated programming language _pa
 ### Older References ###
 
 The Github page for [Additional resources](https://github.com/functional-streams-for-scala/fs2/wiki/Additional-Resources) lists some of the references above and several older ones, mostly from the `scalaz-stream` days.
-
-

--- a/site/scodec.md
+++ b/site/scodec.md
@@ -1,4 +1,4 @@
-# Scodec 
+# Scodec
 
 The `fs2-scodec` library provides the ability to do streaming binary encoding and decoding, powered by [scodec](https://github.com/scodec/scodec). It was originally called [scodec-stream](https://github.com/scodec/scodec-stream) and released independently for many years before being imported in to fs2.
 


### PR DESCRIPTION
Thanks for opening a PR!

If the CI build fails due to Scalafmt, run `sbt scalafmtAll` and push the changes (generally a good idea to run this prior to opening the PR).

It's also helpful to run `sbt prePR`, which runs tests, generates docs, and performs various checks.

Feel free to ask questions on the fs2 and fs2-dev channels on the [Typelevel Discord server](https://discord.gg/9V8FZTVZ9R).
