### PR TITLE
enforce new wildcard syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -11,6 +11,7 @@ project.excludeFilters = [
 fileOverride {
   "glob:**/scala-3/**" {
     runner.dialect = scala3
+    rewrite.scala3.convertToNewSyntax = false
   }
 }
 
@@ -26,3 +27,7 @@ rewrite.rules = [
   PreferCurlyFors
 ]
 
+rewrite.scala3.convertToNewSyntax = true
+runner.dialectOverride.allowAsForImportRename = false
+runner.dialectOverride.allowStarWildcardImport = false
+runner.dialectOverride.allowPostfixStarVarargSplices = false

--- a/build.sbt
+++ b/build.sbt
@@ -259,7 +259,7 @@ lazy val root = tlCrossRootProject
     benchmark
   )
 
-lazy val commonNativeSettings = Seq[Setting[_]](
+lazy val commonNativeSettings = Seq[Setting[?]](
   tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "3.2.15").toMap,
   Test / nativeBrewFormulas += "openssl"
 )

--- a/core/jvm/src/test/scala/fs2/interop/flow/SubscriberSpec.scala
+++ b/core/jvm/src/test/scala/fs2/interop/flow/SubscriberSpec.scala
@@ -93,7 +93,7 @@ final class SubscriberBlackboxSpec
   override def createFlowSubscriber(): StreamSubscriber[IO, Int] =
     StreamSubscriber[IO, Int](chunkSize = 1).unsafeRunSync()
 
-  override def triggerFlowRequest(subscriber: Subscriber[_ >: Int]): Unit =
+  override def triggerFlowRequest(subscriber: Subscriber[? >: Int]): Unit =
     subscriber
       .asInstanceOf[StreamSubscriber[IO, Int]]
       .stream(IO.unit)

