### PR TITLE
Fix various issues with PCAP decoding

### DIFF
--- a/core/shared/src/main/scala/fs2/timeseries/TimeSeries.scala
+++ b/core/shared/src/main/scala/fs2/timeseries/TimeSeries.scala
@@ -156,9 +156,8 @@ object TimeSeries {
               val next = suffix(0)
               val tickCount =
                 ((next.time.toMillis - nextTick.toMillis) / tickPeriod.toMillis + 1).toInt
-              val tickTimes = (0 until tickCount).map(tickTime)
-              val ticks = tickTimes.map(TimeStamped.tick)
-              val rest = Pull.output(Chunk.seq(ticks)) >> go(tickTime(tickCount), tl.cons(suffix))
+              val ticks = Stream.range(0, tickCount).map(i => TimeStamped.tick(tickTime(i)))
+              val rest = ticks.pull.echo >> go(tickTime(tickCount), tl.cons(suffix))
               out >> rest
           }
         case None => Pull.done

--- a/protocols/shared/src/main/scala/fs2/protocols/pcap/CaptureFile.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/pcap/CaptureFile.scala
@@ -78,7 +78,9 @@ object CaptureFile {
     decoderFn <- f(global).fold(StreamDecoder.raiseError, StreamDecoder.emit)
     recordDecoder =
       RecordHeader.codec(global.ordering).flatMap { header =>
-        StreamDecoder.isolate(header.includedLength * 8)(decoderFn(header)).strict
+        fixedSizeBytes(header.includedLength.toInt, decoderFn(header).strict.decodeOnly)
+        // TODO: This **should** be the same but appears to drop some data when decoding
+        //StreamDecoder.isolate(header.includedLength * 8)(decoderFn(header)).strict
       }
     values <- StreamDecoder.many(recordDecoder).flatMap(x => StreamDecoder.emits(x))
   } yield values

--- a/protocols/shared/src/main/scala/fs2/protocols/pcap/CaptureFile.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/pcap/CaptureFile.scala
@@ -79,8 +79,6 @@ object CaptureFile {
     recordDecoder =
       RecordHeader.codec(global.ordering).flatMap { header =>
         fixedSizeBytes(header.includedLength, decoderFn(header).strict.decodeOnly)
-        // TODO: This **should** be the same but appears to drop some data when decoding
-        // StreamDecoder.isolate(header.includedLength * 8)(decoderFn(header)).strict
       }
     values <- StreamDecoder.many(recordDecoder).flatMap(x => StreamDecoder.emits(x))
   } yield values

--- a/protocols/shared/src/main/scala/fs2/protocols/pcap/CaptureFile.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/pcap/CaptureFile.scala
@@ -78,7 +78,7 @@ object CaptureFile {
     decoderFn <- f(global).fold(StreamDecoder.raiseError, StreamDecoder.emit)
     recordDecoder =
       RecordHeader.codec(global.ordering).flatMap { header =>
-        fixedSizeBytes(header.includedLength.toInt, decoderFn(header).strict.decodeOnly)
+        fixedSizeBytes(header.includedLength, decoderFn(header).strict.decodeOnly)
         // TODO: This **should** be the same but appears to drop some data when decoding
         // StreamDecoder.isolate(header.includedLength * 8)(decoderFn(header)).strict
       }

--- a/protocols/shared/src/main/scala/fs2/protocols/pcap/CaptureFile.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/pcap/CaptureFile.scala
@@ -80,7 +80,7 @@ object CaptureFile {
       RecordHeader.codec(global.ordering).flatMap { header =>
         fixedSizeBytes(header.includedLength.toInt, decoderFn(header).strict.decodeOnly)
         // TODO: This **should** be the same but appears to drop some data when decoding
-        //StreamDecoder.isolate(header.includedLength * 8)(decoderFn(header)).strict
+        // StreamDecoder.isolate(header.includedLength * 8)(decoderFn(header)).strict
       }
     values <- StreamDecoder.many(recordDecoder).flatMap(x => StreamDecoder.emits(x))
   } yield values

--- a/scodec/shared/src/main/scala/fs2/interop/scodec/StreamDecoder.scala
+++ b/scodec/shared/src/main/scala/fs2/interop/scodec/StreamDecoder.scala
@@ -116,7 +116,10 @@ final class StreamDecoder[+A] private (private val step: StreamDecoder.Step[A]) 
               val (buffer, remainder) = (carry ++ hd).splitAt(bits)
               if (buffer.size == bits)
                 decoder[F](Stream(buffer)) >> Pull.pure(Some(tl.cons1(remainder)))
-              else loop(buffer, tl)
+              else {
+                assert(remainder.isEmpty)
+                loop(buffer, tl)
+              }
             case None => if (carry.isEmpty) Pull.pure(None) else Pull.pure(Some(Stream(carry)))
           }
         loop(BitVector.empty, s)

