### PR TITLE
Remove JS TLS socket event listeners on finalise

### DIFF
--- a/io/js/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
@@ -44,11 +44,10 @@ private[tls] trait TLSSocketCompanionPlatform { self: TLSSocket.type =>
       duplexOut <- mkDuplex(socket.reads)
       (duplex, out) = duplexOut
       _ <- out.through(socket.writes).compile.drain.background
-      upgraded <- upgrade(duplex)
-      tlsSockReadable <- suspendReadableAndRead(
+      tlsSockReadable <- suspendResourceReadableAndRead(
         destroyIfNotEnded = false,
         destroyIfCanceled = false
-      )(upgraded)
+      )(upgrade(duplex))
       (tlsSock, readable) = tlsSockReadable
       readStream <- SuspendedStream(readable)
     } yield new AsyncTLSSocket(


### PR DESCRIPTION
This fixes an issue we see when running this in AWS lambdas via Scala.js and feral.

The issue is that the lambdas can fail with `java.lang.IllegalStateException: dispatcher already shutdown`. This is coming from the event handler for an `error` event on a TLS socket. As this happens in a node error handler there is no way for our code to catch this exception.

For this to happen this error event must be processed by the callback after the finalizers for the `TLSSocket` Resource have run, as that is where the dispatchers will be shutdown.

I've extended the existing helpers for adding event listeners to provide Resource versions for `once` events and changed the upgrade thunk a `Resource` so these helpers can be used to add, and remove, the event listeners
