### PR TITLE
Upgrade a JS socket to TLS directly if possible

### DIFF
--- a/io/js/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -53,7 +53,7 @@ private[net] trait SocketCompanionPlatform {
         }
       }
 
-  private[net] class AsyncSocket[F[_]](
+  private[net] case class AsyncSocket[F[_]](
       sock: facade.net.Socket,
       readStream: SuspendedStream[F, Byte]
   )(implicit F: Async[F])

--- a/io/js/src/main/scala/fs2/io/net/tls/TLSContextPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/tls/TLSContextPlatform.scala
@@ -89,7 +89,8 @@ private[tls] trait TLSContextCompanionPlatform { self: TLSContext.type =>
                             )
                         )
                         tlsSock
-                      }
+                      },
+                      clientMode = clientMode
                     )
                     .evalTap(_ => handshake.get.rethrow)
                 }
@@ -128,7 +129,8 @@ private[tls] trait TLSContextCompanionPlatform { self: TLSContext.type =>
                             )
                         )
                         tlsSock
-                      }
+                      },
+                      clientMode = clientMode
                     )
                     .evalTap(_ => verifyError.get.rethrow)
                 }


### PR DESCRIPTION
This change alters how an upgrade to a TLS Socket is performed on JS runtimes.

Currently there is a lot of machinery to back and forth between native JS and FS2 constructs in order to perform the upgrade. 
On the client side it currently goes "JS Socket <-> FS2 Socket <-> JS Duplex <-> JS TLS Socket <-> FS2 Socket".

Since JS can perform this upgrade directly we can let it do so when we have access to an underlying JS socket.
This results in "JS Socket <-> JS TLS Socket <-> FS2 Socket" instead, with the associated removal of several layers of Queues and Channels involved in the conversions. Note that the non TLS FS2 socket remains as is, it just is no longer involved in the TLS upgrade.

This is related to #3138 as it performs the optimization described there in limited situations that we can access without changing the API.

Will also address one of the issues on #3338 related to use of closed dispatchers in the duplex stream, as we no longer use it.
