### PR TITLE
Add conflate operations to Stream

### DIFF
--- a/core/shared/src/test/scala/fs2/StreamConflateSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamConflateSuite.scala
@@ -28,14 +28,13 @@ import scala.concurrent.duration._
 
 class StreamConflateSuite extends Fs2Suite {
 
-  test("conflate") {
+  test("conflateMap") {
     TestControl.executeEmbed(
       Stream
         .iterate(0)(_ + 1)
         .covary[IO]
         .metered(10.millis)
-        .map(List(_))
-        .conflate
+        .conflateMap(100)(List(_))
         .metered(101.millis)
         .take(5)
         .compile

--- a/core/shared/src/test/scala/fs2/StreamConflateSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamConflateSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+
+import cats.effect.IO
+import cats.effect.testkit.TestControl
+
+import scala.concurrent.duration._
+
+class StreamConflateSuite extends Fs2Suite {
+
+  test("conflate") {
+    TestControl.executeEmbed(
+      Stream
+        .iterate(0)(_ + 1)
+        .covary[IO]
+        .metered(10.millis)
+        .map(List(_))
+        .conflate
+        .metered(101.millis)
+        .take(5)
+        .compile
+        .toList
+        .assertEquals(
+          List(0) :: (1 until 10).toList :: 10.until(40).toList.grouped(10).toList
+        )
+    )
+  }
+}


### PR DESCRIPTION
Similar to `conflate`/`conflateWithSeed` from akka-streams.

This PR adds:
- `conflateChunks`
- `conflate`
- `conflate1`
- `conflateSemigroup`
- `conflateMap`

Recommended by @seigert on r/scala here: https://www.reddit.com/r/scala/comments/1ayqcx0/comment/krx6nr6/