### PR TITLE
Add `Files.walkWithAttributes`

### DIFF
--- a/io/native/src/main/scala/fs2/io/file/AsyncFilesPlatform.scala
+++ b/io/native/src/main/scala/fs2/io/file/AsyncFilesPlatform.scala
@@ -24,15 +24,15 @@ package io
 package file
 
 private[file] trait AsyncFilesPlatform[F[_]] { self: Files.UnsealedFiles[F] =>
-  override def walk(
+  override def walkWithAttributes(
       start: Path,
       options: WalkOptions
-  ): Stream[F, Path] =
+  ): Stream[F, PathInfo] =
     // Disable eager walks until https://github.com/scala-native/scala-native/issues/3744
     walkJustInTime(start, options)
 
   protected def walkJustInTime(
       start: Path,
       options: WalkOptions
-  ): Stream[F, Path]
+  ): Stream[F, PathInfo]
 }

--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -385,13 +385,21 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
     * For example, to eagerly walk a directory while following symbolic links, emitting all
     * paths as a single chunk, use `walk(start, WalkOptions.Eager.withFollowLinks(true))`.
     */
-  def walk(start: Path, options: WalkOptions): Stream[F, Path]
+  def walk(start: Path, options: WalkOptions): Stream[F, Path] =
+    walkWithAttributes(start, options).map(_.path)
 
   /** Creates a stream of paths contained in a given file tree down to a given depth.
     */
   @deprecated("Use walk(start, WalkOptions.Default.withMaxDepth(..).withFollowLinks(..))", "3.10")
   def walk(start: Path, maxDepth: Int, followLinks: Boolean): Stream[F, Path] =
     walk(start, WalkOptions.Default)
+
+  /** Like `walk` but returns a `PathInfo`, which provides both the `Path` and `BasicFileAttributes`. */
+  def walkWithAttributes(start: Path): Stream[F, PathInfo] =
+    walkWithAttributes(start, WalkOptions.Default)
+
+  /** Like `walk` but returns a `PathInfo`, which provides both the `Path` and `BasicFileAttributes`. */
+  def walkWithAttributes(start: Path, options: WalkOptions): Stream[F, PathInfo]
 
   /** Writes all data to the file at the specified path.
     *
@@ -517,44 +525,46 @@ object Files extends FilesCompanionPlatform with FilesLowPriority {
         case _: NoSuchFileException => ()
       })
 
-    def walk(start: Path, options: WalkOptions): Stream[F, Path] = {
+    def walkWithAttributes(start: Path, options: WalkOptions): Stream[F, PathInfo] = {
 
-      def go(start: Path, maxDepth: Int, ancestry: List[Either[Path, FileKey]]): Stream[F, Path] =
-        Stream.emit(start) ++ {
-          if (maxDepth == 0) Stream.empty
-          else
-            Stream.eval(getBasicFileAttributes(start, followLinks = false)).mask.flatMap { attr =>
-              if (attr.isDirectory)
-                list(start).mask.flatMap { path =>
-                  go(path, maxDepth - 1, attr.fileKey.toRight(start) :: ancestry)
+      def go(
+          start: Path,
+          maxDepth: Int,
+          ancestry: List[Either[Path, FileKey]]
+      ): Stream[F, PathInfo] =
+        Stream.eval(getBasicFileAttributes(start, followLinks = false)).mask.flatMap { attr =>
+          Stream.emit(PathInfo(start, attr)) ++ {
+            if (maxDepth == 0) Stream.empty
+            else if (attr.isDirectory)
+              list(start).mask.flatMap { path =>
+                go(path, maxDepth - 1, attr.fileKey.toRight(start) :: ancestry)
+              }
+            else if (attr.isSymbolicLink && options.followLinks)
+              Stream.eval(getBasicFileAttributes(start, followLinks = true)).mask.flatMap { attr =>
+                val fileKey = attr.fileKey
+                val isCycle = Traverse[List].existsM(ancestry) {
+                  case Right(ancestorKey) => F.pure(fileKey.contains(ancestorKey))
+                  case Left(ancestorPath) => isSameFile(start, ancestorPath)
                 }
-              else if (attr.isSymbolicLink && options.followLinks)
-                Stream.eval(getBasicFileAttributes(start, followLinks = true)).mask.flatMap {
-                  attr =>
-                    val fileKey = attr.fileKey
-                    val isCycle = Traverse[List].existsM(ancestry) {
-                      case Right(ancestorKey) => F.pure(fileKey.contains(ancestorKey))
-                      case Left(ancestorPath) => isSameFile(start, ancestorPath)
-                    }
 
-                    Stream.eval(isCycle).flatMap { isCycle =>
-                      if (!isCycle)
-                        list(start).mask.flatMap { path =>
-                          go(path, maxDepth - 1, attr.fileKey.toRight(start) :: ancestry)
-                        }
-                      else if (options.allowCycles)
-                        Stream.empty
-                      else
-                        Stream.raiseError(new FileSystemLoopException(start.toString))
+                Stream.eval(isCycle).flatMap { isCycle =>
+                  if (!isCycle)
+                    list(start).mask.flatMap { path =>
+                      go(path, maxDepth - 1, attr.fileKey.toRight(start) :: ancestry)
                     }
-
+                  else if (options.allowCycles)
+                    Stream.empty
+                  else
+                    Stream.raiseError(new FileSystemLoopException(start.toString))
                 }
-              else
-                Stream.empty
-            }
+
+              }
+            else
+              Stream.empty
+          }
         }
 
-      Stream.eval(getBasicFileAttributes(start, options.followLinks)) >> go(
+      go(
         start,
         options.maxDepth,
         Nil

--- a/io/shared/src/main/scala/fs2/io/file/PathInfo.scala
+++ b/io/shared/src/main/scala/fs2/io/file/PathInfo.scala
@@ -19,23 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package fs2
-package io
-package file
+package fs2.io.file
 
-private[file] trait AsyncFilesPlatform[F[_]] { self: Files.UnsealedFiles[F] =>
-
-  override def walkWithAttributes(
-      start: Path,
-      options: WalkOptions
-  ): Stream[F, PathInfo] =
-    if (options.chunkSize == Int.MaxValue) walkEager(start, options)
-    else walkJustInTime(start, options)
-
-  protected def walkEager(start: Path, options: WalkOptions): Stream[F, PathInfo]
-
-  protected def walkJustInTime(
-      start: Path,
-      options: WalkOptions
-  ): Stream[F, PathInfo]
-}
+/** Provides a `Path` and its associated `BasicFileAttributes`. */
+case class PathInfo(path: Path, attributes: BasicFileAttributes)


### PR DESCRIPTION
This provides better performance than `Files[F].walk(path).evalMap(p => p -> Files[F].getBasicFileAttributes(p))` given that all implementations of `walk` use file attributes.

Some use cases:

Computing cumulative size of a tree:

```scala
Files[F].walkWithAttributes(path).map(_.attributes.size).compile.foldMonoid
```

Getting all directories in a tree:

```scala
Files[F].walkWithAttributes(path).filter(_.attributes.isDirectory)
```