### PR TITLE
Chunk improvements

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,3 @@
--J-Xms4g
--J-Xmx8g
--J-XX:MaxMetaspaceSize=1024m
+-J-Xms2g
+-J-Xmx4g
+-J-XX:MaxMetaspaceSize=512m

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,3 @@
--J-Xms2g
--J-Xmx4g
--J-XX:MaxMetaspaceSize=512m
+-J-Xms4g
+-J-Xmx8g
+-J-XX:MaxMetaspaceSize=1024m

--- a/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
@@ -33,7 +33,7 @@ class ChunkBenchmark {
 
   @Setup
   def setup() =
-    ints = Chunk.seq((0 until chunkSize).map(_ + 1000)).compact
+    ints = Chunk.from((0 until chunkSize).map(_ + 1000)).compact
 
   @Benchmark
   def map(): Unit = {

--- a/benchmark/src/main/scala/fs2/benchmark/ChunksBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChunksBenchmark.scala
@@ -45,9 +45,9 @@ class ChunksBenchmark {
 
   @Setup
   def setup() = {
-    chunkSeq = Seq.range(0, chunkCount).map(_ => Chunk.seq(Seq.fill(chunkSize)(Obj.create)))
+    chunkSeq = Seq.range(0, chunkCount).map(_ => Chunk.from(Seq.fill(chunkSize)(Obj.create)))
     sizeHint = chunkSeq.foldLeft(0)(_ + _.size)
-    flattened = Chunk.seq(chunkSeq).flatten
+    flattened = Chunk.from(chunkSeq).flatten
   }
 
   @Benchmark

--- a/benchmark/src/main/scala/fs2/benchmark/LinesBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/LinesBenchmark.scala
@@ -49,7 +49,7 @@ class LinesBenchmark {
           .grouped(chunkSize)
           .grouped(chunkSize)
           .foldLeft(Stream[IO, String]()) { case (acc, strings) =>
-            acc ++ Stream.chunk(Chunk.seq(strings))
+            acc ++ Stream.chunk(Chunk.from(strings))
           }
       }
 

--- a/benchmark/src/main/scala/fs2/benchmark/PullBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/PullBenchmark.scala
@@ -34,7 +34,7 @@ class PullBenchmark {
   @Benchmark
   def unconsPull(): Int = {
     val s: Stream[Pure, Int] = Stream
-      .chunk(Chunk.seq(0 to 2560))
+      .chunk(Chunk.from(0 to 2560))
       .repeatPull { s =>
         s.unconsN(n).flatMap {
           case Some((h, t)) => Pull.output(h).as(Some(t))

--- a/build.sbt
+++ b/build.sbt
@@ -215,6 +215,10 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[DirectMissingMethodProblem](
     "fs2.io.file.Watcher#DefaultWatcher.this"
+  ),
+  // Private internal method: #3274
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "fs2.Chunk.platformIterable"
   )
 )
 

--- a/core/shared/src/main/scala-2.12/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-2.12/fs2/ChunkPlatform.scala
@@ -22,6 +22,7 @@
 package fs2
 
 import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.{Iterable => GIterable}
 import scala.collection.generic.{CanBuildFrom, GenericCompanion}
 import scala.collection.mutable.{Builder, WrappedArray}
 import scala.reflect.ClassTag
@@ -65,16 +66,22 @@ private[fs2] trait ChunkAsSeqPlatform[+O] {
 private[fs2] trait ChunkCompanionPlatform {
   self: Chunk.type =>
 
-  protected def platformIterable[O](i: Iterable[O]): Option[Chunk[O]] =
+  protected def platformFrom[O](i: GIterable[O]): Option[Chunk[O]] =
     i match {
-      case a: WrappedArray[O] => Some(wrappedArray(a))
-      case _                  => None
+      case wrappedArray: WrappedArray[O] =>
+        val arr = wrappedArray.array.asInstanceOf[Array[O]]
+        Some(array(arr)(ClassTag(arr.getClass.getComponentType)))
+
+      case _ =>
+        None
     }
 
   /** Creates a chunk backed by a `WrappedArray`
     */
-  def wrappedArray[O](wrappedArray: WrappedArray[O]): Chunk[O] = {
-    val arr = wrappedArray.array.asInstanceOf[Array[O]]
-    array(arr)(ClassTag(arr.getClass.getComponentType))
-  }
+  @deprecated(
+    "Use the `from` general factory instead",
+    "3.8.1"
+  )
+  def wrappedArray[O](wrappedArray: WrappedArray[O]): Chunk[O] =
+    from(wrappedArray)
 }

--- a/core/shared/src/main/scala-2.12/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-2.12/fs2/ChunkPlatform.scala
@@ -29,7 +29,7 @@ import scala.reflect.ClassTag
 private[fs2] trait ChunkPlatform[+O] {
   self: Chunk[O] =>
 
-  def asSeqPlatform: Option[Seq[O]] =
+  def asSeqPlatform: Option[IndexedSeq[O]] =
     None
 }
 
@@ -42,11 +42,11 @@ private[fs2] trait ChunkAsSeqPlatform[+O] {
   override def copyToArray[O2 >: O](xs: Array[O2], start: Int, len: Int): Unit =
     chunk.take(len).copyToArray(xs, start)
 
-  override def map[O2, That](f: O ⇒ O2)(implicit bf: CanBuildFrom[Seq[O], O2, That]): That =
+  override def map[O2, That](f: O ⇒ O2)(implicit bf: CanBuildFrom[IndexedSeq[O], O2, That]): That =
     new ChunkAsSeq(chunk.map(f)).asInstanceOf[That]
 
   override def zipWithIndex[O2 >: O, That](implicit
-      bf: CanBuildFrom[Seq[O], (O2, Int), That]
+      bf: CanBuildFrom[IndexedSeq[O], (O2, Int), That]
   ): That =
     new ChunkAsSeq(chunk.zipWithIndex).asInstanceOf[That]
 
@@ -55,10 +55,10 @@ private[fs2] trait ChunkAsSeqPlatform[+O] {
   ): Col[O @uncheckedVariance] =
     chunk.to(cbf)
 
-  override def genericBuilder[B]: Builder[B, Seq[B]] =
+  override def genericBuilder[B]: Builder[B, IndexedSeq[B]] =
     Vector.newBuilder
 
-  override def companion: GenericCompanion[Seq] =
+  override def companion: GenericCompanion[IndexedSeq] =
     Vector
 }
 

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package fs2
 
 import scala.collection.immutable.ArraySeq

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -120,7 +120,7 @@ private[fs2] final class ChunkAsSeq[+O](
     chunk.toVector
 
   override def toString: String =
-    chunk.toString
+    chunk.iterator.mkString("ChunkAsSeq(", ", ", ")")
 
   override def zipWithIndex: Seq[(O, Int)] =
     new ChunkAsSeq(chunk.zipWithIndex)

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -70,6 +70,9 @@ private[fs2] final class ChunkAsSeq[+O](
   override def isEmpty: Boolean =
     chunk.isEmpty
 
+  override def reverseIterator: Iterator[O] =
+    chunk.reverseIterator
+
   override def foreach[U](f: O => U): Unit =
     chunk.foreach { o => f(o); () }
 

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -57,13 +57,13 @@ private[fs2] trait ChunkAsSeq213And3Compat[+O] {
     math.min(len, xs.length - start)
   }
 
-  override def map[O2](f: O => O2): Seq[O2] =
+  override def map[O2](f: O => O2): IndexedSeq[O2] =
     new ChunkAsSeq(chunk.map(f))
 
-  override def zipWithIndex: Seq[(O, Int)] =
+  override def zipWithIndex: IndexedSeq[(O, Int)] =
     new ChunkAsSeq(chunk.zipWithIndex)
 
-  override def tapEach[U](f: O => U): Seq[O] = {
+  override def tapEach[U](f: O => U): IndexedSeq[O] = {
     chunk.foreach { o => f(o); () }
     this
   }
@@ -71,10 +71,10 @@ private[fs2] trait ChunkAsSeq213And3Compat[+O] {
   override def to[C1](factory: Factory[O, C1]): C1 =
     chunk.to(factory)
 
-  override val iterableFactory: SeqFactory[Seq] =
+  override val iterableFactory: SeqFactory[IndexedSeq] =
     ArraySeq.untagged
 
-  override val empty: Seq[O] =
+  override val empty: IndexedSeq[O] =
     new ChunkAsSeq(Chunk.empty)
 }
 

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -46,6 +46,7 @@ private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
   /** Views this Chunk as a Scala immutable Seq.
     * Contrary to all methods that start with _"to"_ (e.g. {{toVector}}, {{toArray}}),
     * this method does not copy data.
+    * As such, this method is mostly intended for `foreach` kind of interop.
     */
   def asSeq: Seq[O] =
     new ChunkAsSeq(this)

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -87,9 +87,6 @@ private[fs2] trait ChunkCompanion213And3Compat {
         val arr = arraySeq.unsafeArray.asInstanceOf[Array[O]]
         Some(array(arr)(ClassTag[O](arr.getClass.getComponentType)))
 
-      case w: ChunkAsSeq[O] =>
-        Some(w.chunk)
-
       case _ =>
         None
     }

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -51,7 +51,9 @@ private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
     new ChunkAsSeq(this)
 }
 
-private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O]) extends immutable.Seq[O] {
+private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O])
+    extends immutable.Seq[O]
+    with Serializable {
   override def iterator: Iterator[O] =
     chunk.iterator
 

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -74,7 +74,7 @@ private[fs2] trait ChunkAsSeq213And3Compat[+O] {
   override val iterableFactory: SeqFactory[IndexedSeq] =
     ArraySeq.untagged
 
-  override val empty: IndexedSeq[O] =
+  override lazy val empty: IndexedSeq[O] =
     new ChunkAsSeq(Chunk.empty)
 }
 

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -51,7 +51,10 @@ private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
     new ChunkAsSeq(this)
 }
 
-private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O]) extends Seq[O] with Serializable {
+private[fs2] final class ChunkAsSeq[+O](
+    private val chunk: Chunk[O]
+) extends Seq[O]
+    with Serializable {
   override def iterator: Iterator[O] =
     chunk.iterator
 
@@ -61,6 +64,12 @@ private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O]) extends Seq[O] with Ser
   override def length: Int =
     chunk.size
 
+  override def knownSize: Int =
+    chunk.size
+
+  override def isEmpty: Boolean =
+    chunk.isEmpty
+
   override def foreach[U](f: O => U): Unit =
     chunk.foreach { o => f(o); () }
 
@@ -69,10 +78,7 @@ private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O]) extends Seq[O] with Ser
     this
   }
 