--- a/scodec/shared/src/main/scala/fs2/interop/scodec/StreamDecoder.scala
+++ b/scodec/shared/src/main/scala/fs2/interop/scodec/StreamDecoder.scala
@@ -78,7 +78,8 @@ final class StreamDecoder[+A] private (private val step: StreamDecoder.Step[A]) 
       case Decode(decoder, once, failOnErr) =>
         def loop(
             carry: BitVector,
-            s: Stream[F, BitVector]
+            s: Stream[F, BitVector],
+            carriedError: Option[Err]
         ): Pull[F, A, Option[Stream[F, BitVector]]] =
           s.pull.uncons1.flatMap {
             case Some((hd, tl)) =>
@@ -90,26 +91,38 @@ final class StreamDecoder[+A] private (private val step: StreamDecoder.Step[A]) 
                   if (once) p
                   else
                     p.flatMap {
-                      case Some(next) => loop(BitVector.empty, next)
-                      case None       => Pull.pure(None)
+                      case Some(next) =>
+                        loop(BitVector.empty, next, None)
+                      case None => Pull.pure(None)
                     }
-                case Attempt.Failure(_: Err.InsufficientBits) =>
-                  loop(buffer, tl)
+                case Attempt.Failure(e: Err.InsufficientBits) =>
+                  loop(buffer, tl, Some(e))
                 case Attempt.Failure(comp: Err.Composite)
                     if comp.errs.exists(_.isInstanceOf[Err.InsufficientBits]) =>
-                  loop(buffer, tl)
+                  loop(buffer, tl, Some(comp))
                 case Attempt.Failure(e) =>
                   if (failOnErr) Pull.raiseError(CodecError(e))
                   else Pull.pure(Some(tl.cons1(buffer)))
               }
-            case None => if (carry.isEmpty) Pull.pure(None) else Pull.pure(Some(Stream(carry)))
+            case None =>
+              def done = if (carry.isEmpty) Pull.pure(None) else Pull.pure(Some(Stream(carry)))
+              carriedError.filter(_ => failOnErr) match {
+                case Some(_: Err.InsufficientBits) if !once =>
+                  done
+                case Some(e: Err.Composite)
+                    if !once && e.errs.exists(_.isInstanceOf[Err.InsufficientBits]) =>
+                  done
+                case Some(e) => Pull.raiseError(CodecError(e))
+                case None    => done
+              }
           }
