### PR TITLE
Do not let handled errors get printed to the console

### DIFF
--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -87,6 +87,7 @@ private[reactivestreams] final class StreamSubscription[F[_], A] private (
         case Outcome.Canceled()  => cancelMe
       }
       .void
+      .voidError // errors handled above and passed to subscriber
   }
 
   // According to the spec, it's acceptable for a concurrent cancel to not


### PR DESCRIPTION
fix for https://github.com/typelevel/fs2/issues/3384