### PR TITLE
Implement Node.js stream `destroy` w/ `interruptWhen`

### DIFF
--- a/io/js/src/main/scala/fs2/io/NodeStream.scala
+++ b/io/js/src/main/scala/fs2/io/NodeStream.scala
@@ -72,4 +72,5 @@ trait Duplex extends Readable with Writable {
   protected[io] override def destroy(): this.type = js.native
 }
 
+@deprecated("No longer raised", "3.9.3")
 final class StreamDestroyedException private[io] () extends IOException

--- a/io/js/src/main/scala/fs2/io/ioplatform.scala
+++ b/io/js/src/main/scala/fs2/io/ioplatform.scala
@@ -206,7 +206,7 @@ private[fs2] trait ioplatform {
       errorDispatcher <- Dispatcher.sequential[F]
       readQueue <- Queue.bounded[F, Option[Chunk[Byte]]](1).toResource
       writeChannel <- Channel.synchronous[F, Chunk[Byte]].toResource
-      error <- F.deferred[Throwable].toResource
+      interrupt <- F.deferred[Either[Throwable, Unit]].toResource
       duplex <- Resource.make {
         F.delay {
           new facade.stream.Duplex(
@@ -236,10 +236,9 @@ private[fs2] trait ioplatform {
 
               var destroy = { (_, err, cb) =>
                 errorDispatcher.unsafeRunAndForget {
-                  error
+                  interrupt
                     .complete(
-                      Option(err)
-                        .fold[Exception](new StreamDestroyedException)(js.JavaScriptException(_))
+                      Option(err).map(js.JavaScriptException(_)).toLeft(())
                     ) *> F.delay(cb(null))
                 }
               }
@@ -254,10 +253,9 @@ private[fs2] trait ioplatform {
       }
       drainIn = in.enqueueNoneTerminatedChunks(readQueue).drain
       out = writeChannel.stream.unchunks
-        .concurrently(Stream.eval(error.get.flatMap(F.raiseError[Unit])))
     } yield (
       duplex,
-      drainIn.merge(out).adaptError { case IOException(ex) => ex }
+      drainIn.merge(out).interruptWhen(interrupt).adaptError { case IOException(ex) => ex }
     )
 
   /** Stream of bytes read asynchronously from standard input. */

--- a/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -114,4 +114,16 @@ class IoPlatformSuite extends Fs2Suite {
       .timeoutTo(100.millis, IO.unit)
   }
 
+  test("Destroying Node.js stream without error does not raise an exception") {
+    Stream
+      .never[IO]
+      .through {
+        toDuplexAndRead[IO] { duplex =>
+          IO(duplex.destroy())
+        }
+      }
+      .compile
+      .drain
+  }
+
 }


### PR DESCRIPTION
A Node.js stream can be `destroy`ed with or without an error.

- https://nodejs.org/api/stream.html#writabledestroyerror
- https://nodejs.org/api/stream.html#readabledestroyerror

Previously when converting an `fs2.Stream` to a Node.js stream, destruction-with-no-error was handled by raising a special `StreamDestroyedException`. Instead, we should handle it as ordinary interruption via `interruptWhen`.

h/t @kubukoz for reporting