### PR TITLE
Preserve chunking of input to `writeUtf8Lines` with `intersperse`.

### DIFF
--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -443,7 +443,9 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
     * using the specified flags to open the file.
     */
   def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing] = in =>
-    in.intersperse(lineSeparator).through(writeUtf8(path, flags))
+    in.intersperse(lineSeparator)
+      .append(Stream[F, String](lineSeparator))
+      .through(writeUtf8(path, flags))
 }
 
 private[fs2] trait FilesLowPriority { this: Files.type =>

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -443,7 +443,7 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
     * using the specified flags to open the file.
     */
   def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing] = in =>
-    in.flatMap(s => Stream[F, String](s, lineSeparator)).through(writeUtf8(path, flags))
+    in.intersperse(lineSeparator).through(writeUtf8(path, flags))
 }
 
 private[fs2] trait FilesLowPriority { this: Files.type =>

--- a/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/file/FilesSuite.scala
@@ -169,6 +169,20 @@ class FilesSuite extends Fs2IoSuite with BaseFileSuite {
                          |bar
                          |""".stripMargin)
     }
+
+    test("writeUtf8Lines - empty stream") {
+      Stream
+        .resource(tempFile)
+        .flatMap { path =>
+          Stream.empty
+            .covary[IO]
+            .through(Files[IO].writeUtf8Lines(path)) ++ Files[IO]
+            .readUtf8(path)
+        }
+        .compile
+        .foldMonoid
+        .assertEquals("")
+    }
   }
 
   group("tail") {


### PR DESCRIPTION
`writeUtf8Lines` uses a `flatMap` to intersperse a line separator and hence destroys chunking. `intersperse` improves the performance by preserving chunks. 