### PR TITLE
Fix for decoding a PES packet with a header, when the DTS (Decoding Timestamp) is unavailable.

### DIFF
--- a/protocols/shared/src/main/scala/fs2/protocols/mpeg/PesPacketHeader.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/mpeg/PesPacketHeader.scala
@@ -185,7 +185,7 @@ object PesPacketHeader {
       ("flags" | Codec[Flags]).flatPrepend { flags =>
         variableSizeBytes(
           uint8,
-          ("pts" | conditional(flags.ptsFlag, tsCodec(bin"0011"))) ::
+          ("pts" | conditional(flags.ptsFlag, if (flags.dtsFlag) tsCodec(bin"0011") else tsCodec(bin"0010"))) ::
             ("dts" | conditional(flags.dtsFlag, tsCodec(bin"0001"))) ::
             ("escr" | conditional(flags.escrFlag, escrCodec)) ::
             ("es_rate" | conditional(flags.esRateFlag, ignore(1) ~> uint(22) <~ ignore(1))) ::

--- a/protocols/shared/src/main/scala/fs2/protocols/mpeg/PesPacketHeader.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/mpeg/PesPacketHeader.scala
@@ -185,7 +185,10 @@ object PesPacketHeader {
       ("flags" | Codec[Flags]).flatPrepend { flags =>
         variableSizeBytes(
           uint8,
-          ("pts" | conditional(flags.ptsFlag, if (flags.dtsFlag) tsCodec(bin"0011") else tsCodec(bin"0010"))) ::
+          ("pts" | conditional(
+            flags.ptsFlag,
+            if (flags.dtsFlag) tsCodec(bin"0011") else tsCodec(bin"0010")
+          )) ::
             ("dts" | conditional(flags.dtsFlag, tsCodec(bin"0001"))) ::
             ("escr" | conditional(flags.escrFlag, escrCodec)) ::
             ("es_rate" | conditional(flags.esRateFlag, ignore(1) ~> uint(22) <~ ignore(1))) ::


### PR DESCRIPTION
With the fix, when the DTS is absent and only the PTS is available, the decoding of PTS is now working. The starting bits are '0010', conveying the presence of PTS information.