-        loop(BitVector.empty, s)
+        loop(BitVector.empty, s, None)
 
       case Isolate(bits, decoder) =>
         def loop(
             carry: BitVector,
-            s: Stream[F, BitVector]
+            s: Stream[F, BitVector],
+            carriedError: Option[Err]
         ): Pull[F, A, Option[Stream[F, BitVector]]] =
           s.pull.uncons1.flatMap {
             case Some((hd, tl)) =>
@@ -117,12 +130,20 @@ final class StreamDecoder[+A] private (private val step: StreamDecoder.Step[A]) 
               if (buffer.size == bits)
                 decoder[F](Stream(buffer)) >> Pull.pure(Some(tl.cons1(remainder)))
               else {
-                assert(remainder.isEmpty)
-                loop(buffer, tl)
+                assert(
+                  remainder.isEmpty,
+                  s"remainder should be empty; ${bits} ${carry.size} ${hd.size} ${buffer.size} ${remainder.size}"
+                )
+                loop(buffer, tl, Some(Err.InsufficientBits(bits, buffer.size, Nil)))
               }
-            case None => if (carry.isEmpty) Pull.pure(None) else Pull.pure(Some(Stream(carry)))
+            case None =>
+              carriedError match {
+                case Some(e) => Pull.raiseError(CodecError(e))
+                case None =>
+                  if (carry.isEmpty) Pull.pure(None) else Pull.pure(Some(Stream(carry)))
+              }
           }
-        loop(BitVector.empty, s)
+        loop(BitVector.empty, s, None)
     }
 
   /** Creates a stream decoder that, upon decoding an `A`, applies it to the supplied function and decodes
@@ -181,9 +202,7 @@ final class StreamDecoder[+A] private (private val step: StreamDecoder.Step[A]) 
           .apply[Fallible](Stream(bits))
           .flatMap { remainder =>
             remainder
-              .map { r =>
-                r.map(Right(_)).pull.echo
-              }
+              .map(r => r.map(Right(_)).pull.echo)
               .getOrElse(Pull.done)
           }
           .stream
@@ -199,7 +218,9 @@ final class StreamDecoder[+A] private (private val step: StreamDecoder.Step[A]) 
               case CodecError(e) => Attempt.failure(e)
               case other         => Attempt.failure(Err.General(other.getMessage, Nil))
             },
-            { case (acc, rem) => Attempt.successful(DecodeResult(acc, rem)) }
+            { case (acc, rem) =>
+              Attempt.successful(DecodeResult(acc, rem))
+            }
           )
       }
     }
@@ -237,6 +258,7 @@ object StreamDecoder {
     )
 
   /** Creates a stream decoder that repeatedly decodes `A` values using the supplied decoder.
+    * Note: insufficient bit errors raised from the supplied decoder do **not** get re-raised.
     */
   def many[A](decoder: Decoder[A]): StreamDecoder[A] =
     new StreamDecoder[A](
@@ -255,6 +277,7 @@ object StreamDecoder {
   /** Creates a stream decoder that repeatedly decodes `A` values until decoding fails.
     * If decoding fails, the read bits are not consumed and the stream decoder terminates,
     * having emitted any successfully decoded values earlier.
+    * Note: insufficient bit errors raised from the supplied decoder do **not** get re-raised.
     */
   def tryMany[A](decoder: Decoder[A]): StreamDecoder[A] =
     new StreamDecoder[A](
@@ -272,7 +295,7 @@ object StreamDecoder {
     * discarded.
     */
   def isolate[A](bits: Long)(decoder: StreamDecoder[A]): StreamDecoder[A] =
-    new StreamDecoder(Isolate(bits, decoder))
+    new StreamDecoder(Isolate(if (bits < 0) 0 else bits, decoder))
 
   /** Creates a stream decoder that ignores the specified number of bits. */
   def ignore(bits: Long): StreamDecoder[Nothing] =


### PR DESCRIPTION
- Fixes bug in `StreamDecoder.{isolate, once, tryOnce, many, tryMany}` where errors were dropped upon reaching end of input stream.
- Fixes an issue in `interpolateTicks` where large gaps in timestamps would unnecessarily allocate lots of memory.
- Improved `CaptureFile` stream decoding.

Originally spotted these issues by trying to use the stream decoder for `CaptureFile` and noticing we'd lose sync on record structure at chunk boundaries.