### PR TITLE
FIX: Handle root path correctly

### DIFF
--- a/io/js/src/main/scala/fs2/io/file/Path.scala
+++ b/io/js/src/main/scala/fs2/io/file/Path.scala
@@ -100,8 +100,13 @@ object Path extends PathCompanionApi {
   private[file] val sep = facade.path.sep
 
   private[file] def dropTrailingSep(path: String): String = {
+    /*
+     * NOTE: It seems like scala js does not rewrite this to a loop?
+     * Call stack limit is reached if there are too many separators.
+     */
     @tailrec
     def drop(view: IndexedSeqView[Char]): IndexedSeqView[Char] =
+      // Drop separator only if there is something else left
       if (view.endsWith(sep) && view.length > sep.length)
         drop(view.dropRight(sep.length))
       else view
@@ -109,6 +114,10 @@ object Path extends PathCompanionApi {
     drop(path.view).mkString
   }
 
+  /** This method drops trailing separators to match
+    * `java.nio.file.Path.get` behaviour.
+    * But root ("/") is untouched.
+    */
   def apply(path: String): Path =
     new Path(dropTrailingSep(path))
 }

--- a/io/js/src/main/scala/fs2/io/file/Path.scala
+++ b/io/js/src/main/scala/fs2/io/file/Path.scala
@@ -26,6 +26,7 @@ package file
 import fs2.io.internal.facade
 
 import scala.annotation.tailrec
+import scala.collection.IndexedSeqView
 
 final case class Path private[file] (override val toString: String) extends PathApi {
 
@@ -98,9 +99,16 @@ final case class Path private[file] (override val toString: String) extends Path
 object Path extends PathCompanionApi {
   private[file] val sep = facade.path.sep
 
+  private[file] def dropTrailingSep(path: String): String = {
+    @tailrec
+    def drop(view: IndexedSeqView[Char]): IndexedSeqView[Char] =
+      if (view.endsWith(sep) && view.length > sep.length)
+        drop(view.dropRight(sep.length))
+      else view
+
+    drop(path.view).mkString
+  }
+
   def apply(path: String): Path =
-    if (path.endsWith(sep))
-      new Path(path.dropRight(sep.length))
-    else
-      new Path(path)
+    new Path(dropTrailingSep(path))
 }

--- a/io/js/src/main/scala/fs2/io/file/Path.scala
+++ b/io/js/src/main/scala/fs2/io/file/Path.scala
@@ -98,21 +98,15 @@ final case class Path private[file] (override val toString: String) extends Path
 object Path extends PathCompanionApi {
   private[file] val sep = facade.path.sep
 
-  /*
-   * NOTE: It seems like scala js does not rewrite this to a loop?
-   * Call stack limit is reached if there are too many separators.
-   */
-  @tailrec
-  private[file] def dropTrailingSep(path: String): String =
-    // Drop separator only if there is something else left
-    if (path.endsWith(sep) && path.length > sep.length)
-      dropTrailingSep(path.dropRight(sep.length))
-    else path
+  def apply(path: String): Path = {
 
-  /** This method drops trailing separators to match
-    * `java.nio.file.Path.get` behaviour.
-    * But root ("/") is untouched.
-    */
-  def apply(path: String): Path =
-    new Path(dropTrailingSep(path))
+    /** Parse and then reconstruct the path
+      * to drop all trailing separators
+      * to match `java.nio.file.Paths.get` behaviour.
+      */
+    val parsed = facade.path.parse(path)
+    val formatted = facade.path.format(parsed)
+
+    new Path(formatted)
+  }
 }

--- a/io/js/src/main/scala/fs2/io/file/Path.scala
+++ b/io/js/src/main/scala/fs2/io/file/Path.scala
@@ -99,11 +99,9 @@ object Path extends PathCompanionApi {
   private[file] val sep = facade.path.sep
 
   def apply(path: String): Path = {
-
-    /** Parse and then reconstruct the path
-      * to drop all trailing separators
-      * to match `java.nio.file.Paths.get` behaviour.
-      */
+    // Parse and then reconstruct the path
+    // to drop all trailing separators
+    // to match `java.nio.file.Paths.get` behaviour.
     val parsed = facade.path.parse(path)
     val formatted = facade.path.format(parsed)
 

--- a/io/js/src/main/scala/fs2/io/file/Path.scala
+++ b/io/js/src/main/scala/fs2/io/file/Path.scala
@@ -26,7 +26,6 @@ package file
 import fs2.io.internal.facade
 
 import scala.annotation.tailrec
-import scala.collection.IndexedSeqView
 
 final case class Path private[file] (override val toString: String) extends PathApi {
 
@@ -99,20 +98,16 @@ final case class Path private[file] (override val toString: String) extends Path
 object Path extends PathCompanionApi {
   private[file] val sep = facade.path.sep
 
-  private[file] def dropTrailingSep(path: String): String = {
-    /*
-     * NOTE: It seems like scala js does not rewrite this to a loop?
-     * Call stack limit is reached if there are too many separators.
-     */
-    @tailrec
-    def drop(view: IndexedSeqView[Char]): IndexedSeqView[Char] =
-      // Drop separator only if there is something else left
-      if (view.endsWith(sep) && view.length > sep.length)
-        drop(view.dropRight(sep.length))
-      else view
-
-    drop(path.view).mkString
-  }
+  /*
+   * NOTE: It seems like scala js does not rewrite this to a loop?
+   * Call stack limit is reached if there are too many separators.
+   */
+  @tailrec
+  private[file] def dropTrailingSep(path: String): String =
+    // Drop separator only if there is something else left
+    if (path.endsWith(sep) && path.length > sep.length)
+      dropTrailingSep(path.dropRight(sep.length))
+    else path
 
   /** This method drops trailing separators to match
     * `java.nio.file.Path.get` behaviour.

--- a/io/js/src/main/scala/fs2/io/internal/facade/path.scala
+++ b/io/js/src/main/scala/fs2/io/internal/facade/path.scala
@@ -73,4 +73,8 @@ private[io] object path {
     def name: String = js.native
     def ext: String = js.native
   }
+
+  @js.native
+  @JSImport("path", "format")
+  def format(pathObject: ParsedPath): String = js.native
 }

--- a/io/shared/src/test/scala/fs2/io/file/PathSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/PathSuite.scala
@@ -44,6 +44,20 @@ class PathSuite extends Fs2IoSuite {
   test("construction") {
     assertEquals(Path("foo/bar"), Path("foo") / "bar")
     assertEquals(Path("/foo/bar"), Path("/foo") / "bar")
+    forAll((sepLength: Int) =>
+      if (sepLength >= 0 && sepLength <= 100)
+        assertEquals(
+          Path("/".repeat(sepLength)).toString,
+          "/"
+        )
+    )
+    forAll((sepLength: Int, path: Path) =>
+      if (sepLength >= 0 && sepLength <= 100)
+        assertEquals(
+          Path(path.toString + "/".repeat(sepLength)),
+          path
+        )
+    )
   }
 
   test("normalize") {

--- a/io/shared/src/test/scala/fs2/io/file/PathSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/PathSuite.scala
@@ -29,7 +29,7 @@ import cats.kernel.laws.discipline.OrderTests
 import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
 import org.scalacheck.Gen
-import org.scalacheck.Prop.{forAll, propBoolean}
+import org.scalacheck.Prop.forAll
 
 class PathSuite extends Fs2IoSuite {
 

--- a/io/shared/src/test/scala/fs2/io/file/PathSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/PathSuite.scala
@@ -52,7 +52,7 @@ class PathSuite extends Fs2IoSuite {
         )
     )
     forAll((sepLength: Int, path: Path) =>
-      if (sepLength >= 0 && sepLength <= 100)
+      if (sepLength >= 0 && sepLength <= 100 && path.toString.nonEmpty)
         assertEquals(
           Path(path.toString + "/".repeat(sepLength)),
           path


### PR DESCRIPTION
Drop trailing separators in `Path` creation only if it is not the only thing in the path.

Fixes #3353
