### PR TITLE
Make Chunk.asSeqPlatform private

### DIFF
--- a/core/shared/src/main/scala-2.12/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-2.12/fs2/ChunkPlatform.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
 private[fs2] trait ChunkPlatform[+O] {
   self: Chunk[O] =>
 
-  def asSeqPlatform: Option[IndexedSeq[O]] =
+  private[fs2] def asSeqPlatform: Option[IndexedSeq[O]] =
     None
 }
 

--- a/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-2.13/fs2/ChunkPlatform.scala
@@ -26,7 +26,7 @@ import scala.collection.immutable.ArraySeq
 private[fs2] trait ChunkPlatform[+O] extends Chunk213And3Compat[O] {
   self: Chunk[O] =>
 
-  def asSeqPlatform: Option[IndexedSeq[O]] =
+  private[fs2] def asSeqPlatform: Option[IndexedSeq[O]] =
     this match {
       case arraySlice: Chunk.ArraySlice[?] =>
         Some(

--- a/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
+++ b/core/shared/src/main/scala-3/fs2/ChunkPlatform.scala
@@ -39,7 +39,7 @@ private[fs2] trait ChunkPlatform[+O] extends Chunk213And3Compat[O] {
       case _ => new Chunk.IArraySlice(IArray.unsafeFromArray(toArray(ct)), 0, size)
     }
 
-  def asSeqPlatform: Option[IndexedSeq[O]] =
+  private[fs2] def asSeqPlatform: Option[IndexedSeq[O]] =
     this match {
       case arraySlice: Chunk.ArraySlice[_] =>
         Some(


### PR DESCRIPTION
Originally in #3271 We accidentally left this internal helper as public.