### PR TITLE
fix comment about followLinks

### DIFF
--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -176,7 +176,7 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
   def getBasicFileAttributes(path: Path): F[BasicFileAttributes] =
     getBasicFileAttributes(path, false)
 
-  /** Gets `BasicFileAttributes` for the supplied path. Symbolic links are not followed when `followLinks` is true. */
+  /** Gets `BasicFileAttributes` for the supplied path. Symbolic links are followed when `followLinks` is true. */
   def getBasicFileAttributes(path: Path, followLinks: Boolean): F[BasicFileAttributes]
 
   /** Gets the last modified time of the supplied path.


### PR DESCRIPTION
The fixed comment contradicts with the [comment](https://github.com/typelevel/fs2/compare/main...nikiforo:fix-comment?expand=1#diff-9ec1ae212cbd3462c65322379f67496c8c4274971e5f2e4fe3033c42a69e2cf0R175) above it.
Also, all other comments about methods with explicit `followLinks` attribute in `Files.scala` are used without negation.
Moreover, in sources `followLinks` means `stat`, which follows link.

