### PR TITLE
Fix performance of Stream.from(Blocking)Iterator when using large chunk sizes

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3605,7 +3605,7 @@ object Stream extends StreamLowPriority {
 
       def getNextChunk(i: Iterator[A]): F[Option[(Chunk[A], Iterator[A])]] =
         F.suspend(hint) {
-          for (_ <- 1 to chunkSize if i.hasNext) yield i.next()
+          i.take(chunkSize).toVector
         }.map { s =>
           if (s.isEmpty) None else Some((Chunk.from(s), i))
         }


### PR DESCRIPTION
When passing large chunk sizes to `Stream.fromBlockingIterator`, CPU is wasted calling `hasNext` on an empty iterable -- `chunkSize - i.size` times.

Noticed this when passing `Int.MaxValue` for chunk size and an operation took over 3 minutes longer than it should have.