### PR TITLE
Default `client_auth_type = optional` for TLS clients on Native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -240,6 +240,10 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   // package-private method: #3318
   ProblemFilters.exclude[IncompatibleMethTypeProblem](
     "fs2.io.package.readInputStreamGeneric"
+  ),
+  // sealed trait: #3349
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "fs2.io.net.tls.TLSParameters.withClientAuthType"
   )
 )
 

--- a/io/native/src/main/scala/fs2/io/net/tls/TLSParameters.scala
+++ b/io/native/src/main/scala/fs2/io/net/tls/TLSParameters.scala
@@ -46,6 +46,8 @@ sealed trait TLSParameters {
   val verifyHostCallback: Option[String => SyncIO[Boolean]]
   val clientAuthType: Option[CertAuthType]
 
+  private[tls] def withClientAuthType(clientAuthType: Option[CertAuthType]): TLSParameters
+
   private[tls] def configure[F[_]](
       conn: Ptr[s2n_connection]
   )(implicit F: Sync[F]): Resource[F, Unit] =
@@ -123,6 +125,9 @@ object TLSParameters {
       serverName: Option[String],
       verifyHostCallback: Option[String => SyncIO[Boolean]],
       clientAuthType: Option[CertAuthType]
-  ) extends TLSParameters
+  ) extends TLSParameters {
+    def withClientAuthType(clientAuthType: Option[CertAuthType]) =
+      copy(clientAuthType = clientAuthType)
+  }
 
 }

--- a/io/native/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/native/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -242,7 +242,8 @@ class TLSSocketSuite extends TLSSuite {
               clientSocket.reads.take(msg.size.toLong)
           }
 
-          client.concurrently(echoServer)
+          client.mask //
+            .concurrently(echoServer)
         }
         .compile
         .to(Chunk)

--- a/io/native/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
+++ b/io/native/src/test/scala/fs2/io/net/tls/TLSSocketSuite.scala
@@ -205,7 +205,7 @@ class TLSSocketSuite extends TLSSuite {
         .intercept[SSLException]
     }
 
-    test("mTLS client verification") {
+    test("mTLS client verification fails if client cannot authenticate") {
       val msg = Chunk.array(("Hello, world! " * 100).getBytes)
 
       val setup = for {
@@ -247,6 +247,48 @@ class TLSSocketSuite extends TLSSuite {
         .compile
         .to(Chunk)
         .intercept[SSLException]
+    }
+
+    test("mTLS client verification happy-path") {
+      val msg = Chunk.array(("Hello, world! " * 100).getBytes)
+
+      val setup = for {
+        tlsContext <- testTlsContext
+        addressAndConnections <- Network[IO].serverResource(Some(ip"127.0.0.1"))
+        (serverAddress, server) = addressAndConnections
+        client = Network[IO]
+          .client(serverAddress)
+          .flatMap(
+            tlsContext
+              .clientBuilder(_)
+              .withParameters(TLSParameters(serverName = Some("Unknown")))
+              .build
+          )
+      } yield server.flatMap(s =>
+        Stream.resource(
+          tlsContext
+            .serverBuilder(s)
+            .withParameters(TLSParameters(clientAuthType = CertAuthType.Required.some)) // mTLS
+            .build
+        )
+      ) -> client
+
+      Stream
+        .resource(setup)
+        .flatMap { case (server, clientSocket) =>
+          val echoServer = server.map { socket =>
+            socket.reads.chunks.foreach(socket.write(_))
+          }.parJoinUnbounded
+
+          val client = Stream.resource(clientSocket).flatMap { clientSocket =>
+            Stream.exec(clientSocket.write(msg)) ++
+              clientSocket.reads.take(msg.size.toLong)
+          }
+
+          client.concurrently(echoServer)
+        }
+        .compile
+        .to(Chunk)
     }
 
     test("echo insecure client") {


### PR DESCRIPTION
This matches the default behavior on JVM and Node.js, which is that if the server requests client authentication then the client will cooperate. s2n defaults to `none` which causes mTLS to always fail.

Major props to @yurique for painstakingly tracking down this issue while working on https://github.com/joan38/kubernetes-client/pull/239.