### PR TITLE
Refactor Node.js `Duplex` interop

### DIFF
--- a/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -141,4 +141,12 @@ class IoPlatformSuite extends Fs2Suite {
     }.take(2).compile.toList.assertEquals(List[Byte](0, 1))
   }
 
+  test("toReadable does not start input stream eagerly") {
+    IO.ref(true).flatMap { notStarted =>
+      toReadableResource(Stream.exec(notStarted.set(false))).surround {
+        IO.sleep(100.millis) *> notStarted.get.assert
+      }
+    }
+  }
+
 }

--- a/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/js/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -126,4 +126,19 @@ class IoPlatformSuite extends Fs2Suite {
       .drain
   }
 
+  test("write in readWritable write callback does not hang") {
+    readWritable { writable =>
+      IO.async_[Unit] { cb =>
+        writable.write(
+          Chunk[Byte](0).toUint8Array,
+          _ => { // start the next write in the callback
+            writable.write(Chunk[Byte](1).toUint8Array, _ => cb(Right(())))
+            ()
+          }
+        )
+        ()
+      }
+    }.take(2).compile.toList.assertEquals(List[Byte](0, 1))
+  }
+
 }


### PR DESCRIPTION
Following in the steps of https://github.com/typelevel/fs2/pull/3348, this PR replaces the `Dispatcher`/`Queue`/`Channel` used for `Duplex` interop with a custom concurrent data structure. Besides the performance benefits of removing indirection, this enables a semantics fix/enhancement: the FS2 upstream will not start until the Node.js downstream signals readiness. AFAIK it's not possible to implement this semantic with a `Queue` since you cannot receive an (async) signal for readiness, only a signal when an enqueue completes.