### PR TITLE
Fix TLS session access on JS

### DIFF
--- a/io/js/src/main/scala/fs2/io/internal/facade/tls.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/tls.scala
@@ -188,6 +188,8 @@ package tls {
 
     def ssl: SSL = js.native
 
+    def getSession(): js.UndefOr[Uint8Array] = js.native
+
   }
 
   @js.native

--- a/io/js/src/main/scala/fs2/io/net/tls/TLSContextPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/tls/TLSContextPlatform.scala
@@ -89,8 +89,7 @@ private[tls] trait TLSContextCompanionPlatform { self: TLSContext.type =>
                             )
                         )
                         tlsSock
-                      },
-                      seqDispatcher
+                      }
                     )
                     .evalTap(_ => handshake.get.rethrow)
                 }
@@ -129,8 +128,7 @@ private[tls] trait TLSContextCompanionPlatform { self: TLSContext.type =>
                             )
                         )
                         tlsSock
-                      },
-                      seqDispatcher
+                      }
                     )
                     .evalTap(_ => verifyError.get.rethrow)
                 }

--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -270,7 +270,9 @@ class TLSSocketSuite extends TLSSuite {
             val echoServer = server
               .evalTap(s => s.applicationProtocol.assertEquals("h2"))
               .flatMap { socket =>
-                socket.reads.chunks.foreach(socket.write(_)) ++ Stream.eval(socket.session.void)
+                Stream
+                  .eval(socket.session)
+                  .concurrently(socket.reads.chunks.foreach(socket.write(_)))
               }
 
             val client = Stream.resource(clientSocket).flatMap { clientSocket =>

--- a/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/js/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -269,23 +269,21 @@ class TLSSocketSuite extends TLSSuite {
           .flatMap { case (server, clientSocket) =>
             val echoServer = server
               .evalTap(s => s.applicationProtocol.assertEquals("h2"))
-              .map { socket =>
-                socket.reads.chunks.foreach(socket.write(_)) ++ Stream.exec(socket.session.void)
+              .flatMap { socket =>
+                socket.reads.chunks.foreach(socket.write(_)) ++ Stream.eval(socket.session.void)
               }
-              .parJoinUnbounded
 
             val client = Stream.resource(clientSocket).flatMap { clientSocket =>
               Stream.exec(clientSocket.applicationProtocol.assertEquals("h2")) ++
                 Stream.exec(clientSocket.session.void) ++
                 Stream.exec(clientSocket.write(msg)) ++
-                clientSocket.reads.take(msg.size.toLong)
+                Stream.eval(clientSocket.readN(msg.size).assertEquals(msg))
             }
 
-            client.concurrently(echoServer)
+            client.parZip(echoServer)
           }
           .compile
-          .to(Chunk)
-          .assertEquals(msg)
+          .drain
       }
     }
 


### PR DESCRIPTION
We had a test, but it wasn't working properly for server-side TLS sockets. So I fixed that.

In the end fussing with `'session'` events was more complicated and didn't seem to work for server sockets anyway. Even though the docs warn against it for TLS v1.3 `getSession()` seems to work fine 🤔 

> Note: `getSession()` works only for TLSv1.2 and below. For TLSv1.3, applications must use the `'session'` event

https://nodejs.org/api/tls.html#tlssocketgetsession

Well, let me double-check that before we merge 😅 

Another one h/t @etspaceman