### PR TITLE
Refactor merge implementation

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1936,12 +1936,10 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   )(implicit F: Concurrent[F2]): Stream[F2, O2] =
     Stream.force {
       // `State` describes the state of an upstream stream (`this` and `that` are both upstream streams)
-      // None            : the stream is has not yet terminated
+      // None            : the stream has not yet terminated
       // Some(Left(t))   : the stream terminated with an error
       // Some(Right(())) : the stream terminated successfully
       type State = Option[Either[Throwable, Unit]]
-      // `bothStates` keeps track of the state of `this` and `that` stream so we can terminate the
-      // downstream when both upstreams terminate.
       for {
         // `bothStates` keeps track of the state of `this` and `that` stream
         // so we can terminate downstream when both upstreams terminate.

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1974,6 +1974,8 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
 
             (Stream.exec(guard.acquire) ++ s.chunks.foreach(sendChunk))
               // Stop when the other upstream has errored or the downstream has completed.
+              // This may also interrupt the initial call to `guard.acquire` as the call is made at the
+              // beginning of the stream.
               .interruptWhen(stop)
               .compile
               .drain

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1994,8 +1994,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
             // both streams will stop gracefully and the fibers will complete.
             val setup: F2[Fiber[F2, Throwable, Unit]] =
               run(this).start >> run(that).start >> waitForBoth.start
-            Stream.bracket(setup)(waitForBoth =>
-              signalStop >> waitForBoth.joinWithUnit
+            Stream.bracket(setup)(wfb => signalStop >> wfb.joinWithUnit)
             ) >> output.stream.flatten.interruptWhen(stop)
           }
         }

