### PR TITLE
Avoid double evaluation of pattern matchers in Chunk.collect

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
@@ -46,4 +46,14 @@ class ChunkBenchmark {
     ints.filter(_ % 3 == 0)
     ()
   }
+
+  private object OddStringExtractor {
+    def unapply(i: Int): Option[String] = if (i % 2 != 0) Some(i.toString) else None
+  }
+
+  @Benchmark
+  def collect(): Unit = {
+    ints.collect { case OddStringExtractor(s) => s }
+    ()
+  }
 }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -87,7 +87,8 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
   def collect[O2](pf: PartialFunction[O, O2]): Chunk[O2] = {
     val b = makeArrayBuilder[Any]
     b.sizeHint(size)
-    foreach(o => if (pf.isDefinedAt(o)) b += pf(o))
+    val f = pf.runWith(b += _)
+    foreach { o => f(o); () }
     Chunk.array(b.result()).asInstanceOf[Chunk[O2]]
   }
 


### PR DESCRIPTION
`fs2.Chunk#collect` evaluates pattern matchers and guards of a passed partial function twice because it calls `pf.isDefinedAt` and then `pf.apply`:
```scala
// ...
foreach(o => if (pf.isDefinedAt(o)) b += pf(o))
// ...
```
Scala collections use `pf.applyOrElse`/`pf.runWith` (depending on scala version) instead to avoid double evaluation. This PR implements the same approach in a `Chunk`.

It should be noted that this may change observable behavior for those who use a partial function with side-effecting matchers/guards. But hey, side-effecting matchers/guards is considered a bad practice anyway, and I doubt that there's an fs2 user relying on that double evaluation "feature."
