### PR TITLE
Handle `AggregateError`s on Node.js

### DIFF
--- a/io/js/src/main/scala/fs2/io/internal/facade/AggregateError.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/AggregateError.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.io.internal.facade
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+
+@JSGlobal
+@js.native
+private[io] class AggregateError extends js.Error {
+  def errors: js.Array[js.Error] = js.native
+}

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -161,7 +161,7 @@ class SocketSuite extends Fs2IoSuite with SocketSuitePlatform {
         .drain
     }
 
-    test("errors - should be captured in the effect".only) {
+    test("errors - should be captured in the effect") {
       (for {
         port <- Network[IO].serverResource(Some(ip"127.0.0.1")).use(s => IO.pure(s._1.port))
         _ <- Network[IO]

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -161,12 +161,15 @@ class SocketSuite extends Fs2IoSuite with SocketSuitePlatform {
         .drain
     }
 
-    test("errors - should be captured in the effect") {
+    test("errors - should be captured in the effect".only) {
       (for {
-        bindAddress <- Network[IO].serverResource(Some(ip"127.0.0.1")).use(s => IO.pure(s._1))
-        _ <- Network[IO].client(bindAddress).use(_ => IO.unit).recover {
-          case ex: ConnectException => assertEquals(ex.getMessage, "Connection refused")
-        }
+        port <- Network[IO].serverResource(Some(ip"127.0.0.1")).use(s => IO.pure(s._1.port))
+        _ <- Network[IO]
+          .client(SocketAddress(host"localhost", port))
+          .use_
+          .recover { case ex: ConnectException =>
+            assertEquals(ex.getMessage, "Connection refused")
+          }
       } yield ()) >> (for {
         bindAddress <- Network[IO].serverResource(Some(ip"127.0.0.1")).map(_._1)
         _ <- Network[IO]


### PR DESCRIPTION
Node.js 20 appears to have started throwing [`AggregateError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError)s in some situations (similar to FS2's `CompositeFailure`) e.g. see https://github.com/typelevel/skunk/pull/935#issue-1833175626. This confounds the `js.Error => java.io.IOException` translation. So now we specially handle `AggregateError` as part of that translation.



