### PR TITLE
Optmize `interop.flow.StreamSubscriber.onNext`

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/FlowInteropBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FlowInteropBenchmark.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package benchmark
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+
+import org.openjdk.jmh.annotations.{
+  Benchmark,
+  BenchmarkMode,
+  Mode,
+  OutputTimeUnit,
+  Param,
+  Scope,
+  State
+}
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.Flow.{Publisher, Subscriber, Subscription}
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class FlowInteropBenchmark {
+  @Param(Array("1024", "5120", "10240", "51200", "512000"))
+  var totalElements: Long = _
+
+  @Param(Array("1000"))
+  var iterations: Int = _
+
+  @Benchmark
+  def fastPublisher(): Unit = {
+    def publisher =
+      new Publisher[Unit] {
+        override final def subscribe(subscriber: Subscriber[? >: Unit]): Unit =
+          subscriber.onSubscribe(
+            new Subscription {
+              var i: Long = 0
+              @volatile var canceled: Boolean = false
+
+              // Sequential fast Publisher.
+              override final def request(n: Long): Unit = {
+                val elementsToProduce = math.min(i + n, totalElements)
+
+                while (i < elementsToProduce) {
+                  subscriber.onNext(())
+                  i += 1
+                }
+
+                if (i == totalElements || canceled) {
+                  subscriber.onComplete()
+                }
+              }
+
+              override final def cancel(): Unit =
+                canceled = true
+            }
+          )
+      }
+
+    val stream =
+      interop.flow.fromPublisher[IO](publisher, chunkSize = 512)
+
+    val program =
+      stream.compile.drain
+
+    program.replicateA_(iterations).unsafeRunSync()
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -256,7 +256,23 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.hash.createHash"),
   ProblemFilters.exclude[MissingClassProblem]("fs2.hash$Hash"),
   ProblemFilters.exclude[MissingFieldProblem]("fs2.hash.openssl"),
-  ProblemFilters.exclude[MissingClassProblem]("fs2.hash$openssl$")
+  ProblemFilters.exclude[MissingClassProblem]("fs2.hash$openssl$"),
+  // Privates: #3387
+  ProblemFilters.exclude[MissingClassProblem](
+    "fs2.interop.flow.StreamSubscriber$Input$Next"
+  ),
+  ProblemFilters.exclude[MissingClassProblem](
+    "fs2.interop.flow.StreamSubscriber$Input$Next$"
+  ),
+  ProblemFilters.exclude[MissingFieldProblem](
+    "fs2.interop.flow.StreamSubscriber#Input.Next"
+  ),
+  ProblemFilters.exclude[Problem](
+    "fs2.interop.flow.StreamSubscriber#State#WaitingOnUpstream.*"
+  ),
+  ProblemFilters.exclude[MissingTypesProblem](
+    "fs2.interop.flow.StreamSubscriber$State$WaitingOnUpstream$"
+  )
 )
 
 lazy val root = tlCrossRootProject

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamSubscription.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamSubscription.scala
@@ -109,6 +109,7 @@ private[flow] final class StreamSubscription[F[_], A] private (
             // if we were externally canceled, this is handled below
             F.unit
         }
+        .mask
 
     val cancellation = F.asyncCheckAttempt[Unit] { cb =>
       F.delay {


### PR DESCRIPTION
Since the `reactive-streams` spec mentions that all calls must be done _"serially"_ these changes optimize the tight loop of multiple consequential `onNext` calls.

-----

## Benchmark results

### Before the optimization

| Benchmark | (fibers) | (iterations) | Mode | Cnt | Score | Error | Units |
| - | - | - | - | - | - | - | - |
| FlowInteropBenchmark.fastPublisher | 1000 |   1024 | thrpt | 20 | 25.938 | ± 0.306 | ops/s |
| FlowInteropBenchmark.fastPublisher | 1000 |   5120 | thrpt | 20 |  6.519 | ± 0.015 | ops/s |
| FlowInteropBenchmark.fastPublisher | 1000 |  10240 | thrpt | 20 |  3.201 | ± 0.168 | ops/s |
| FlowInteropBenchmark.fastPublisher | 1000 |  51200 | thrpt | 20 |  0.680 | ± 0.013 | ops/s |
| FlowInteropBenchmark.fastPublisher | 1000 | 512000 | thrpt | 20 |  0.062 | ± 0.001 | ops/s |

### After the optimization

| Benchmark | (fibers) | (iterations) | Mode | Cnt | Score | Error | Units |
| - | - | - | - | - | - | - | - |
| FlowInteropBenchmark.fastPublisher | 1000 |   1024 | thrpt | 20 | 63.846 | ± 0.094 | ops/s |
| FlowInteropBenchmark.fastPublisher | 1000 |   5120 | thrpt | 20 | 22.314 | ± 0.107 | ops/s |
| FlowInteropBenchmark.fastPublisher | 1000 |  10240 | thrpt | 20 | 12.662 | ± 0.028 | ops/s |
| FlowInteropBenchmark.fastPublisher | 1000 |  51200 | thrpt | 20 |  2.736 | ± 0.012 | ops/s |
| FlowInteropBenchmark.fastPublisher | 1000 | 512000 | thrpt | 20 |  0.275 | ± 0.002 | ops/s |

-----

## Analysis

For only `2` chunks of `512` elements the improvements were almost `2.5` times better.
For `20` chunks, the improvements were almost `4` times better.
But the improvements for `1000` chunks were just `4.4` times better.

It seems then that in a fully sequential and CPU-bound `Publisher`, the new `Subscriber` is roughly 4 times more efficient. As long as the chunk size is adequate, and there are enough chunks to flatten the overhead of the general machinery.
Overall, I would say this optimization looks great, even if realistic use cases won't get such a big increase, it is likely the effects will be noticeable.

-----

> Lies, Damn Lies, and Benchmarks