--- a/core/shared/src/test/scala/fs2/Generators.scala
+++ b/core/shared/src/test/scala/fs2/Generators.scala
@@ -22,9 +22,18 @@
 package fs2
 
 import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.util.Pretty
 import Arbitrary.arbitrary
 
 trait Generators extends ChunkGenerators {
+
+  implicit def streamPretty(s: Stream[Pure, Int]): Pretty = Pretty { _ =>
+    val n = 3
+    val xs = s.take(n.toLong + 1).compile.toList
+    val text = xs.take(n).mkString(", ")
+    val omission = if (xs.size == n + 1) ", ..." else ""
+    s"Stream($text$omission)"
+  }
 
   implicit def pureStreamGenerator[A: Arbitrary]: Arbitrary[Stream[Pure, A]] =
     Arbitrary {

--- a/core/shared/src/test/scala/fs2/HashSuite.scala
+++ b/core/shared/src/test/scala/fs2/HashSuite.scala
@@ -55,7 +55,7 @@ class HashSuite extends Fs2Suite with HashSuitePlatform with TestPlatform {
   }
 
   test("empty input") {
-    Stream.empty[IO].through(sha1).compile.count.assertEquals(20L)
+    Stream.empty.covary[IO].through(sha1).compile.count.assertEquals(20L)
   }
 
   test("zero or one output") {

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -41,18 +41,20 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
   group("awakeEvery") {
     test("basic") {
-      Stream
-        .awakeEvery[IO](500.millis)
-        .map(_.toMillis)
-        .take(5)
-        .compile
-        .toVector
-        .map { r =>
-          r.sliding(2)
-            .map(s => (s.head, s.tail.head))
-            .map { case (prev, next) => next - prev }
-            .foreach(delta => assert(delta >= 350L && delta <= 650L))
-        }
+      TestControl.executeEmbed {
+        Stream
+          .awakeEvery[IO](500.millis)
+          .map(_.toMillis)
+          .take(5)
+          .compile
+          .toVector
+          .map { r =>
+            r.sliding(2)
+              .map(s => (s.head, s.tail.head))
+              .map { case (prev, next) => next - prev }
+              .foreach(delta => assert(clue(delta) == 500L))
+          }
+      }
     }
 
     test("liveness") {
@@ -65,17 +67,17 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
     test("short periods, no underflow") {
       val input: Stream[IO, Int] = Stream.range(0, 10)
-      input.metered(1.nanos).assertEmitsSameAs(input)
+      TestControl.executeEmbed(input.metered(1.nanos).assertEmitsSameAs(input))
     }
 
     test("very short periods, no underflow") {
       val input: Stream[IO, Int] = Stream.range(0, 10)
-      input.metered(0.3.nanos).assertEmitsSameAs(input)
+      TestControl.executeEmbed(input.metered(0.3.nanos).assertEmitsSameAs(input))
     }
 
     test("zero-length periods, no underflow") {
       val input: Stream[IO, Int] = Stream.range(0, 10)
-      input.metered(0.nanos).assertEmitsSameAs(input)
+      TestControl.executeEmbed(input.metered(0.nanos).assertEmitsSameAs(input))
     }
 
     test("dampening") {
@@ -90,7 +92,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
         .toVector
         .map { v =>
           val elapsed = v.last - v.head
-          assert(elapsed > count * period)
+          assert(clue(elapsed) > count * period)
         }
     }
   }
@@ -261,19 +263,18 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
   test("duration") {
     val delay = 200.millis
-    Stream
-      .emit(())
-      .append(Stream.eval(IO.sleep(delay)))
-      .zip(Stream.duration[IO])
-      .drop(1)
-      .map(_._2)
-      .compile
-      .toVector
-      .map { result =>
-        assertEquals(result.size, 1)
-        val head = result.head
-        assert(clue(head.toMillis) >= clue(delay.toMillis - 5))
-      }
+    TestControl.executeEmbed {
+      Stream.unit
+        .append(Stream.sleep[IO](delay))
+        .zipRight(Stream.duration[IO])
+        .tail
+        .compile
+        .toVector
+        .map { result =>
+          assertEquals(clue(result.size), 1)
+          assert(clue(result.head.toMillis) == clue(delay.toMillis))
+        }
+    }
   }
 
   test("either") {
@@ -681,45 +682,47 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   group("groupWithin") {
+    implicit val groupSizeArb: Arbitrary[Int] = Arbitrary(Gen.choose(1, 20))
+    implicit val timeoutArb: Arbitrary[FiniteDuration] = Arbitrary(Gen.choose(0, 50).map(_.millis))
+
+    def sleep(d: Int): IO[Unit] = IO.sleep((d % 500).abs.micros)
+
     test("should never lose any elements") {
-      forAllF { (s0: Stream[Pure, Int], d0: Int, maxGroupSize0: Int) =>
-        val maxGroupSize = (maxGroupSize0 % 20).abs + 1
-        val d = (d0 % 50).abs.millis
-        val s = s0.map(i => (i % 500).abs)
-        s.covary[IO]
-          .evalTap(shortDuration => IO.sleep(shortDuration.micros))
-          .groupWithin(maxGroupSize, d)
-          .flatMap(s => Stream.emits(s.toList))
-          .assertEmitsSameAs(s)
+      forAllF { (s: Stream[Pure, Int], timeout: FiniteDuration, groupSize: Int) =>
+        TestControl.executeEmbed {
+          s.covary[IO]
+            .evalTap(sleep)
+            .groupWithin(groupSize, timeout)
+            .flatMap(Stream.chunk)
+            .assertEmitsSameAs(s)
+        }
       }
     }
 
     test("should never emit empty groups") {
-      forAllF { (s: Stream[Pure, Int], d0: Int, maxGroupSize0: Int) =>
-        val maxGroupSize = (maxGroupSize0 % 20).abs + 1
-        val d = (d0 % 50).abs.millis
-
-        s
-          .map(i => (i % 500).abs)
-          .covary[IO]
-          .evalTap(shortDuration => IO.sleep(shortDuration.micros))
-          .groupWithin(maxGroupSize, d)
-          .compile
-          .toList
-          .map(it => assert(it.forall(_.nonEmpty)))
+      forAllF { (s: Stream[Pure, Int], timeout: FiniteDuration, groupSize: Int) =>
+        TestControl.executeEmbed {
+          s
+            .covary[IO]
+            .evalTap(sleep)
+            .groupWithin(groupSize, timeout)
+            .compile
+            .toList
+            .map(it => assert(it.forall(_.nonEmpty)))
+        }
       }
     }
 
     test("should never have more elements than in its specified limit") {
-      forAllF { (s: Stream[Pure, Int], d0: Int, maxGroupSize0: Int) =>
-        val maxGroupSize = (maxGroupSize0 % 20).abs + 1
-        val d = (d0 % 50).abs.millis
-        s.map(i => (i % 500).abs)
-          .evalTap(shortDuration => IO.sleep(shortDuration.micros))
-          .groupWithin(maxGroupSize, d)
-          .compile
-          .toList
-          .map(it => assert(it.forall(_.size <= maxGroupSize)))
+      forAllF { (s: Stream[Pure, Int], timeout: FiniteDuration, groupSize: Int) =>
+        TestControl.executeEmbed {
+          s
+            .evalTap(sleep)
+            .groupWithin(groupSize, timeout)
+            .compile
+            .toList
+            .map(it => assert(it.forall(_.size <= groupSize)))
+        }
       }
     }
 
@@ -730,7 +733,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
       val groupedWithin = s.covary[IO].groupWithin(size, 1.second).map(_.toList)
       val expected = s.chunkN(size).map(_.toList)
 
-      groupedWithin.assertEmitsSameAs(expected)
+      TestControl.executeEmbed(groupedWithin.assertEmitsSameAs(expected))
     }
 
     test(
@@ -738,18 +741,20 @@ class StreamCombinatorsSuite extends Fs2Suite {
     ) {
       forAllF { (streamAsList0: List[Int]) =>
         val streamAsList = 0 :: streamAsList0
-        Stream
-          .emits(streamAsList)
-          .covary[IO]
-          .groupWithin(streamAsList.size, (Int.MaxValue - 1L).nanoseconds)
-          .compile
-          .toList
-          .map(_.head.toList)
-          .assertEquals(streamAsList)
+        TestControl.executeEmbed {
+          Stream
+            .emits(streamAsList)
+            .covary[IO]
+            .groupWithin(streamAsList.size, (Int.MaxValue - 1L).nanoseconds)
+            .compile
+            .toList
+            .map(_.head.toList)
+            .assertEquals(streamAsList)
+        }
       }
     }
 
-    test("accumulation and splitting".flaky) {
+    test("accumulation and splitting") {
       val t = 200.millis
       val size = 5
       val sleep = Stream.sleep_[IO](2 * t)
@@ -773,7 +778,12 @@ class StreamCombinatorsSuite extends Fs2Suite {
         List(19, 20, 21, 22)
       )
 
-      source.groupWithin(size, t).map(_.toList).assertEmits(expected)
+      TestControl.executeEmbed {
+        source
+          .groupWithin(size, t)
+          .map(_.toList)
+          .assertEmits(expected)
+      }
     }
 
     test("does not reset timeout if nothing is emitted") {
@@ -890,18 +900,20 @@ class StreamCombinatorsSuite extends Fs2Suite {
     test("stress test: all elements are processed") {
       val rangeLength = 10000
 
-      Stream
-        .eval(Ref.of[IO, Int](0))
-        .flatMap { counter =>
-          Stream
-            .range(0, rangeLength)
-            .covary[IO]
-            .groupWithin(4096, 100.micros)
-            .evalTap(ch => counter.update(_ + ch.size)) *> Stream.eval(counter.get)
-        }
-        .compile
-        .lastOrError
-        .assertEquals(rangeLength)
+      TestControl.executeEmbed {
+        Stream
+          .eval(Ref.of[IO, Int](0))
+          .flatMap { counter =>
+            Stream
+              .range(0, rangeLength)
+              .covary[IO]
+              .groupWithin(4096, 100.micros)
+              .evalTap(ch => counter.update(_ + ch.size)) *> Stream.eval(counter.get)
+          }
+          .compile
+          .lastOrError
+          .assertEquals(rangeLength)
+      }
     }
   }
 
@@ -1209,17 +1221,19 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
 
     test("starts in paused state") {
-      SignallingRef[IO, Boolean](true)
-        .product(Ref[IO].of(false))
-        .flatMap { case (pause, written) =>
-          Stream
-            .eval(written.set(true))
-            .pauseWhen(pause)
-            .timeout(200.millis)
-            .compile
-            .drain
-            .attempt >> written.get.assertEquals(false)
-        }
+      TestControl.executeEmbed {
+        SignallingRef[IO, Boolean](true)
+          .product(Ref[IO].of(false))
+          .flatMap { case (pause, written) =>
+            Stream
+              .eval(written.set(true))
+              .pauseWhen(pause)
+              .timeout(200.millis)
+              .compile
+              .drain
+              .attempt >> written.get.assertEquals(false)
+          }
+      }
     }
   }
 

--- a/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
@@ -362,7 +362,7 @@ class StreamInterruptSuite extends Fs2Suite {
 
   test("23 - sync compiler interruption - succeeds when interrupted never") {
     val ioNever = IO.never[Either[Throwable, Unit]]
-    compileWithSync(Stream.empty[IO].interruptWhen(ioNever)).toList.assertEquals(Nil)
+    compileWithSync(Stream.empty.covary[IO].interruptWhen(ioNever)).toList.assertEquals(Nil)
   }
 
   test("24 - sync compiler interruption - non-terminating when interrupted") {

--- a/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -107,8 +107,7 @@ class IoPlatformSuite extends Fs2Suite {
       )
     }
 
-    Stream
-      .empty
+    Stream.empty
       .covary[IO]
       .through(writeWritable[IO](writable))
       .compile

--- a/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -108,7 +108,8 @@ class IoPlatformSuite extends Fs2Suite {
     }
 
     Stream
-      .empty[IO]
+      .empty
+      .covary[IO]
       .through(writeWritable[IO](writable))
       .compile
       .drain


### PR DESCRIPTION
To give some context, @djspiewak  and I were looking through `merge` and found the implementation difficult to understand, then tried to rewrite it to use new cats-effect primitives.

I'm not sure that the code I've settled on is actually any better than the old implementation, but think it's worth getting a second opinion on. 

The main differences are:
 - The use of `SingallingRef` over two `Deferred`s for managing the upstream state.
 - The use of `evalMap(guard.aquire)` instead of an explicit pull for pulling from upstream.