### PR TITLE
Tidy unnecessary cast in JS `Socket`

### DIFF
--- a/io/js/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -103,7 +103,7 @@ private[net] trait SocketCompanionPlatform {
       Stream.chunk(bytes).through(writes).compile.drain
 
     override def writes: Pipe[F, Byte, Nothing] =
-      writeWritable(sock.asInstanceOf[Writable].pure, endAfterUse = false)
+      writeWritable(F.pure(sock), endAfterUse = false)
   }
 
 }


### PR DESCRIPTION
This looks like a hold-over from the auto-generated facade days, which was unable to properly encode that the Node.js `Socket` implements the `Writable` interface.