### PR TITLE
Use  nondirect buffer instead of direct buffer

### DIFF
--- a/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -45,13 +45,13 @@ private[net] trait SocketCompanionPlatform {
   )(implicit F: Async[F])
       extends Socket[F] {
     private[this] final val defaultReadSize = 8192
-    private[this] var readBuffer: ByteBuffer = ByteBuffer.allocateDirect(defaultReadSize)
+    private[this] var readBuffer: ByteBuffer = ByteBuffer.allocate(defaultReadSize)
 
     private def withReadBuffer[A](size: Int)(f: ByteBuffer => F[A]): F[A] =
       readMutex.lock.surround {
         F.delay {
           if (readBuffer.capacity() < size)
-            readBuffer = ByteBuffer.allocateDirect(size)
+            readBuffer = ByteBuffer.allocate(size)
           else
             (readBuffer: Buffer).limit(size)
           f(readBuffer)


### PR DESCRIPTION
Thanks for opening a PR!

If the CI build fails due to Scalafmt, run `sbt scalafmtAll` and push the changes (generally a good idea to run this prior to opening the PR).

It's also helpful to run `sbt prePR`, which runs tests, generates docs, and performs various checks.

Feel free to ask questions on the fs2 and fs2-dev channels on the [Typelevel Discord server](https://discord.gg/9V8FZTVZ9R).
