### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Quick links:
 
 ### <a id="docs"></a>Documentation and getting help ###
 
-* There are Scaladoc API documentations for [the core library][core-api], which defines and implements the core types for streams and pulls, as well as the type aliases for pipes and sinks. [The `io` library][io-api] provides FS2 bindings for NIO-based file I/O and TCP/UDP networking.
+* There are Scaladoc API documentations for [the core library][api], which defines and implements the core types for streams and pulls, as well as the type aliases for pipes and sinks. [The `io` library][io-api] provides FS2 bindings for NIO-based file I/O and TCP/UDP networking.
 * [The official guide](https://fs2.io/#/guide) is a good starting point for learning more about the library.
 * The [documentation page](https://fs2.io/#/documentation) is intended to serve as a list of all references, including conference presentation recordings, academic papers, and blog posts, on the use and implementation of `fs2`.
 * [The FAQ](https://fs2.io/#/faq) has frequently asked questions. Feel free to open issues or PRs with additions to the FAQ!

--- a/README.md
+++ b/README.md
@@ -28,12 +28,10 @@ Quick links:
 
 [microsite]: http://fs2.io
 [api]: https://www.javadoc.io/doc/co.fs2/fs2-docs_2.13/latest/fs2/index.html
-[io-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.13/3.1.0/fs2-io_2.13-3.1.0-javadoc.jar/!/fs2/io/index.html
-[rx-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.13/3.1.0/fs2-reactive-streams_2.13-3.1.0-javadoc.jar/!/fs2/interop/reactivestreams/index.html
 
 ### <a id="docs"></a>Documentation and getting help ###
 
-* There are Scaladoc API documentations for [the core library][api], which defines and implements the core types for streams and pulls, as well as the type aliases for pipes and sinks. [The `io` library][io-api] provides FS2 bindings for NIO-based file I/O and TCP/UDP networking.
+* There are [Scaladoc API documentations][api] for the library.
 * [The official guide](https://fs2.io/#/guide) is a good starting point for learning more about the library.
 * The [documentation page](https://fs2.io/#/documentation) is intended to serve as a list of all references, including conference presentation recordings, academic papers, and blog posts, on the use and implementation of `fs2`.
 * [The FAQ](https://fs2.io/#/faq) has frequently asked questions. Feel free to open issues or PRs with additions to the FAQ!


### PR DESCRIPTION
The [README currently](https://github.com/typelevel/fs2/blob/0377f21532f3486c54da62d38430d9657d052960/README.md) contains "There are Scaladoc API documentations for [the core library][core-api], which defines and..."; note that a link has not been rendered to "[core-api]".

Looking through [git blame](https://github.com/typelevel/fs2/blame/main/README.md), "core-api" previously existed ([relevant commit](https://github.com/typelevel/fs2/commit/fa9cd8cb963d7a106ae1b69530d6b2ad7538e94f)) and pointed to a link on sonatype.org. The reference "[core-api]" changed to "[api]" in [this commit](https://github.com/typelevel/fs2/commit/15c790e498175e65c4d43dd8396d8fcee85bd847) but one reference to "core-api" was not updated.