### PR TITLE
Update scaladoc for Process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If at any point you run into problems, you can always ask a question on [the fs2
 
 ## How to submit a change
 
-If you see something worth adding, make the relevant changes in a fork of the source code and [submit a pull request to the project](fs2-pulls). If you don't know what you could help with, take a look at [the issues marked as "help wanted"][low-hanging-fruit] or ask on [Discord][fs2-dev].
+If you see something worth adding, make the relevant changes in a fork of the source code and [submit a pull request to the project][fs2-pulls]. If you don't know what you could help with, take a look at [the issues marked as "help wanted"][low-hanging-fruit] or ask on [Discord][fs2-dev].
 
 We follow similar rules to [the cats-effect project's](https://github.com/typelevel/cats-effect#development).
 Most importantly, any contributions are expected to be made in the form of [GitHub pull requests to the FS2 repository][fs2-pulls].

--- a/io/shared/src/main/scala/fs2/io/process/Process.scala
+++ b/io/shared/src/main/scala/fs2/io/process/Process.scala
@@ -34,16 +34,26 @@ sealed trait Process[F[_]] {
 
   /** A `Pipe` that writes to `stdin` of the process. The resulting stream should be compiled
     * at most once, and interrupting or otherwise canceling a write-in-progress may kill the process.
+    * If the process expects data through `stdin`, you have to supply it or close it. Failure to do so
+    * may cause the process to block, or even deadlock.
+    *
+    * `stdin` resulting stream can be closed like this:
+    *
+    * @example {{{
+    * Stream.empty.through(stdin).compile.drain
+    * }}}
     */
   def stdin: Pipe[F, Byte, Nothing]
 
   /** A `Stream` that reads from `stdout` of the process. This stream should be compiled at most once,
-    * and interrupting or otherwise canceling a read-in-progress may kill the process.
+    * and interrupting or otherwise canceling a read-in-progress may kill the process. Not draining
+    * this `Stream` may cause the process to block, or even deadlock.
     */
   def stdout: Stream[F, Byte]
 
   /** A `Stream` that reads from `stderr` of the process. This stream should be compiled at most once,
-    * and interrupting or otherwise canceling a read-in-progress may kill the process.
+    * and interrupting or otherwise canceling a read-in-progress may kill the process. Not draining
+    * this `Stream` may cause the process to block, or even deadlock.
     */
   def stderr: Stream[F, Byte]
 


### PR DESCRIPTION
I fell into this trap last week. Essentially, I was running a program that looks like this:

```scala
//> using scala "3.3.0"
//> using lib "co.fs2::fs2-io:3.9.3"

import cats.effect._
import fs2._

object Main extends IOApp.Simple {
  val run = fs2.io.process
    .ProcessBuilder(
      "git",
      "show",
      "46d8140:lightweight-dynamo.json" // just a large file that exists in the git repo
    )
    .spawn[IO]
    .use { p =>
      p.exitValue *> p.stdout.through(fs2.text.utf8.decode).compile.string
    }
    .flatMap(IO.println)
}
```

Unfortunately for me, when the file in question (`lightweight-dynamo.json` in this instance) was somewhat large, my program would hang. I tracked this down to: you must drain stdout if the process you starts is writing to it. Failure to do it can cause the process to block because it's write buffer is full (because nobody reads from it). [Relevant java docs](https://docs.oracle.com/javase/7/docs/api/java/lang/Process.html).

This change in the documentation should help avoiding such issue. But I think the best thing would be to have a mechanism in place to ensure stdin is drained. I'm not sure how I would implemented this though.