-  override def isEmpty: Boolean =
-    chunk.isEmpty
-
-  override def copyToArray[B >: O](xs: Array[B], start: Int, len: Int): Int = {
+  override def copyToArray[O2 >: O](xs: Array[O2], start: Int, len: Int): Int = {
     chunk.take(len).copyToArray(xs, start)
     math.min(len, xs.length - start)
   }
@@ -100,7 +106,7 @@ private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O]) extends Seq[O] with Ser
   override def to[C1](factory: Factory[O, C1]): C1 =
     chunk.to(factory)
 
-  override def toArray[B >: O: ClassTag]: Array[B] =
+  override def toArray[O2 >: O: ClassTag]: Array[O2] =
     chunk.toArray
 
   override def toList: List[O] =
@@ -114,6 +120,15 @@ private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O]) extends Seq[O] with Ser
 
   override def zipWithIndex: Seq[(O, Int)] =
     new ChunkAsSeq(chunk.zipWithIndex)
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case thatChunkWrapper: ChunkAsSeq[_] =>
+        chunk == thatChunkWrapper.chunk
+
+      case _ =>
+        false
+    }
 }
 
 private[fs2] trait ChunkCompanion213And3Compat { self: Chunk.type =>

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -49,7 +49,19 @@ private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
     * As such, this method is mostly intended for `foreach` kind of interop.
     */
   def asSeq: Seq[O] =
-    new ChunkAsSeq(this)
+    this match {
+      case indexedSeqChunk: Chunk.IndexedSeqChunk[_] =>
+        indexedSeqChunk.s match {
+          case seq: Seq[O] =>
+            seq
+
+          case _ =>
+            new ChunkAsSeq(this)
+        }
+
+      case _ =>
+        new ChunkAsSeq(this)
+    }
 }
 
 private[fs2] final class ChunkAsSeq[+O](

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -21,8 +21,8 @@
 
 package fs2
 
+import scala.collection.Factory
 import scala.collection.immutable.ArraySeq
-import scala.collection.immutable
 import scala.reflect.ClassTag
 
 private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
@@ -51,9 +51,7 @@ private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
     new ChunkAsSeq(this)
 }
 
-private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O])
-    extends immutable.Seq[O]
-    with Serializable {
+private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O]) extends Seq[O] with Serializable {
   override def iterator: Iterator[O] =
     chunk.iterator
 
@@ -62,23 +60,77 @@ private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O])
 
   override def length: Int =
     chunk.size