--- a/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
@@ -28,7 +28,7 @@ private[fs2] trait ChunkPlatform[+O] extends Chunk213And3Compat[O] {
 
   def asSeqPlatform: Option[IndexedSeq[O]] =
     this match {
-      case arraySlice: Chunk.ArraySlice[_] =>
+      case arraySlice: Chunk.ArraySlice[?] =>
         Some(
           ArraySeq
             .unsafeWrapArray(arraySlice.values)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -355,7 +355,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
     * of `++`.
     */
   def toIndexedChunk: Chunk[O] = this match {
-    case _: Chunk.Queue[_] =>
+    case _: Chunk.Queue[?] =>
       val b = makeArrayBuilder[Any]
       b.sizeHint(size)
       foreach(o => b += o)
@@ -522,7 +522,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
 
   override def equals(a: Any): Boolean =
     a match {
-      case c: Chunk[_] =>
+      case c: Chunk[?] =>
         size == c.size && iterator.sameElements(c.iterator: Iterator[Any])
       case _ => false
     }
@@ -537,7 +537,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] with ChunkRu
     */
   def asSeq: IndexedSeq[O] =
     asSeqPlatform.getOrElse(this match {
-      case indexedSeqChunk: Chunk.IndexedSeqChunk[_] =>
+      case indexedSeqChunk: Chunk.IndexedSeqChunk[?] =>
         indexedSeqChunk.s match {
           case indexedSeq: IndexedSeq[O] =>
             indexedSeq
@@ -1579,10 +1579,10 @@ private[fs2] final class ChunkAsSeq[+O](
 
   override def equals(that: Any): Boolean =
     that match {
-      case thatChunkWrapper: ChunkAsSeq[_] =>
+      case thatChunkWrapper: ChunkAsSeq[?] =>
         chunk == thatChunkWrapper.chunk
 
-      case seq: GSeq[_] =>
+      case seq: GSeq[?] =>
         chunk.iterator.sameElements(seq.iterator): @nowarn213("msg=a type was inferred to be `Any`")
 
       case _ =>

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -180,7 +180,7 @@ sealed abstract class Pull[+F[_], +O, +R] {
     new Bind[F2, O2, R, S](this) {
       def cont(r: Terminal[R]): Pull[F2, O2, S] =
         r match {
-          case _: Succeeded[_] => post
+          case _: Succeeded[?] => post
           case r: Interrupted  => r
           case r: Fail         => r
         }
@@ -327,7 +327,7 @@ object Pull extends PullLowPriority {
     ): Pull[F2, O2, Unit] =
       self match {
         case a: AlgEffect[F, Unit] => a
-        case r: Terminal[_]        => r
+        case r: Terminal[?]        => r
         case _                     => FlatMapOutput(self, f)
       }
 
@@ -419,7 +419,7 @@ object Pull extends PullLowPriority {
   private[fs2] def acquireCancelable[F[_], R](
       resource: Poll[F] => F[R],
       release: (R, ExitCase) => F[Unit]
-  )(implicit F: MonadCancel[F, _]): Pull[F, Nothing, R] =
+  )(implicit F: MonadCancel[F, ?]): Pull[F, Nothing, R] =
     Acquire(F.uncancelable(resource), release, cancelable = true)
 
   /** Like [[eval]] but if the effectful value fails, the exception is returned
@@ -744,7 +744,7 @@ object Pull extends PullLowPriority {
     py match {
       case ty: Terminal[X] =>
         del match {
-          case cici: BindBind[F, O, _, X] =>
+          case cici: BindBind[F, O, ?, X] =>
             bindBindAux(cici.bb.cont(ty), cici.del)
           case _ => del.cont(ty)
         }
@@ -892,7 +892,7 @@ object Pull extends PullLowPriority {
           b.step match {
             case c: Bind[G, X, z, Y] =>
               viewL(new BindBind[G, X, z, Y](c.step, c.delegate, b.delegate))
-            case e: Action[G, X, _] =>
+            case e: Action[G, X, ?] =>
               contP = b.delegate
               e
             case r: Terminal[Y] => viewL(b.cont(r))
@@ -915,7 +915,7 @@ object Pull extends PullLowPriority {
           // all other actions, roll the interruption forwards
           getCont()(interruption)
         case interrupted: Interrupted => interrupted // impossible
-        case _: Succeeded[_]          => interruption
+        case _: Succeeded[?]          => interruption
         case failed: Fail =>
           val errs = interruption.deferredError.toList :+ failed.error
           Fail(CompositeFailure.fromList(errs).getOrElse(failed.error))
@@ -1036,7 +1036,7 @@ object Pull extends PullLowPriority {
       class FlatMapR[Y](view: Cont[Unit, G, X], fun: Y => Pull[G, X, Unit])
           extends Run[G, Y, F[End]] {
         private[this] def unconsed(chunk: Chunk[Y], tail: Pull[G, Y, Unit]): Pull[G, X, Unit] =
-          if (chunk.size == 1 && tail.isInstanceOf[Succeeded[_]])
+          if (chunk.size == 1 && tail.isInstanceOf[Succeeded[?]])
             // nb: If tl is Pure, there's no need to propagate flatMap through the tail. Hence, we
             // check if hd has only a single element, and if so, process it directly instead of folding.
             // This allows recursive infinite streams of the form `def s: Stream[Pure,O] = Stream(o).flatMap { _ => s }`
@@ -1226,18 +1226,18 @@ object Pull extends PullLowPriority {
       }
 
       (viewL(stream): @unchecked) match { // unchecked b/c scala 3 erroneously reports exhaustiveness warning
-        case tst: Translate[h, G, _] @unchecked => // y = Unit
+        case tst: Translate[h, G, ?] @unchecked => // y = Unit
           val translateRunner: Run[h, X, F[End]] = new TranslateRunner(tst.fk, getCont())
           val composed: h ~> F = translation.compose(tst.fk)
           go(scope, extendedTopLevelScope, composed, translateRunner, tst.stream)
 
-        case output: Output[_] =>
+        case output: Output[?] =>
           val view = getCont()
           interruptGuard(scope, view)(
             runner.out(output.values, scope, view(unit))
           )
 
-        case fmout: FlatMapOutput[G, z, _] => // y = Unit
+        case fmout: FlatMapOutput[G, z, ?] => // y = Unit
           val fmrunr = new FlatMapR(getCont(), fmout.fun)
           F.unit >> go(scope, extendedTopLevelScope, translation, fmrunr, fmout.stream)
 
@@ -1256,17 +1256,17 @@ object Pull extends PullLowPriority {
             .flatMap(go(_, extendedTopLevelScope, translation, runr, s.stream).attempt)
             .flatMap(_.fold(goErr(_, v), _.apply(new StepLegRunR(v))))
 
-        case _: GetScope[_] =>
+        case _: GetScope[?] =>
           go(scope, extendedTopLevelScope, translation, runner, getCont()(Succeeded(scope)))
         case eval: Eval[G, r]       => goEval[r](eval, getCont())
-        case acquire: Acquire[G, _] => goAcquire(acquire, getCont())
-        case inScope: InScope[G, _] =>
+        case acquire: Acquire[G, ?] => goAcquire(acquire, getCont())
+        case inScope: InScope[G, ?] =>
           goInScope(inScope.stream, inScope.useInterruption, getCont())
         case int: InterruptWhen[G] =>
           goInterruptWhen(translation(int.haltOnSignal), getCont())
         case close: CloseScope => goCloseScope(close, getCont())
 
-        case _: Succeeded[_]  => runner.done(scope)
+        case _: Succeeded[?]  => runner.done(scope)
         case failed: Fail     => runner.fail(failed.error)
         case int: Interrupted => runner.interrupted(int)
       }
@@ -1291,7 +1291,7 @@ object Pull extends PullLowPriority {
         } catch {
           case NonFatal(e) =>
             viewL(tail) match {
-              case _: Action[F, O, _] =>
+              case _: Action[F, O, ?] =>
                 go(scope, None, initFk, self, getCont()(Fail(e)))
               case Succeeded(_)        => F.raiseError(e)
               case Fail(e2)            => F.raiseError(CompositeFailure(e2, e))
@@ -1315,10 +1315,10 @@ object Pull extends PullLowPriority {
       fK: F ~> G
   ): Pull[G, O, Unit] =
     stream match {
-      case t: Translate[_, f, _] =>
+      case t: Translate[?, f, ?] =>
         translate(t.stream, t.fk.andThen(fK.asInstanceOf[f ~> G]))
-      case o: Output[_]   => o
-      case r: Terminal[_] => r
+      case o: Output[?]   => o
+      case r: Terminal[?] => r
       case _              => Translate(stream, fK)
     }
 

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3208,7 +3208,7 @@ object Stream extends StreamLowPriority {
   def bracketFull[F[_], R](
       acquire: Poll[F] => F[R]
   )(release: (R, Resource.ExitCase) => F[Unit])(implicit
-      F: MonadCancel[F, _]
+      F: MonadCancel[F, ?]
   ): Stream[F, R] =
     bracketFullWeak(acquire)(release).scope
 
@@ -3218,7 +3218,7 @@ object Stream extends StreamLowPriority {
   def bracketFullWeak[F[_], R](
       acquire: Poll[F] => F[R]
   )(release: (R, Resource.ExitCase) => F[Unit])(implicit
-      F: MonadCancel[F, _]
+      F: MonadCancel[F, ?]
   ): Stream[F, R] =
     Pull.acquireCancelable[F, R](acquire, release).flatMap(Pull.output1).streamNoScope
 
@@ -3826,11 +3826,11 @@ object Stream extends StreamLowPriority {
   def repeatEval[F[_], O](fo: F[O]): Stream[F, O] = eval(fo).repeat
 
   /** Converts the supplied resource into a singleton stream. */
-  def resource[F[_], O](r: Resource[F, O])(implicit F: MonadCancel[F, _]): Stream[F, O] =
+  def resource[F[_], O](r: Resource[F, O])(implicit F: MonadCancel[F, ?]): Stream[F, O] =
     resourceWeak(r).scope
 
   /** Same as [[resource]], but expressed as a FunctionK. */
-  def resourceK[F[_]](implicit F: MonadCancel[F, _]): Resource[F, *] ~> Stream[F, *] =
+  def resourceK[F[_]](implicit F: MonadCancel[F, ?]): Resource[F, *] ~> Stream[F, *] =
     new (Resource[F, *] ~> Stream[F, *]) {
       override def apply[A](fa: Resource[F, A]): Stream[F, A] = resource[F, A](fa)
     }
@@ -3840,7 +3840,7 @@ object Stream extends StreamLowPriority {
     *
     * Scopes can be manually introduced via [[Stream#scope]] if desired.
     */
-  def resourceWeak[F[_], O](r: Resource[F, O])(implicit F: MonadCancel[F, _]): Stream[F, O] =
+  def resourceWeak[F[_], O](r: Resource[F, O])(implicit F: MonadCancel[F, ?]): Stream[F, O] =
     r match {
       case Resource.Allocate(resource) =>
         Stream
@@ -3855,7 +3855,7 @@ object Stream extends StreamLowPriority {
     }
 
   /** Same as [[resourceWeak]], but expressed as a FunctionK. */
-  def resourceWeakK[F[_]](implicit F: MonadCancel[F, _]): Resource[F, *] ~> Stream[F, *] =
+  def resourceWeakK[F[_]](implicit F: MonadCancel[F, ?]): Resource[F, *] ~> Stream[F, *] =
     new (Resource[F, *] ~> Stream[F, *]) {
       override def apply[A](fa: Resource[F, A]): Stream[F, A] = resourceWeak[F, A](fa)
     }

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamPublisher.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamPublisher.scala
@@ -49,7 +49,7 @@ private[flow] sealed abstract class StreamPublisher[F[_], A] private (
 ) extends Publisher[A] {
   protected def runSubscription(run: F[Unit]): Unit
 
-  override final def subscribe(subscriber: Subscriber[_ >: A]): Unit = {
+  override final def subscribe(subscriber: Subscriber[? >: A]): Unit = {
     requireNonNull(
       subscriber,
       "The subscriber provided to subscribe must not be null"

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -54,25 +54,25 @@ class ChunkSuite extends Fs2Suite {
     }
 
     test("Chunk.apply is optimized") {
-      assert(Chunk(1).isInstanceOf[Chunk.Singleton[_]])
-      assert(Chunk("Hello").isInstanceOf[Chunk.Singleton[_]])
+      assert(Chunk(1).isInstanceOf[Chunk.Singleton[?]])
+      assert(Chunk("Hello").isInstanceOf[Chunk.Singleton[?]])
       // Varargs on Scala.js use a scala.scalajs.js.WrappedArray, which
       // ends up falling through to the Chunk.indexedSeq constructor
       if (isJVM) {
-        assert(Chunk(1, 2, 3).isInstanceOf[Chunk.ArraySlice[_]])
-        assert(Chunk("Hello", "world").isInstanceOf[Chunk.ArraySlice[_]])
+        assert(Chunk(1, 2, 3).isInstanceOf[Chunk.ArraySlice[?]])
+        assert(Chunk("Hello", "world").isInstanceOf[Chunk.ArraySlice[?]])
       }
     }
 
     test("Chunk.from is optimized") {
-      assert(Chunk.from(List(1)).isInstanceOf[Chunk.Singleton[_]])
-      assert(Chunk.from(Vector(1)).isInstanceOf[Chunk.Singleton[_]])
+      assert(Chunk.from(List(1)).isInstanceOf[Chunk.Singleton[?]])
+      assert(Chunk.from(Vector(1)).isInstanceOf[Chunk.Singleton[?]])
     }
 
     test("Array casts in Chunk.from are safe") {
       val as = collection.mutable.ArraySeq[Int](0, 1, 2)
       val c = Chunk.from(as)
-      assert(c.isInstanceOf[Chunk.ArraySlice[_]])
+      assert(c.isInstanceOf[Chunk.ArraySlice[?]])
     }
 
     test("Chunk.asSeq roundtrip") {
@@ -85,7 +85,7 @@ class ChunkSuite extends Fs2Suite {
         assertEquals(result, c)
 
         // Check unwrap.
-        if (seq.isInstanceOf[ChunkAsSeq[_]]) {
+        if (seq.isInstanceOf[ChunkAsSeq[?]]) {
           assert(result eq c)
         }
       } && forAll { (e: Either[Seq[Int], Vector[Int]]) =>
@@ -98,7 +98,7 @@ class ChunkSuite extends Fs2Suite {
         assertEquals(result, seq)
 
         // Check unwrap.
-        if (seq.isInstanceOf[Vector[_]] && chunk.size >= 2) {
+        if (seq.isInstanceOf[Vector[?]] && chunk.size >= 2) {
           assert(result eq seq)
         }
       }

--- a/core/shared/src/test/scala/fs2/Logger.scala
+++ b/core/shared/src/test/scala/fs2/Logger.scala
@@ -31,7 +31,7 @@ trait Logger[F[_]] {
 
   def logInfo(msg: String): Stream[F, Nothing] = Stream.exec(log(LogEvent.Info(msg)))
 
-  def logLifecycle(tag: String)(implicit F: MonadCancel[F, _]): Stream[F, Unit] =
+  def logLifecycle(tag: String)(implicit F: MonadCancel[F, ?]): Stream[F, Unit] =
     Stream.resource(logLifecycleR(tag))
 
   def logLifecycleR(tag: String)(implicit F: Functor[F]): Resource[F, Unit] =

--- a/core/shared/src/test/scala/fs2/interop/flow/SubscriberStabilitySpec.scala
+++ b/core/shared/src/test/scala/fs2/interop/flow/SubscriberStabilitySpec.scala
@@ -36,7 +36,7 @@ class SubscriberStabilitySpec extends Fs2Suite {
   test("StreamSubscriber has no race condition") {
     val publisher = new Publisher[ByteBuffer] {
 
-      class SubscriptionImpl(val s: Subscriber[_ >: ByteBuffer]) extends Subscription {
+      class SubscriptionImpl(val s: Subscriber[? >: ByteBuffer]) extends Subscription {
         override def request(n: Long): Unit = {
           s.onNext(ByteBuffer.wrap(new Array[Byte](1)))
           s.onComplete()
@@ -45,7 +45,7 @@ class SubscriberStabilitySpec extends Fs2Suite {
         override def cancel(): Unit = {}
       }
 
-      override def subscribe(s: Subscriber[_ >: ByteBuffer]): Unit =
+      override def subscribe(s: Subscriber[? >: ByteBuffer]): Unit =
         s.onSubscribe(new SubscriptionImpl(s))
     }
 

--- a/io/jvm-native/src/main/scala/fs2/io/DeprecatedWatcher.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/DeprecatedWatcher.scala
@@ -94,9 +94,9 @@ object Watcher {
     case object Deleted extends EventType
     case object Modified extends EventType
     case object Overflow extends EventType
-    final case class NonStandard(kind: WatchEvent.Kind[_]) extends EventType
+    final case class NonStandard(kind: WatchEvent.Kind[?]) extends EventType
 
-    def toWatchEventKind(et: EventType): WatchEvent.Kind[_] =
+    def toWatchEventKind(et: EventType): WatchEvent.Kind[?] =
       et match {
         case EventType.Created           => StandardWatchEventKinds.ENTRY_CREATE
         case EventType.Modified          => StandardWatchEventKinds.ENTRY_MODIFY
@@ -113,14 +113,14 @@ object Watcher {
     final case class Deleted(path: Path, count: Int) extends Event
     final case class Modified(path: Path, count: Int) extends Event
     final case class Overflow(count: Int) extends Event
-    final case class NonStandard(event: WatchEvent[_], registeredDirectory: Path) extends Event
+    final case class NonStandard(event: WatchEvent[?], registeredDirectory: Path) extends Event
 
     /** Converts a NIO `WatchEvent` to an FS2 `Watcher.Event`.
       *
       * @param e event to convert
       * @param registeredDirectory path of the directory for which the event's path is relative
       */
-    def fromWatchEvent(e: WatchEvent[_], registeredDirectory: Path): Event =
+    def fromWatchEvent(e: WatchEvent[?], registeredDirectory: Path): Event =
       e match {
         case e: WatchEvent[Path] @unchecked if e.kind == StandardWatchEventKinds.ENTRY_CREATE =>
           Event.Created(registeredDirectory.resolve(e.context), e.count)

--- a/io/jvm-native/src/main/scala/fs2/io/file/DeprecatedFilesApi.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/DeprecatedFilesApi.scala
@@ -50,13 +50,13 @@ private[file] trait DeprecatedFilesApi[F[_]] { self: Files[F] =>
   /** Creates a new directory at the given path.
     */
   @deprecated("Use overload which uses fs2.io.file.Path", "3.1.0")
-  def createDirectory(path: JPath, flags: Seq[FileAttribute[_]] = Seq.empty): F[JPath] =
+  def createDirectory(path: JPath, flags: Seq[FileAttribute[?]] = Seq.empty): F[JPath] =
     Sync[F].blocking(JFiles.createDirectory(path, flags: _*))
 
   /** Creates a new directory at the given path and creates all nonexistent parent directories beforehand.
     */
   @deprecated("Use overload which uses fs2.io.file.Path", "3.1.0")
-  def createDirectories(path: JPath, flags: Seq[FileAttribute[_]] = Seq.empty): F[JPath] =
+  def createDirectories(path: JPath, flags: Seq[FileAttribute[?]] = Seq.empty): F[JPath] =
     Sync[F].blocking(JFiles.createDirectories(path, flags: _*))
 
   /** Deletes a file.
@@ -262,7 +262,7 @@ private[file] trait DeprecatedFilesApi[F[_]] { self: Files[F] =>
       dir: Option[JPath] = None,
       prefix: String = "",
       suffix: String = ".tmp",
-      attributes: Seq[FileAttribute[_]] = Seq.empty
+      attributes: Seq[FileAttribute[?]] = Seq.empty
   ): Resource[F, JPath] =
     Resource.make {
       dir match {
@@ -285,7 +285,7 @@ private[file] trait DeprecatedFilesApi[F[_]] { self: Files[F] =>
   def tempDirectory(
       dir: Option[JPath] = None,
       prefix: String = "",
-      attributes: Seq[FileAttribute[_]] = Seq.empty
+      attributes: Seq[FileAttribute[?]] = Seq.empty
   ): Resource[F, JPath] =
     Resource.make {
       dir match {

--- a/io/jvm-native/src/main/scala/fs2/io/file/PermissionsPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/PermissionsPlatform.scala
@@ -26,7 +26,7 @@ package file
 import java.nio.file.attribute.{FileAttribute, PosixFilePermissions}
 
 private[file] trait PermissionsPlatform {
-  def toNioFileAttribute: FileAttribute[_] = (this: @unchecked) match {
+  def toNioFileAttribute: FileAttribute[?] = (this: @unchecked) match {
     case p: PosixPermissions =>
       PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(p.toString))
   }

--- a/io/jvm-native/src/main/scala/fs2/io/file/Watcher.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/Watcher.scala
@@ -106,9 +106,9 @@ object Watcher {
     case object Deleted extends EventType
     case object Modified extends EventType
     case object Overflow extends EventType
-    final case class NonStandard(kind: WatchEvent.Kind[_]) extends EventType
+    final case class NonStandard(kind: WatchEvent.Kind[?]) extends EventType
 
-    def toWatchEventKind(et: EventType): WatchEvent.Kind[_] =
+    def toWatchEventKind(et: EventType): WatchEvent.Kind[?] =
       et match {
         case EventType.Created           => StandardWatchEventKinds.ENTRY_CREATE
         case EventType.Modified          => StandardWatchEventKinds.ENTRY_MODIFY
@@ -125,14 +125,14 @@ object Watcher {
     final case class Deleted(path: Path, count: Int) extends Event
     final case class Modified(path: Path, count: Int) extends Event
     final case class Overflow(count: Int) extends Event
-    final case class NonStandard(event: WatchEvent[_], registeredDirectory: Path) extends Event
+    final case class NonStandard(event: WatchEvent[?], registeredDirectory: Path) extends Event
 
     /** Converts a NIO `WatchEvent` to an FS2 `Watcher.Event`.
       *
       * @param e event to convert
       * @param registeredDirectory path of the directory for which the event's path is relative
       */
-    def fromWatchEvent(e: WatchEvent[_], registeredDirectory: JPath): Event =
+    def fromWatchEvent(e: WatchEvent[?], registeredDirectory: JPath): Event =
       e match {
         case e: WatchEvent[JPath] @unchecked if e.kind == StandardWatchEventKinds.ENTRY_CREATE =>
           Event.Created(Path.fromNioPath(registeredDirectory.resolve(e.context)), e.count)

--- a/io/jvm-native/src/main/scala/fs2/io/file/file.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/file.scala
@@ -223,7 +223,7 @@ package object file {
       dir: JPath,
       prefix: String = "",
       suffix: String = ".tmp",
-      attributes: Seq[FileAttribute[_]] = Seq.empty
+      attributes: Seq[FileAttribute[?]] = Seq.empty
   ): Stream[F, JPath] =
     Stream.resource(Files.forAsync[F].tempFile(Some(dir), prefix, suffix, attributes))
 
@@ -236,7 +236,7 @@ package object file {
       dir: JPath,
       prefix: String = "",
       suffix: String = ".tmp",
-      attributes: Seq[FileAttribute[_]] = Seq.empty
+      attributes: Seq[FileAttribute[?]] = Seq.empty
   ): Resource[F, JPath] =
     Files.forAsync[F].tempFile(Some(dir), prefix, suffix, attributes)
 
@@ -248,7 +248,7 @@ package object file {
   def tempDirectoryStream[F[_]: Async](
       dir: JPath,
       prefix: String = "",
-      attributes: Seq[FileAttribute[_]] = Seq.empty
+      attributes: Seq[FileAttribute[?]] = Seq.empty
   ): Stream[F, JPath] =
     Stream.resource(Files.forAsync[F].tempDirectory(Some(dir), prefix, attributes))
 
@@ -260,7 +260,7 @@ package object file {
   def tempDirectoryResource[F[_]: Async](
       dir: JPath,
       prefix: String = "",
-      attributes: Seq[FileAttribute[_]] = Seq.empty
+      attributes: Seq[FileAttribute[?]] = Seq.empty
   ): Resource[F, JPath] =
     Files.forAsync[F].tempDirectory(Some(dir), prefix, attributes)
 
@@ -269,7 +269,7 @@ package object file {
   @deprecated("Use Files[F].createDirectory", "3.0.0")
   def createDirectory[F[_]: Async](
       path: JPath,
-      flags: Seq[FileAttribute[_]] = Seq.empty
+      flags: Seq[FileAttribute[?]] = Seq.empty
   ): F[JPath] =
     Files.forAsync[F].createDirectory(path, flags)
 
@@ -278,7 +278,7 @@ package object file {
   @deprecated("Use Files[F].createDirectories", "3.0.0")
   def createDirectories[F[_]: Async](
       path: JPath,
-      flags: Seq[FileAttribute[_]] = Seq.empty
+      flags: Seq[FileAttribute[?]] = Seq.empty
   ): F[JPath] =
     Files.forAsync[F].createDirectories(path, flags)
 

--- a/io/jvm/src/main/scala/fs2/io/net/tls/TLSEngine.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/tls/TLSEngine.scala
@@ -72,7 +72,7 @@ private[tls] object TLSEngine {
     } yield new TLSEngine[F] {
       private val doLog: (() => String) => F[Unit] =
         logger match {
-          case e: TLSLogger.Enabled[_] => msg => e.log(msg())
+          case e: TLSLogger.Enabled[?] => msg => e.log(msg())
           case TLSLogger.Disabled      => _ => Applicative[F].unit
         }
 

--- a/io/jvm/src/test/scala/fs2/io/IoPlatformSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/IoPlatformSuite.scala
@@ -56,8 +56,8 @@ class IoPlatformSuite extends Fs2Suite {
           .zipWithPrevious
           .assertForall {
             case (None, _)                        => true // skip first element
-            case (_, _: Chunk.Singleton[_])       => true // skip singleton bytes
-            case (Some(_: Chunk.Singleton[_]), _) => true // skip singleton bytes
+            case (_, _: Chunk.Singleton[?])       => true // skip singleton bytes
+            case (Some(_: Chunk.Singleton[?]), _) => true // skip singleton bytes
             case (Some(Chunk.ArraySlice(bs1, o1, l1)), Chunk.ArraySlice(bs2, o2, _)) =>
               {
                 // if first slice buffer is not 'full'

--- a/protocols/shared/src/main/scala/fs2/protocols/mpeg/transport/Demultiplexer.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/mpeg/transport/Demultiplexer.scala
@@ -268,7 +268,7 @@ object Demultiplexer {
       case ah: DecodeState.AwaitingHeader =>
         processHeader(ah.acc ++ newData, ah.startedAtOffsetZero, payloadUnitStartAfterData)
 
-      case ab: DecodeState.AwaitingBody[_] =>
+      case ab: DecodeState.AwaitingBody[?] =>
         processBody(ab.accumulate(newData), payloadUnitStartAfterData)
     }
 

--- a/protocols/shared/src/main/scala/fs2/protocols/mpeg/transport/psi/TableBuilder.scala
+++ b/protocols/shared/src/main/scala/fs2/protocols/mpeg/transport/psi/TableBuilder.scala
@@ -28,7 +28,7 @@ package psi
 
 case class TableBuildingError(tableId: Int, message: String) extends MpegError
 
-class TableBuilder private (cases: Map[Int, List[TableSupport[_]]]) {
+class TableBuilder private (cases: Map[Int, List[TableSupport[?]]]) {
 
   def supporting[T <: Table](implicit ts: TableSupport[T]): TableBuilder = {
     val newCases = ts :: cases.getOrElse(ts.tableId, Nil)
@@ -39,7 +39,7 @@ class TableBuilder private (cases: Map[Int, List[TableSupport[_]]]) {
     cases.get(gs.tableId) match {
       case None | Some(Nil) => Left(TableBuildingError(gs.tableId, "Unknown table id"))
       case Some(list) =>
-        list.dropRight(1).foldRight[Either[String, _]](list.last.toTable(gs)) { (next, res) =>
+        list.dropRight(1).foldRight[Either[String, ?]](list.last.toTable(gs)) { (next, res) =>
           res.fold(_ => next.toTable(gs), Right(_))
         } match {
           case Right(table) => Right(table.asInstanceOf[Table])

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamUnicastPublisher.scala
@@ -53,7 +53,7 @@ final class StreamUnicastPublisher[F[_]: Async, A](
   ) =
     this(stream, startDispatcher)
 
-  def subscribe(subscriber: Subscriber[_ >: A]): Unit = {
+  def subscribe(subscriber: Subscriber[? >: A]): Unit = {
     nonNull(subscriber)
     try
       startDispatcher.unsafeRunAndForget(

--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
@@ -99,7 +99,7 @@ final class SubscriberBlackboxSpec
   def createSubscriber(): StreamSubscriber[IO, Int] =
     StreamSubscriber[IO, Int](bufferSize = 1).unsafeRunSync()
 
-  override def triggerRequest(s: Subscriber[_ >: Int]): Unit = {
+  override def triggerRequest(s: Subscriber[? >: Int]): Unit = {
     val req = s.asInstanceOf[StreamSubscriber[IO, Int]].sub.dequeue1
     Stream.eval(IO.sleep(100.milliseconds) >> req).compile.drain.unsafeRunAsync(_ => ())
   }

--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/SubscriberStabilitySpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/SubscriberStabilitySpec.scala
@@ -35,7 +35,7 @@ class SubscriberStabilitySpec extends Fs2Suite {
   test("StreamSubscriber has no race condition") {
     val publisher = new Publisher[ByteBuffer] {
 
-      class SubscriptionImpl(val s: Subscriber[_ >: ByteBuffer]) extends Subscription {
+      class SubscriptionImpl(val s: Subscriber[? >: ByteBuffer]) extends Subscription {
         override def request(n: Long): Unit = {
           s.onNext(ByteBuffer.wrap(new Array[Byte](1)))
           s.onComplete()
@@ -44,7 +44,7 @@ class SubscriberStabilitySpec extends Fs2Suite {
         override def cancel(): Unit = {}
       }
 
-      override def subscribe(s: Subscriber[_ >: ByteBuffer]): Unit =
+      override def subscribe(s: Subscriber[? >: ByteBuffer]): Unit =
         s.onSubscribe(new SubscriptionImpl(s))
     }
 

--- a/scodec/shared/src/test/scala/fs2/interop/scodec/MpegExample.scala
+++ b/scodec/shared/src/test/scala/fs2/interop/scodec/MpegExample.scala
@@ -73,14 +73,14 @@ object Mpeg extends IOApp.Simple {
 
     val filePath = Path("path/to/file")
 
-    def countElements(decoder: StreamDecoder[_]): IO[Long] =
+    def countElements(decoder: StreamDecoder[?]): IO[Long] =
       Files[IO]
         .readAll(filePath)
         .through(decoder.toPipeByte)
         .compile
         .count
 
-    def run(label: String, decoder: StreamDecoder[_]): IO[Unit] =
+    def run(label: String, decoder: StreamDecoder[?]): IO[Unit] =
       time(countElements(decoder)).flatMap { case (elapsed, cnt) =>
         IO.println(s"$label stream packet count: $cnt (took $elapsed)")
       }


### PR DESCRIPTION
- Scala 3 report warnings since 3.4 https://github.com/lampepfl/dotty/pull/18813
- Scala 2.12 and 2.13 support new syntax without `-Xsource:3` option https://github.com/scala/scala/pull/10005