### PR TITLE
Fix macos gha runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,8 @@ jobs:
         project: [ioJS, ioJVM, ioNative]
     runs-on: ${{ matrix.os }}
     steps:
+      - run: brew install sbt
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,9 @@ ThisBuild / githubWorkflowAddedJobs +=
     javas = List(githubWorkflowJavaVersions.value.head),
     oses = List("macos-latest"),
     matrixAdds = Map("project" -> List("ioJS", "ioJVM", "ioNative")),
-    steps = githubWorkflowJobSetup.value.toList ++ List(
+    steps = List(
+      WorkflowStep.Run(List("brew install sbt"))
+    ) ++ githubWorkflowJobSetup.value.toList ++ List(
       WorkflowStep.Run(List("brew install s2n"), cond = Some("matrix.project == 'ioNative'")),
       WorkflowStep.Sbt(List("${{ matrix.project }}/test"))
     )


### PR DESCRIPTION
Latest MacOS images no longer include SBT. See https://github.com/actions/setup-java/issues/627

h/t @BalmungSan 