+
+  override def foreach[U](f: O => U): Unit =
+    chunk.foreach { o => f(o); () }
+
+  override def tapEach[U](f: O => U): Seq[O] = {
+    chunk.foreach { o => f(o); () }
+    this
+  }
+
+  override def isEmpty: Boolean =
+    chunk.isEmpty
+
+  override def copyToArray[B >: O](xs: Array[B], start: Int, len: Int): Int = {
+    chunk.take(len).copyToArray(xs, start)
+    math.min(len, xs.length - start)
+  }
+
+  override def headOption: Option[O] =
+    chunk.head
+
+  override def head: O =
+    if (chunk.nonEmpty) chunk.apply(0)
+    else throw new NoSuchElementException("head of empty Seq")
+
+  override def lastOption: Option[O] =
+    chunk.last
+
+  override def last: O =
+    if (chunk.nonEmpty) chunk.apply(chunk.size - 1)
+    else throw new NoSuchElementException("tail of empty Seq")
+
+  override def take(n: Int): Seq[O] =
+    new ChunkAsSeq(chunk.take(n))
+
+  override def takeRight(n: Int): Seq[O] =
+    new ChunkAsSeq(chunk.takeRight(n))
+
+  override def to[C1](factory: Factory[O, C1]): C1 =
+    chunk.to(factory)
+
+  override def toArray[B >: O: ClassTag]: Array[B] =
+    chunk.toArray
+
+  override def toList: List[O] =
+    chunk.toList
+
+  override def toVector: Vector[O] =
+    chunk.toVector
+
+  override def toString: String =
+    chunk.toString
+
+  override def zipWithIndex: Seq[(O, Int)] =
+    new ChunkAsSeq(chunk.zipWithIndex)
 }
 
 private[fs2] trait ChunkCompanion213And3Compat { self: Chunk.type =>
 
   protected def platformIterable[O](i: Iterable[O]): Option[Chunk[O]] =
     i match {
-      case a: immutable.ArraySeq[O] => Some(arraySeq(a))
-      case _                        => None
+      case a: ArraySeq[O] => Some(arraySeq(a))
+      case _              => None
     }
 
   /** Creates a chunk backed by an immutable `ArraySeq`. */
-  def arraySeq[O](arraySeq: immutable.ArraySeq[O]): Chunk[O] = {
+  def arraySeq[O](arraySeq: ArraySeq[O]): Chunk[O] = {
     val arr = arraySeq.unsafeArray.asInstanceOf[Array[O]]
     array(arr)(ClassTag[O](arr.getClass.getComponentType))
   }
 
   /** Creates a chunk from a `scala.collection.IterableOnce`. */
-  def iterableOnce[O](i: collection.IterableOnce[O]): Chunk[O] =
+  def iterableOnce[O](i: IterableOnce[O]): Chunk[O] =
     iterator(i.iterator)
 }

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -52,7 +52,7 @@ private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
 }
 
 private[fs2] final class ChunkAsSeq[+O](
-    private val chunk: Chunk[O]
+    private[fs2] val chunk: Chunk[O]
 ) extends Seq[O]
     with Serializable {
   override def iterator: Iterator[O] =
@@ -138,8 +138,9 @@ private[fs2] trait ChunkCompanion213And3Compat { self: Chunk.type =>
 
   protected def platformIterable[O](i: Iterable[O]): Option[Chunk[O]] =
     i match {
-      case a: ArraySeq[O] => Some(arraySeq(a))
-      case _              => None
+      case a: ArraySeq[O]   => Some(arraySeq(a))
+      case w: ChunkAsSeq[O] => Some(w.chunk)
+      case _                => None
     }
 
   /** Creates a chunk backed by an immutable `ArraySeq`. */

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -25,7 +25,9 @@ import scala.collection.{Factory, SeqFactory}
 import scala.collection.immutable.ArraySeq
 import scala.reflect.ClassTag
 
-private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
+private[fs2] trait Chunk213And3Compat[+O] {
+  self: Chunk[O] =>
+
   def toArraySeq[O2 >: O: ClassTag]: ArraySeq[O2] = {
     val array: Array[O2] = new Array[O2](size)
     copyToArray(array)
@@ -42,117 +44,32 @@ private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
     }
     buf.result()
   }
-
-  /** Views this Chunk as a Scala immutable Seq.
-    * Contrary to all methods that start with _"to"_ (e.g. {{toVector}}, {{toArray}}),
-    * this method does not copy data.
-    * As such, this method is mostly intended for `foreach` kind of interop.
-    */
-  def asSeq: Seq[O] =
-    this match {
-      case indexedSeqChunk: Chunk.IndexedSeqChunk[_] =>
-        indexedSeqChunk.s match {
-          case seq: Seq[O] =>
-            seq
-
-          case _ =>
-            new ChunkAsSeq(this)
-        }
-
-      case arraySlice: Chunk.ArraySlice[_] =>
-        ArraySeq
-          .unsafeWrapArray(arraySlice.values)
-          .slice(
-            from = arraySlice.offset,
-            until = arraySlice.offset + arraySlice.length
-          )
-
-      case _ =>
-        new ChunkAsSeq(this)
-    }
 }
 
-private[fs2] final class ChunkAsSeq[+O](
-    private[fs2] val chunk: Chunk[O]
-) extends Seq[O]
-    with Serializable {
-  override def iterator: Iterator[O] =
-    chunk.iterator
-
-  override def apply(i: Int): O =
-    chunk.apply(i)
-
-  override def length: Int =
-    chunk.size
+private[fs2] trait ChunkAsSeq213And3Compat[+O] {
+  self: ChunkAsSeq[O] =>
 
   override def knownSize: Int =
     chunk.size
-
-  override def isEmpty: Boolean =
-    chunk.isEmpty
-
-  override def reverseIterator: Iterator[O] =
-    chunk.reverseIterator
-
-  override def foreach[U](f: O => U): Unit =
-    chunk.foreach { o => f(o); () }
-
-  override def tapEach[U](f: O => U): Seq[O] = {
-    chunk.foreach { o => f(o); () }
-    this
-  }
 
   override def copyToArray[O2 >: O](xs: Array[O2], start: Int, len: Int): Int = {
     chunk.take(len).copyToArray(xs, start)
     math.min(len, xs.length - start)
   }
 
-  override def headOption: Option[O] =
-    chunk.head
-
-  override def head: O =
-    if (chunk.nonEmpty) chunk.apply(0)
-    else throw new NoSuchElementException("head of empty Seq")
-
-  override def lastOption: Option[O] =
-    chunk.last
-
-  override def last: O =
-    if (chunk.nonEmpty) chunk.apply(chunk.size - 1)
-    else throw new NoSuchElementException("tail of empty Seq")
-
-  override def take(n: Int): Seq[O] =
-    new ChunkAsSeq(chunk.take(n))
-
-  override def takeRight(n: Int): Seq[O] =
-    new ChunkAsSeq(chunk.takeRight(n))
-
-  override def to[C1](factory: Factory[O, C1]): C1 =
-    chunk.to(factory)
-
-  override def toArray[O2 >: O: ClassTag]: Array[O2] =
-    chunk.toArray
-
-  override def toList: List[O] =
-    chunk.toList
-
-  override def toVector: Vector[O] =
-    chunk.toVector
-
-  override def toString: String =
-    chunk.iterator.mkString("ChunkAsSeq(", ", ", ")")
+  override def map[O2](f: O => O2): Seq[O2] =
+    new ChunkAsSeq(chunk.map(f))
 
   override def zipWithIndex: Seq[(O, Int)] =
     new ChunkAsSeq(chunk.zipWithIndex)
 
-  override def equals(that: Any): Boolean =
-    that match {
-      case thatChunkWrapper: ChunkAsSeq[_] =>
-        chunk == thatChunkWrapper.chunk
+  override def tapEach[U](f: O => U): Seq[O] = {
+    chunk.foreach { o => f(o); () }
+    this
+  }
 
-      case _ =>
-        false
-    }
+  override def to[C1](factory: Factory[O, C1]): C1 =
+    chunk.to(factory)
 
   override val iterableFactory: SeqFactory[Seq] =
     ArraySeq.untagged
@@ -161,7 +78,8 @@ private[fs2] final class ChunkAsSeq[+O](
     new ChunkAsSeq(Chunk.empty)
 }
 
-private[fs2] trait ChunkCompanion213And3Compat { self: Chunk.type =>
+private[fs2] trait ChunkCompanion213And3Compat {
+  self: Chunk.type =>
 
   protected def platformIterable[O](i: Iterable[O]): Option[Chunk[O]] =
     i match {

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -59,6 +59,14 @@ private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
             new ChunkAsSeq(this)
         }
 
+      case arraySlice: Chunk.ArraySlice[_] =>
+        ArraySeq
+          .unsafeWrapArray(arraySlice.values)
+          .slice(
+            from = arraySlice.offset,
+            until = arraySlice.offset + arraySlice.length
+          )
+
       case _ =>
         new ChunkAsSeq(this)
     }

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -1,0 +1,42 @@
+package fs2
+
+import scala.collection.immutable.ArraySeq
+import scala.collection.immutable
+import scala.reflect.ClassTag
+
+private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
+  def toArraySeq[O2 >: O: ClassTag]: ArraySeq[O2] = {
+    val array: Array[O2] = new Array[O2](size)
+    copyToArray(array)
+    ArraySeq.unsafeWrapArray[O2](array)
+  }
+
+  def toArraySeqUntagged: ArraySeq[O] = {
+    val buf = ArraySeq.untagged.newBuilder[O]
+    buf.sizeHint(size)
+    var i = 0
+    while (i < size) {
+      buf += apply(i)
+      i += 1
+    }
+    buf.result()
+  }
+}
+
+private[fs2] trait ChunkCompanion213And3Compat { self: Chunk.type =>
+  protected def platformIterable[O](i: Iterable[O]): Option[Chunk[O]] =
+    i match {
+      case a: immutable.ArraySeq[O] => Some(arraySeq(a))
+      case _                        => None
+    }
+
+  /** Creates a chunk backed by an immutable `ArraySeq`. */
+  def arraySeq[O](arraySeq: immutable.ArraySeq[O]): Chunk[O] = {
+    val arr = arraySeq.unsafeArray.asInstanceOf[Array[O]]
+    array(arr)(ClassTag[O](arr.getClass.getComponentType))
+  }
+
+  /** Creates a chunk from a `scala.collection.IterableOnce`. */
+  def iterableOnce[O](i: collection.IterableOnce[O]): Chunk[O] =
+    iterator(i.iterator)
+}

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -21,9 +21,28 @@ private[fs2] trait Chunk213And3Compat[+O] { self: Chunk[O] =>
     }
     buf.result()
   }
+
+  /** Views this Chunk as a Scala immutable Seq.
+    * Contrary to all methods that start with _"to"_ (e.g. {{toVector}}, {{toArray}}),
+    * this method does not copy data.
+    */
+  def asSeq: Seq[O] =
+    new ChunkAsSeq(this)
+}
+
+private[fs2] final class ChunkAsSeq[+O](chunk: Chunk[O]) extends immutable.Seq[O] {
+  override def iterator: Iterator[O] =
+    chunk.iterator
+
+  override def apply(i: Int): O =
+    chunk.apply(i)
+
+  override def length: Int =
+    chunk.size
 }
 
 private[fs2] trait ChunkCompanion213And3Compat { self: Chunk.type =>
+
   protected def platformIterable[O](i: Iterable[O]): Option[Chunk[O]] =
     i match {
       case a: immutable.ArraySeq[O] => Some(arraySeq(a))

--- a/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
+++ b/core/shared/src/main/scala-2.13+/fs2/Chunk213And3Compat.scala
@@ -21,7 +21,7 @@
 
 package fs2
 
-import scala.collection.Factory
+import scala.collection.{Factory, SeqFactory}
 import scala.collection.immutable.ArraySeq
 import scala.reflect.ClassTag
 
@@ -133,6 +133,12 @@ private[fs2] final class ChunkAsSeq[+O](
       case _ =>
         false
     }
+
+  override val iterableFactory: SeqFactory[Seq] =
+    ArraySeq.untagged
+
+  override val empty: Seq[O] =
+    new ChunkAsSeq(Chunk.empty)
 }
 
 private[fs2] trait ChunkCompanion213And3Compat { self: Chunk.type =>

--- a/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
@@ -26,7 +26,7 @@ import scala.collection.immutable.ArraySeq
 private[fs2] trait ChunkPlatform[+O] extends Chunk213And3Compat[O] {
   self: Chunk[O] =>
 
-  def asSeqPlatform: Option[Seq[O]] =
+  def asSeqPlatform: Option[IndexedSeq[O]] =
     this match {
       case arraySlice: Chunk.ArraySlice[_] =>
         Some(

--- a/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
@@ -21,7 +21,32 @@
 
 package fs2
 
-private[fs2] trait ChunkPlatform[+O] extends Chunk213And3Compat[O] { self: Chunk[O] => }
+import scala.collection.immutable.ArraySeq
 
-private[fs2] trait ChunkCompanionPlatform extends ChunkCompanion213And3Compat { self: Chunk.type =>
+private[fs2] trait ChunkPlatform[+O] extends Chunk213And3Compat[O] {
+  self: Chunk[O] =>
+
+  def asSeqPlatform: Option[Seq[O]] =
+    this match {
+      case arraySlice: Chunk.ArraySlice[_] =>
+        Some(
+          ArraySeq
+            .unsafeWrapArray(arraySlice.values)
+            .slice(
+              from = arraySlice.offset,
+              until = arraySlice.offset + arraySlice.length
+            )
+        )
+
+      case _ =>
+        None
+    }
+}
+
+private[fs2] trait ChunkAsSeqPlatform[+O] extends ChunkAsSeq213And3Compat[O] {
+  self: ChunkAsSeq[O] =>
+}
+
+private[fs2] trait ChunkCompanionPlatform extends ChunkCompanion213And3Compat {
+  self: Chunk.type =>
 }

--- a/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
@@ -21,46 +21,7 @@
 
 package fs2
 
-import scala.collection.immutable.ArraySeq
-import scala.collection.immutable
-import scala.reflect.ClassTag
+private[fs2] trait ChunkPlatform[+O] extends Chunk213And3Compat[O] { self: Chunk[O] => }
 
-private[fs2] trait ChunkPlatform[+O] { self: Chunk[O] =>
-
-  def toArraySeq[O2 >: O: ClassTag]: ArraySeq[O2] = {
-    val array: Array[O2] = new Array[O2](size)
-    copyToArray(array)
-    ArraySeq.unsafeWrapArray[O2](array)
-  }
-
-  def toArraySeqUntagged: ArraySeq[O] = {
-    val buf = ArraySeq.untagged.newBuilder[O]
-    buf.sizeHint(size)
-    var i = 0
-    while (i < size) {
-      buf += apply(i)
-      i += 1
-    }
-    buf.result()
-  }
-}
-
-private[fs2] trait ChunkCompanionPlatform { self: Chunk.type =>
-
-  protected def platformIterable[O](i: Iterable[O]): Option[Chunk[O]] =
-    i match {
-      case a: immutable.ArraySeq[O] => Some(arraySeq(a))
-      case _                        => None
-    }
-
-  /** Creates a chunk backed by an immutable `ArraySeq`.
-    */
-  def arraySeq[O](arraySeq: immutable.ArraySeq[O]): Chunk[O] = {
-    val arr = arraySeq.unsafeArray.asInstanceOf[Array[O]]
-    array(arr)(ClassTag[O](arr.getClass.getComponentType))
-  }
-
-  /** Creates a chunk from a `scala.collection.IterableOnce`. */
-  def iterableOnce[O](i: collection.IterableOnce[O]): Chunk[O] =
-    iterator(i.iterator)
+private[fs2] trait ChunkCompanionPlatform extends ChunkCompanion213And3Compat { self: Chunk.type =>
 }

--- a/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
@@ -27,25 +27,7 @@ import scala.collection.immutable.ArraySeq
 import scala.collection.immutable
 import scala.reflect.ClassTag
 
-private[fs2] trait ChunkPlatform[+O] { self: Chunk[O] =>
-
-  def toArraySeq[O2 >: O: ClassTag]: ArraySeq[O2] = {
-    val array: Array[O2] = new Array[O2](size)
-    copyToArray(array)
-    ArraySeq.unsafeWrapArray[O2](array)
-  }
-
-  def toArraySeqUntagged: ArraySeq[O] = {
-    val buf = ArraySeq.untagged.newBuilder[O]
-    buf.sizeHint(size)
-    var i = 0
-    while (i < size) {
-      buf += apply(i)
-      i += 1
-    }
-    buf.result()
-  }
-
+private[fs2] trait ChunkPlatform[+O] extends Chunk213And3Compat[O] { self: Chunk[O] =>
   def toIArray[O2 >: O: ClassTag]: IArray[O2] = IArray.unsafeFromArray(toArray)
 
   def toIArraySlice[O2 >: O](implicit ct: ClassTag[O2]): Chunk.IArraySlice[O2] =
@@ -56,27 +38,12 @@ private[fs2] trait ChunkPlatform[+O] { self: Chunk[O] =>
     }
 }
 
-private[fs2] trait ChunkCompanionPlatform { self: Chunk.type =>
+private[fs2] trait ChunkCompanionPlatform extends ChunkCompanion213And3Compat { self: Chunk.type =>
 
-  protected def platformIterable[O](i: Iterable[O]): Option[Chunk[O]] =
-    i match {
-      case a: immutable.ArraySeq[O] => Some(arraySeq(a))
-      case _                        => None
-    }
-
-  /** Creates a chunk backed by an immutable `ArraySeq`.
-    */
-  def arraySeq[O](arraySeq: immutable.ArraySeq[O]): Chunk[O] = {
-    val arr = arraySeq.unsafeArray.asInstanceOf[Array[O]]
-    array(arr)(ClassTag[O](arr.getClass.getComponentType))
-  }
-
-  /** Creates a chunk backed by an immutable array.
-    */
+  /** Creates a chunk backed by an immutable array. */
   def iarray[O: ClassTag](arr: IArray[O]): Chunk[O] = new IArraySlice(arr, 0, arr.length)
 
-  /** Creates a chunk backed by a slice of an immutable array.
-    */
+  /** Creates a chunk backed by a slice of an immutable array. */
   def iarray[O: ClassTag](arr: IArray[O], offset: Int, length: Int): Chunk[O] =
     new IArraySlice(arr, offset, length)
 
@@ -121,8 +88,4 @@ private[fs2] trait ChunkCompanionPlatform { self: Chunk.type =>
         ByteVector.view(values.asInstanceOf[Array[Byte]], offset, length)
       else ByteVector.viewAt(i => apply(i.toInt), size.toLong)
   }
-
-  /** Creates a chunk from a `scala.collection.IterableOnce`. */
-  def iterableOnce[O](i: collection.IterableOnce[O]): Chunk[O] =
-    iterator(i.iterator)
 }

--- a/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
@@ -39,7 +39,7 @@ private[fs2] trait ChunkPlatform[+O] extends Chunk213And3Compat[O] {
       case _ => new Chunk.IArraySlice(IArray.unsafeFromArray(toArray(ct)), 0, size)
     }
 
-  def asSeqPlatform: Option[Seq[O]] =
+  def asSeqPlatform: Option[IndexedSeq[O]] =
     this match {
       case arraySlice: Chunk.ArraySlice[_] =>
         Some(

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1559,10 +1559,8 @@ private[fs2] final class ChunkAsSeq[+O](
   override def toString: String =
     chunk.iterator.mkString("ChunkAsSeq(", ", ", ")")
 
-  override def hashCode: Int = {
-    import util.hashing.MurmurHash3
-    MurmurHash3.indexedSeqHash(this, seed = MurmurHash3.seqSeed)
-  }
+  override def hashCode: Int =
+    util.hashing.MurmurHash3.seqHash(this)
 
   override def equals(that: Any): Boolean =
     that match {

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -679,6 +679,8 @@ object Chunk
         new ArraySlice(arr, 0, size)(ClassTag.Object.asInstanceOf[ClassTag[O with Object]])
     }
 
+  // Added in the "Avoid copying" spirit.
+  // It may be better removed if data shows it has little usage.
   private final class JavaListChunk[O](
       javaList: ju.List[O] with ju.RandomAccess
   ) extends Chunk[O] {

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -88,6 +88,10 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
     Chunk.array(b.result()).asInstanceOf[Chunk[O2]]
   }
 
+  /** Returns true if the Chunk contains the given element. */
+  def contains[O2 >: O](elem: O2): Boolean =
+    iterator.contains(elem)
+
   /** Copies the elements of this chunk in to the specified array at the specified start index. */
   def copyToArray[O2 >: O](xs: Array[O2], start: Int = 0): Unit
 
@@ -104,11 +108,19 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
   def compactUntagged[O2 >: O]: Chunk.ArraySlice[O2] =
     Chunk.ArraySlice(toArray[Any], 0, size).asInstanceOf[Chunk.ArraySlice[O2]]
 
+  /** Counts the number of elements which satisfy a predicate. */
+  def count(p: O => Boolean): Int =
+    iterator.count(p)
+
   /** Drops the first `n` elements of this chunk. */
   def drop(n: Int): Chunk[O] = splitAt(n)._2
 
   /** Drops the right-most `n` elements of this chunk queue in a way that preserves chunk structure. */
   def dropRight(n: Int): Chunk[O] = if (n <= 0) this else take(size - n)
+
+  /** Returns true if at least one element passes the predicate. */
+  def exists(p: O => Boolean): Boolean =
+    iterator.exists(p)
 
   protected def thisClassTag: ClassTag[Any] = implicitly[ClassTag[Any]]
 

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1338,6 +1338,7 @@ object Chunk
 private[fs2] final class ChunkAsJavaList[O](
     private[fs2] val chunk: Chunk[O]
 ) extends ju.AbstractList[O]
+    with ju.RandomAccess
     with Serializable {
   override def size: Int =
     chunk.size

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1533,6 +1533,9 @@ private[fs2] final class ChunkAsSeq[+O](
       case thatChunkWrapper: ChunkAsSeq[_] =>
         chunk == thatChunkWrapper.chunk
 
+      case seq: GSeq[_] =>
+        chunk.iterator.sameElements(seq.iterator)
+
       case _ =>
         false
     }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -611,7 +611,9 @@ object Chunk
       singleton(s.head) // Use size instead of tail.isEmpty as indexed seqs know their size
     else new IndexedSeqChunk(s)
 
-  private final class IndexedSeqChunk[O](s: GIndexedSeq[O]) extends Chunk[O] {
+  private[fs2] final class IndexedSeqChunk[O](
+      private[fs2] val s: GIndexedSeq[O]
+  ) extends Chunk[O] {
     def size = s.length
     def apply(i: Int) = s(i)
     def copyToArray[O2 >: O](xs: Array[O2], start: Int): Unit = {

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1180,13 +1180,40 @@ object Chunk
     override def reverseIterator: Iterator[O] = chunks.reverseIterator.flatMap(_.reverseIterator)
 
     override def ++[O2 >: O](that: Chunk[O2]): Chunk[O2] =
-      if (that.isEmpty) this
-      else if (isEmpty) that
-      else new Queue(chunks :+ that, size + that.size)
+      if (that.isEmpty)
+        this
+      else if (this.isEmpty)
+        that
+      else
+        that match {
+          case q: Queue[O2] =>
+            new Queue(
+              q.chunks ++ this.chunks,
+              this.size + q.size
+            )
+
+          case _ =>
+            new Queue(
+              that +: this.chunks,
+              this.size + that.size
+            )
+        }
 
     /** Prepends a chunk to the start of this chunk queue. */
     def +:[O2 >: O](c: Chunk[O2]): Queue[O2] =
-      if (c.isEmpty) this
+      if (c.isEmpty)
+        this
+      else if (this.isEmpty)
+        c match {
+          case q: Queue[O2] =>
+            q
+
+          case _ =>
+            new Queue(
+              chunks = collection.immutable.Queue(c),
+              size = c.size
+            )
+        }
       else
         c match {
           case q: Queue[O2] =>
@@ -1204,7 +1231,19 @@ object Chunk
 
     /** Appends a chunk to the end of this chunk queue. */
     def :+[O2 >: O](c: Chunk[O2]): Queue[O2] =
-      if (c.isEmpty) this
+      if (c.isEmpty)
+        this
+      else if (this.isEmpty)
+        c match {
+          case q: Queue[O2] =>
+            q
+
+          case _ =>
+            new Queue(
+              chunks = collection.immutable.Queue(c),
+              size = c.size
+            )
+        }
       else
         c match {
           case q: Queue[O2] =>

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -571,7 +571,6 @@ object Chunk
       sys.error("impossible")
     override def map[O2](f: Nothing => O2): Chunk[O2] = this
     override def toByteVector[B](implicit ev: B =:= Byte): ByteVector = ByteVector.empty
-    override def toString = "empty"
   }
 
   private[fs2] val unit: Chunk[Unit] = singleton(())

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -688,7 +688,7 @@ object Chunk
     }
 
   // Added in the "Avoid copying" spirit.
-  // It may be better removed if data shows it has little usage.
+  // It may be latter removed if data shows it has little usage.
   private final class JavaListChunk[O](
       javaList: ju.List[O] with ju.RandomAccess
   ) extends Chunk[O] {
@@ -729,6 +729,9 @@ object Chunk
 
   def from[O](i: GIterable[O]): Chunk[O] =
     platformFrom(i).getOrElse(i match {
+      case w: ChunkAsSeq[O] =>
+        w.chunk
+
       case a: mutable.ArraySeq[o] =>
         val arr = a.array.asInstanceOf[Array[O]]
         array(arr)(ClassTag(arr.getClass.getComponentType))
@@ -744,8 +747,7 @@ object Chunk
 
       case s: GIndexedSeq[O] =>
         if (s.isEmpty) empty
-        else if (s.size == 1)
-          singleton(s.head) // Use size instead of tail.isEmpty as indexed seqs know their size
+        else if (s.size == 1) singleton(s.head)
         else new IndexedSeqChunk(s)
 
       case _ =>

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1310,5 +1310,17 @@ object Chunk
           fa: Chunk[A]
       )(f: A => F[Option[B]])(implicit F: Applicative[F]): F[Chunk[B]] = fa.traverseFilter(f)
       override def mapFilter[A, B](fa: Chunk[A])(f: A => Option[B]): Chunk[B] = fa.mapFilter(f)
+
+      override def contains_[A](fa: Chunk[A], v: A)(implicit ev: Eq[A]): Boolean =
+        fa.contains(v)
+
+      override def count[A](fa: Chunk[A])(p: A => Boolean): Long =
+        fa.count(p).toLong
+
+      override def exists[A](fa: Chunk[A])(p: A => Boolean): Boolean =
+        fa.exists(p)
+
+      override def forall[A](fa: Chunk[A])(p: A => Boolean): Boolean =
+        fa.forall(p)
     }
 }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1560,11 +1560,7 @@ private[fs2] final class ChunkAsSeq[+O](
 
   override def hashCode: Int = {
     import util.hashing.MurmurHash3
-    var h = MurmurHash3.stringHash("ChunkAsSeq")
-    chunk.foreach { o =>
-      h = MurmurHash3.mix(h, o.##)
-    }
-    MurmurHash3.finalizeHash(h, chunk.size)
+    MurmurHash3.indexedSeqHash(this, seed = MurmurHash3.seqSeed)
   }
 
   override def equals(that: Any): Boolean =

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -704,8 +704,8 @@ object Chunk
     }
 
     override protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) = {
-      val left = javaList.subList(0, n + 1).asInstanceOf[ju.List[O] with ju.RandomAccess]
-      val right = javaList.subList(n + 1, size).asInstanceOf[ju.List[O] with ju.RandomAccess]
+      val left = javaList.subList(0, n).asInstanceOf[ju.List[O] with ju.RandomAccess]
+      val right = javaList.subList(n, size).asInstanceOf[ju.List[O] with ju.RandomAccess]
 
       new JavaListChunk(left) -> new JavaListChunk(right)
     }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1519,6 +1519,15 @@ private[fs2] final class ChunkAsSeq[+O](
   override def toString: String =
     chunk.iterator.mkString("ChunkAsSeq(", ", ", ")")
 
+  override def hashCode: Int = {
+    import util.hashing.MurmurHash3
+    var h = MurmurHash3.stringHash("ChunkAsSeq")
+    chunk.foreach { o =>
+      h = MurmurHash3.mix(h, o.##)
+    }
+    MurmurHash3.finalizeHash(h, chunk.size)
+  }
+
   override def equals(that: Any): Boolean =
     that match {
       case thatChunkWrapper: ChunkAsSeq[_] =>

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -91,8 +91,8 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
   }
 
   /** Returns true if the Chunk contains the given element. */
-  def contains[O2 >: O: Eq](elem: O2): Boolean =
-    iterator.exists(o => Eq[O2].eqv(o, elem))
+  def contains[O2 >: O](elem: O2)(implicit ev: Eq[O2]): Boolean =
+    iterator.exists(o => ev.eqv(o, elem))
 
   /** Copies the elements of this chunk in to the specified array at the specified start index. */
   def copyToArray[O2 >: O](xs: Array[O2], start: Int = 0): Unit

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -533,12 +533,12 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
     * this method does not copy data.
     * As such, this method is mostly intended for `foreach` kind of interop.
     */
-  def asSeq: Seq[O] =
+  def asSeq: IndexedSeq[O] =
     asSeqPlatform.getOrElse(this match {
       case indexedSeqChunk: Chunk.IndexedSeqChunk[_] =>
         indexedSeqChunk.s match {
-          case seq: Seq[O] =>
-            seq
+          case indexedSeq: IndexedSeq[O] =>
+            indexedSeq
 
           case _ =>
             new ChunkAsSeq(this)
@@ -1397,7 +1397,7 @@ object Chunk
 
 private[fs2] final class ChunkAsSeq[+O](
     private[fs2] val chunk: Chunk[O]
-) extends Seq[O]
+) extends IndexedSeq[O]
     with ChunkAsSeqPlatform[O]
     with Serializable {
   override def iterator: Iterator[O] =
@@ -1432,13 +1432,13 @@ private[fs2] final class ChunkAsSeq[+O](
     if (chunk.nonEmpty) chunk.apply(chunk.size - 1)
     else throw new NoSuchElementException("tail of empty Seq")
 
-  override def filter(p: O => Boolean): Seq[O] =
+  override def filter(p: O => Boolean): IndexedSeq[O] =
     new ChunkAsSeq(chunk.filter(p))
 
-  override def take(n: Int): Seq[O] =
+  override def take(n: Int): IndexedSeq[O] =
     new ChunkAsSeq(chunk.take(n))
 
-  override def takeRight(n: Int): Seq[O] =
+  override def takeRight(n: Int): IndexedSeq[O] =
     new ChunkAsSeq(chunk.takeRight(n))
 
   override def toArray[O2 >: O: ClassTag]: Array[O2] =

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -698,8 +698,15 @@ object Chunk
       javaList.get(i)
 
     override def copyToArray[O2 >: O](xs: Array[O2], start: Int): Unit = {
-      val javaListAsArray = javaList.toArray
-      System.arraycopy(javaListAsArray, 0, xs, start, javaListAsArray.length)
+      var i = start
+      var j = 0
+      val end = javaList.size
+
+      while (j < end) {
+        xs(i) = javaList.get(j)
+        i += 1
+        j += 1
+      }
     }
 
     override protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) = {

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1186,11 +1186,39 @@ object Chunk
 
     /** Prepends a chunk to the start of this chunk queue. */
     def +:[O2 >: O](c: Chunk[O2]): Queue[O2] =
-      if (c.isEmpty) this else new Queue(c +: chunks, c.size + size)
+      if (c.isEmpty) this
+      else
+        c match {
+          case q: Queue[O2] =>
+            new Queue(
+              q.chunks ++ this.chunks,
+              this.size + q.size
+            )
+
+          case _ =>
+            new Queue(
+              c +: this.chunks,
+              this.size + c.size
+            )
+        }
 
     /** Appends a chunk to the end of this chunk queue. */
     def :+[O2 >: O](c: Chunk[O2]): Queue[O2] =
-      if (c.isEmpty) this else new Queue(chunks :+ c, size + c.size)
+      if (c.isEmpty) this
+      else
+        c match {
+          case q: Queue[O2] =>
+            new Queue(
+              this.chunks ++ q.chunks,
+              this.size + q.size
+            )
+
+          case _ =>
+            new Queue(
+              this.chunks :+ c,
+              this.size + c.size
+            )
+        }
 
     def apply(i: Int): O = {
       if (i < 0 || i >= size) throw new IndexOutOfBoundsException()

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1339,9 +1339,37 @@ private[fs2] final class ChunkAsJavaList[O](
     private[fs2] val chunk: Chunk[O]
 ) extends ju.AbstractList[O]
     with Serializable {
-  override def size(): Int =
+  override def size: Int =
     chunk.size
 
   override def get(index: Int): O =
     chunk.apply(index)
+
+  override def isEmpty: Boolean =
+    chunk.isEmpty
+
+  override def iterator: ju.Iterator[O] = new ju.Iterator[O] {
+    private var i = 0
+
+    override def hasNext: Boolean =
+      i < chunk.size
+
+    override def next(): O = {
+      val result = chunk.apply(i)
+      i += 1
+      result
+    }
+  }
+
+  override def toArray: Array[Object] =
+    chunk.toArray[Any].asInstanceOf[Array[Object]]
+
+  override def toArray[T](a: Array[T with Object]): Array[T with Object] = {
+    val arr: Array[Object] =
+      if (a.length >= chunk.size) a.asInstanceOf[Array[Object]]
+      else new Array[Object](chunk.size)
+
+    chunk.asInstanceOf[Chunk[Object]].copyToArray(arr)
+    arr.asInstanceOf[Array[T with Object]]
+  }
 }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -641,6 +641,19 @@ object Chunk
     override def map[O2](f: O => O2): Chunk[O2] = indexedSeq(s.map(f))
   }
 
+  /** Creates a chunk from a `java.util.List`. */
+  def javaList[O](javaList: ju.List[O]): Chunk[O] =
+    javaList match {
+      case chunkAsJavaList: ChunkAsJavaList[O] =>
+        chunkAsJavaList.chunk
+
+      case _ =>
+        val size = javaList.size
+        val arr = new Array[Object](size).asInstanceOf[Array[O with Object]]
+        javaList.toArray(arr)
+        new ArraySlice(arr, 0, size)(ClassTag.Object.asInstanceOf[ClassTag[O with Object]])
+    }
+
   /** Creates a chunk from a `scala.collection.Seq`. */
   def seq[O](s: GSeq[O]): Chunk[O] = iterable(s)
 

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -89,8 +89,8 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
   }
 
   /** Returns true if the Chunk contains the given element. */
-  def contains[O2 >: O](elem: O2): Boolean =
-    iterator.contains(elem)
+  def contains[O2 >: O: Eq](elem: O2): Boolean =
+    iterator.exists(o => Eq[O2].eqv(o, elem))
 
   /** Copies the elements of this chunk in to the specified array at the specified start index. */
   def copyToArray[O2 >: O](xs: Array[O2], start: Int = 0): Unit

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1190,13 +1190,13 @@ object Chunk
         that match {
           case q: Queue[O2] =>
             new Queue(
-              q.chunks ++ this.chunks,
+              this.chunks ++ q.chunks,
               this.size + q.size
             )
 
           case _ =>
             new Queue(
-              that +: this.chunks,
+              this.chunks :+ that,
               this.size + that.size
             )
         }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2706,7 +2706,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     *
     * @example {{{
     * scala> Stream.range(0, 10).split(_ % 4 == 0).toList
-    * res0: List[Chunk[Int]] = List(empty, Chunk(1, 2, 3), Chunk(5, 6, 7), Chunk(9))
+    * res0: List[Chunk[Int]] = List(Chunk(), Chunk(1, 2, 3), Chunk(5, 6, 7), Chunk(9))
     * }}}
     */
   def split(f: O => Boolean): Stream[F, Chunk[O]] = {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -332,13 +332,13 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
               case ((out, buf, last), i) =>
                 val cur = f(i)
                 if (!cur && last)
-                  (Chunk.vector(buf :+ i) :: out, Vector.empty, cur)
+                  (Chunk.from(buf :+ i) :: out, Vector.empty, cur)
                 else (out, buf :+ i, cur)
             }
           if (out.isEmpty)
-            go(Chunk.vector(buf) :: buffer, newLast, tl)
+            go(Chunk.from(buf) :: buffer, newLast, tl)
           else
-            dumpBuffer(buffer) >> dumpBuffer(out) >> go(List(Chunk.vector(buf)), newLast, tl)
+            dumpBuffer(buffer) >> dumpBuffer(out) >> go(List(Chunk.from(buf)), newLast, tl)
 
         case None => dumpBuffer(buffer)
       }
@@ -576,7 +576,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   /** Prepends a chunk onto the front of this stream.
     *
     * @example {{{
-    * scala> Stream(1,2,3).consChunk(Chunk.vector(Vector(-1, 0))).toList
+    * scala> Stream(1,2,3).consChunk(Chunk.from(Vector(-1, 0))).toList
     * res0: List[Int] = List(-1, 0, 1, 2, 3)
     * }}}
     */
@@ -1153,7 +1153,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
               if (f(last, o)) (acc :+ o, o)
               else (acc, last)
             }
-            Pull.output(Chunk.vector(acc)) >> go(newLast, tl)
+            Pull.output(Chunk.from(acc)) >> go(newLast, tl)
           }
       }
     this.pull.uncons1.flatMap {
@@ -1183,7 +1183,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * the source stream and concatenated all of the results.
     *
     * @example {{{
-    * scala> Stream(1, 2, 3).flatMap { i => Stream.chunk(Chunk.seq(List.fill(i)(i))) }.toList
+    * scala> Stream(1, 2, 3).flatMap { i => Stream.chunk(Chunk.from(List.fill(i)(i))) }.toList
     * res0: List[Int] = List(1, 2, 2, 3, 3, 3)
     * }}}
     */
@@ -1338,10 +1338,10 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
         // whole chunk matches the current key, add this chunk to the accumulated output
         if (out.size + chunk.size < limit) {
           val newCurrent = Some((k1, out ++ chunk))
-          Pull.output(Chunk.seq(acc)) >> go(newCurrent, s)
+          Pull.output(Chunk.from(acc)) >> go(newCurrent, s)
         } else {
           val (prefix, suffix) = chunk.splitAt(limit - out.size)
-          Pull.output(Chunk.seq(acc :+ ((k1, out ++ prefix)))) >> go(
+          Pull.output(Chunk.from(acc :+ ((k1, out ++ prefix)))) >> go(
             Some((k1, suffix)),
             s
           )
@@ -1505,7 +1505,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
           Stream
             .eval(dequeueNextOutput)
             .repeat
-            .collectWhile { case Some(data) => Chunk.vector(data) }
+            .collectWhile { case Some(data) => Chunk.from(data) }
 
         Stream
           .bracketCase(enqueueAsync) { case (upstream, exitCase) =>
@@ -1736,7 +1736,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
         bldr += separator
         bldr += o
       }
-      Chunk.vector(bldr.result())
+      Chunk.from(bldr.result())
     }
     def go(str: Stream[F, O]): Pull[F, O2, Unit] =
       str.pull.uncons.flatMap {
@@ -2061,7 +2061,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
               rChunk.indexWhere(order.gteq(_, lLast)).getOrElse(rChunk.size)
             )
         Pull.output(
-          Chunk.vector((emitLeft ++ emitRight).toVector.sorted(order))
+          Chunk.from((emitLeft ++ emitRight).toVector.sorted(order))
         ) >> go(leftLeg.setHead(keepLeft), rightLeg.setHead(keepRight))
       } else { // otherwise, we need to shift leg
         if (lChunk.isEmpty) {
@@ -3255,7 +3255,7 @@ object Stream extends StreamLowPriority {
     os match {
       case Nil               => empty
       case collection.Seq(x) => emit(x)
-      case _                 => Pull.output(Chunk.seq(os)).streamNoScope
+      case _                 => Pull.output(Chunk.from(os)).streamNoScope
     }
 
   /** Empty pure stream. */
@@ -3468,7 +3468,7 @@ object Stream extends StreamLowPriority {
         F.suspend(hint) {
           for (_ <- 1 to chunkSize if i.hasNext) yield i.next()
         }.map { s =>
-          if (s.isEmpty) None else Some((Chunk.seq(s), i))
+          if (s.isEmpty) None else Some((Chunk.from(s), i))
         }
 
       Stream.unfoldChunkEval(iterator)(getNextChunk)
@@ -3697,7 +3697,7 @@ object Stream extends StreamLowPriority {
   /** Like `emits`, but works for any class that extends `Iterable`
     */
   def iterable[F[x] >: Pure[x], A](os: Iterable[A]): Stream[F, A] =
-    Stream.chunk(Chunk.iterable(os))
+    Stream.chunk(Chunk.from(os))
 
   /** An infinite `Stream` that repeatedly applies a given function
     * to a start value. `start` is the first value emitted, followed
@@ -3943,7 +3943,7 @@ object Stream extends StreamLowPriority {
   /** Like [[unfold]] but each invocation of `f` provides a chunk of output.
     *
     * @example {{{
-    * scala> Stream.unfoldChunk(0)(i => if (i < 5) Some(Chunk.seq(List.fill(i)(i)) -> (i+1)) else None).toList
+    * scala> Stream.unfoldChunk(0)(i => if (i < 5) Some(Chunk.from(List.fill(i)(i)) -> (i+1)) else None).toList
     * res0: List[Int] = List(1, 2, 2, 3, 3, 3, 4, 4, 4, 4)
     * }}}
     */

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -169,7 +169,7 @@ object text {
               buf1 = processSingleChunk(bldr, buf1, nextBytes)
               idx = idx + 1
             }
-            Pull.output(Chunk.seq(bldr.result())) >> doPull(buf1, tail)
+            Pull.output(Chunk.from(bldr.result())) >> doPull(buf1, tail)
           case None if buf.nonEmpty =>
             Pull.output1(new String(buf.toArray, utf8Charset))
           case None =>
@@ -554,7 +554,7 @@ object text {
                 new LineTooLongException(stringBuilder.length, max)
               )(raiseThrowable)
             case _ =>
-              Pull.output(Chunk.indexedSeq(linesBuffer)) >> go(stream, stringBuilder, first = false)
+              Pull.output(Chunk.from(linesBuffer)) >> go(stream, stringBuilder, first = false)
           }
       }
 

--- a/core/shared/src/main/scala/fs2/timeseries/TimeSeries.scala
+++ b/core/shared/src/main/scala/fs2/timeseries/TimeSeries.scala
@@ -158,7 +158,7 @@ object TimeSeries {
                 ((next.time.toMillis - nextTick.toMillis) / tickPeriod.toMillis + 1).toInt
               val tickTimes = (0 until tickCount).map(tickTime)
               val ticks = tickTimes.map(TimeStamped.tick)
-              val rest = Pull.output(Chunk.seq(ticks)) >> go(tickTime(tickCount), tl.cons(suffix))
+              val rest = Pull.output(Chunk.from(ticks)) >> go(tickTime(tickCount), tl.cons(suffix))
               out >> rest
           }
         case None => Pull.done

--- a/core/shared/src/main/scala/fs2/timeseries/TimeStamped.scala
+++ b/core/shared/src/main/scala/fs2/timeseries/TimeStamped.scala
@@ -156,7 +156,7 @@ object TimeStamped {
                 e2 = e2 + over
               }
               bldr += (tsa.map(Right.apply))
-              ((Some(e2), f(tsa.value)), Chunk.seq(bldr.result()))
+              ((Some(e2), f(tsa.value)), Chunk.from(bldr.result()))
             }
           case None => ((Some(tsa.time + over), f(tsa.value)), Chunk(tsa.map(Right.apply)))
         }

--- a/core/shared/src/test/scala-2.13/fs2/ChunkPlatformSuite.scala
+++ b/core/shared/src/test/scala-2.13/fs2/ChunkPlatformSuite.scala
@@ -99,13 +99,13 @@ class ChunkPlatformSuite extends Fs2Suite {
     group(s"fromArraySeq ArraySeq[$testTypeName]") {
       property("mutable") {
         forAll { (arraySeq: mutable.ArraySeq[A]) =>
-          assertEquals(Chunk.arraySeq(arraySeq).toVector, arraySeq.toVector)
+          assertEquals(Chunk.from(arraySeq).toVector, arraySeq.toVector)
         }
       }
 
       property("immutable") {
         forAll { (arraySeq: immutable.ArraySeq[A]) =>
-          assertEquals(Chunk.arraySeq(arraySeq).toVector, arraySeq.toVector)
+          assertEquals(Chunk.from(arraySeq).toVector, arraySeq.toVector)
         }
       }
     }
@@ -122,19 +122,5 @@ class ChunkPlatformSuite extends Fs2Suite {
     testChunkFromArraySeq[Boolean]
     testChunkFromArraySeq[Unit]
     testChunkFromArraySeq[String]
-  }
-
-  group("Chunk iterable") {
-    property("mutable ArraySeq") {
-      forAll { (a: mutable.ArraySeq[String]) =>
-        assertEquals(Chunk.iterable(a).toVector, a.toVector)
-      }
-    }
-
-    property("immutable ArraySeq") {
-      forAll { (a: immutable.ArraySeq[String]) =>
-        assertEquals(Chunk.iterable(a).toVector, a.toVector)
-      }
-    }
   }
 }

--- a/core/shared/src/test/scala/fs2/ChunkGenerators.scala
+++ b/core/shared/src/test/scala/fs2/ChunkGenerators.scala
@@ -25,6 +25,7 @@ import cats.data.Chain
 import scala.reflect.ClassTag
 import scodec.bits.ByteVector
 import java.nio.{Buffer => JBuffer, ByteBuffer => JByteBuffer, CharBuffer => JCharBuffer}
+import java.util.{List => JList}
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import Arbitrary.arbitrary
@@ -40,6 +41,7 @@ trait ChunkGeneratorsLowPriority1 extends MiscellaneousGenerators {
       5 -> genA.map(Chunk.singleton),
       10 -> Gen.listOf(genA).map(Chunk.from),
       10 -> Gen.listOf(genA).map(_.toVector).map(Chunk.from),
+      10 -> Gen.listOf(genA).map(l => JList.of(l: _*)).map(Chunk.javaList),
       10 -> Gen
         .listOf(genA)
         .map(_.toVector)

--- a/core/shared/src/test/scala/fs2/ChunkGenerators.scala
+++ b/core/shared/src/test/scala/fs2/ChunkGenerators.scala
@@ -38,8 +38,8 @@ trait ChunkGeneratorsLowPriority1 extends MiscellaneousGenerators {
     val gen = Gen.frequency(
       1 -> Gen.const(Chunk.empty[A]),
       5 -> genA.map(Chunk.singleton),
-      10 -> Gen.listOf(genA).map(Chunk.seq),
-      10 -> Gen.listOf(genA).map(_.toVector).map(Chunk.vector),
+      10 -> Gen.listOf(genA).map(Chunk.from),
+      10 -> Gen.listOf(genA).map(_.toVector).map(Chunk.from),
       10 -> Gen
         .listOf(genA)
         .map(_.toVector)

--- a/core/shared/src/test/scala/fs2/ChunkGenerators.scala
+++ b/core/shared/src/test/scala/fs2/ChunkGenerators.scala
@@ -25,7 +25,6 @@ import cats.data.Chain
 import scala.reflect.ClassTag
 import scodec.bits.ByteVector
 import java.nio.{Buffer => JBuffer, ByteBuffer => JByteBuffer, CharBuffer => JCharBuffer}
-import java.util.{List => JList}
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import Arbitrary.arbitrary
@@ -41,7 +40,7 @@ trait ChunkGeneratorsLowPriority1 extends MiscellaneousGenerators {
       5 -> genA.map(Chunk.singleton),
       10 -> Gen.listOf(genA).map(Chunk.from),
       10 -> Gen.listOf(genA).map(_.toVector).map(Chunk.from),
-      10 -> Gen.listOf(genA).map(l => JList.of(l: _*)).map(Chunk.javaList),
+      10 -> Gen.listOf(genA).map(l => java.util.Arrays.asList(l: _*)).map(Chunk.javaList),
       10 -> Gen
         .listOf(genA)
         .map(_.toVector)

--- a/core/shared/src/test/scala/fs2/ChunkQueueSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkQueueSuite.scala
@@ -82,7 +82,7 @@ class ChunkQueueSuite extends Fs2Suite {
         assert(queue.startsWith(prefix))
       }
 
-      val viaTake = queue.take(items.size) == Chunk.seq(items)
+      val viaTake = queue.take(items.size) == Chunk.from(items)
       val computed = flattened.startsWith(items)
       assertEquals(computed, viaTake)
       // here is another way to express the law:

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -177,6 +177,25 @@ class ChunkSuite extends Fs2Suite {
           assertEquals((chunkScan.toList, chunkCarry), ((listScan.tail, listScan.last)))
         }
       }
+      property("asSeq") {
+        forAll { (c: Chunk[A]) =>
+          val s = c.asSeq
+          val v = c.toVector
+          val l = c.toList
+
+          // Equality.
+          assertEquals(s, v)
+          assertEquals(s, l: Seq[A])
+
+          // Hashcode.
+          assertEquals(s.hashCode, v.hashCode)
+          assertEquals(s.hashCode, l.hashCode)
+
+          // Copy to array.
+          assertEquals(s.toArray.toVector, v.toArray.toVector)
+          assertEquals(s.toArray.toVector, l.toArray.toVector)
+        }
+      }
 
       if (implicitly[ClassTag[A]] == ClassTag.Byte) {
         property("toByteBuffer.byte") {

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -31,6 +31,7 @@ import scodec.bits.ByteVector
 
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
+import java.util.{List => JList}
 import scala.reflect.ClassTag
 
 class ChunkSuite extends Fs2Suite {
@@ -194,6 +195,28 @@ class ChunkSuite extends Fs2Suite {
           // Copy to array.
           assertEquals(s.toArray.toVector, v.toArray.toVector)
           assertEquals(s.toArray.toVector, l.toArray.toVector)
+        }
+      }
+      property("asJava") {
+        forAll { (c: Chunk[A]) =>
+          val view = c.asJava
+          val copy = JList.of(c.toVector: _*)
+
+          // Equality.
+          assertEquals(view, copy)
+
+          // Hashcode.
+          assertEquals(view.hashCode, copy.hashCode)
+
+          // Copy to array (untyped).
+          assertEquals(view.toArray.toVector, copy.toArray.toVector)
+
+          // Copy to array (typed).
+          val hint = Array.empty[A with Object]
+          val viewArray = view.toArray(hint)
+          val copyArray = copy.toArray(hint)
+          assertEquals(viewArray.toVector, copyArray.toVector)
+          assertEquals(viewArray.toVector, c.toVector)
         }
       }
 

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -47,10 +47,8 @@ class ChunkSuite extends Fs2Suite {
 
     property("chunk-formation (2)") {
       forAll { (c: Vector[Int]) =>
-        assertEquals(Chunk.seq(c).toVector, c)
-        assertEquals(Chunk.seq(c).toList, c.toList)
-        assertEquals(Chunk.indexedSeq(c).toVector, c)
-        assertEquals(Chunk.indexedSeq(c).toList, c.toList)
+        assertEquals(Chunk.from(c).toVector, c)
+        assertEquals(Chunk.from(c).toList, c.toList)
       }
     }
 
@@ -65,13 +63,13 @@ class ChunkSuite extends Fs2Suite {
       }
     }
 
-    test("Chunk.seq is optimized") {
-      assert(Chunk.seq(List(1)).isInstanceOf[Chunk.Singleton[_]])
+    test("Chunk.from is optimized") {
+      assert(Chunk.from(List(1)).isInstanceOf[Chunk.Singleton[_]])
     }
 
-    test("Array casts in Chunk.seq are safe") {
+    test("Array casts in Chunk.from are safe") {
       val as = collection.mutable.ArraySeq[Int](0, 1, 2)
-      val c = Chunk.seq(as)
+      val c = Chunk.from(as)
       assert(c.isInstanceOf[Chunk.ArraySlice[_]])
     }
   }

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -211,7 +211,7 @@ class ChunkSuite extends Fs2Suite {
           assertEquals(view.toArray.toVector, copy.toArray.toVector)
 
           // Copy to array (typed).
-          val hint = implicitly[ClassTag[A]].newArray(0).asInstanceOf[Array[A with Object]]
+          val hint = Array.emptyObjectArray.asInstanceOf[Array[A with Object]]
           val viewArray = view.toArray(hint)
           val copyArray = copy.toArray(hint)
           val viewVector: Vector[A] = viewArray.toVector

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -31,7 +31,6 @@ import scodec.bits.ByteVector
 
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
-import java.util.{List => JList}
 import scala.reflect.ClassTag
 
 class ChunkSuite extends Fs2Suite {
@@ -200,7 +199,7 @@ class ChunkSuite extends Fs2Suite {
       property("asJava") {
         forAll { (c: Chunk[A]) =>
           val view = c.asJava
-          val copy = JList.of(c.toVector: _*)
+          val copy = java.util.Arrays.asList(c.toVector: _*)
 
           // Equality.
           assertEquals(view, copy)

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -211,11 +211,13 @@ class ChunkSuite extends Fs2Suite {
           assertEquals(view.toArray.toVector, copy.toArray.toVector)
 
           // Copy to array (typed).
-          val hint = Array.empty[A with Object]
+          val hint = implicitly[ClassTag[A]].newArray(0).asInstanceOf[Array[A with Object]]
           val viewArray = view.toArray(hint)
           val copyArray = copy.toArray(hint)
-          assertEquals(viewArray.toVector, copyArray.toVector)
-          assertEquals(viewArray.toVector, c.toVector)
+          val viewVector: Vector[A] = viewArray.toVector
+          val copyVector: Vector[A] = copyArray.toVector
+          assertEquals(viewVector, copyVector)
+          assertEquals(viewVector, c.toVector)
         }
       }
 

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -118,7 +118,11 @@ class ChunkSuite extends Fs2Suite {
   ): Unit =
     group(s"$name") {
       implicit val implicitChunkArb: Arbitrary[Chunk[A]] = Arbitrary(genChunk)
-      property("size")(forAll((c: Chunk[A]) => assertEquals(c.size, c.toList.size)))
+      property("size") {
+        forAll { (c: Chunk[A]) =>
+          assertEquals(c.size, c.toList.size)
+        }
+      }
       property("take") {
         forAll { (c: Chunk[A], n: Int) =>
           assertEquals(c.take(n).toVector, c.toVector.take(n))

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -1373,7 +1373,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
     )
     assertEquals(
       Stream("hel", "l", "o Wor", "ld")
-        .repartition(s => Chunk.indexedSeq(s.grouped(2).toVector))
+        .repartition(s => Chunk.from(s.grouped(2).toVector))
         .toList,
       List("he", "ll", "o ", "Wo", "rl", "d")
     )
@@ -1381,7 +1381,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
     Stream("hello").repartition(_ => Chunk.empty).assertEmpty()
 
     def input = Stream("ab").repeat
-    def ones(s: String) = Chunk.vector(s.grouped(1).toVector)
+    def ones(s: String) = Chunk.from(s.grouped(1).toVector)
     assertEquals(input.take(2).repartition(ones).toVector, Vector("a", "b", "a", "b"))
     assertEquals(
       input.take(4).repartition(ones).toVector,
@@ -1398,7 +1398,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
       List(1, 3, 6, 10, 15, 15)
     )
     assertEquals(
-      Stream(1, 10, 100).repartition(_ => Chunk.seq(1 to 1000)).take(4).toList,
+      Stream(1, 10, 100).repartition(_ => Chunk.from(1 to 1000)).take(4).toList,
       List(1, 2, 3, 4)
     )
   }

--- a/core/shared/src/test/scala/fs2/StreamPerformanceSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamPerformanceSuite.scala
@@ -173,7 +173,7 @@ class StreamPerformanceSuite extends Fs2Suite {
     Ns.foreach { N =>
       test(N.toString) {
         val s: Stream[Pure, Int] = Stream
-          .chunk(Chunk.seq(0 until N))
+          .chunk(Chunk.from(0 until N))
           .repeatPull {
             _.uncons1.flatMap {
               case None           => Pull.pure(None)

--- a/protocols/shared/src/main/scala/fs2/protocols/mpeg/transport/psi/GroupedSections.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/mpeg/transport/psi/GroupedSections.scala
@@ -96,7 +96,7 @@ object GroupedSections {
           (newState, out)
         case Some(sections) =>
           val newState = ExtendedSectionGrouperState(state.accumulatorByIds - key)
-          val out = Chunk.seq((Right(sections) :: err.map(e => Left(e)).toList).reverse)
+          val out = Chunk.from((Right(sections) :: err.map(e => Left(e)).toList).reverse)
           (newState, out)
       }
     }


### PR DESCRIPTION
Fixes #3271

-----

## Improvements
  - [x] `Chunk.asJava`.
  - [x] `Chunk.asSeq`.
  - [x] More `Chunk` operations like `contains` & `exists` _(also overridden on the `Foldable` instance)_.
  - [x] Add `Chunk.javaList` to create chunks based on a **Java** `ju.List` .
  - [x] Add `Chunk.from` to accept any stdlib collection, and deprecate specific factories.
  - [x] Improve `Chunk.Queue` `:+`, `+:`, and `++` methods.

----

As always, I look forward to your feedback. Especially related to naming, scaladoc, and tests.