### PR TITLE
Add `interop.flow.pipeToProcessor` & `interop.flow.processorToPipe`

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -5564,6 +5564,26 @@ object Stream extends StreamLowPriority {
       interop.flow.pipeToProcessor(pipe = self, chunkSize)
   }
 
+  /** Provides operations on IO pipes for syntactic convenience. */
+  implicit final class IOPipeOps[I, O](private val self: Pipe[IO, I, O]) extends AnyVal {
+
+    /** Creates a [[Processor]] from this [[Pipe]].
+      *
+      * You are required to manually subscribe this [[Processor]] to an upstream [[Publisher]], and have at least one downstream [[Subscriber]] subscribe to the [[Consumer]].
+      *
+      * @param chunkSize setup the number of elements asked each time from the upstream [[Publisher]].
+      *                  A high number may be useful if the publisher is triggering from IO,
+      *                  like requesting elements from a database.
+      *                  A high number will also lead to more elements in memory.
+      */
+    def unsafeToProcessor(
+        chunkSize: Int
+    )(implicit
+        runtime: IORuntime
+    ): Processor[I, O] =
+      interop.flow.unsafePipeToProcessor(pipe = self, chunkSize)
+  }
+
   /** Provides operations on pure pipes for syntactic convenience. */
   implicit final class PurePipeOps[I, O](private val self: Pipe[Pure, I, O]) extends AnyVal {
 

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2853,7 +2853,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * @param subscriber the [[Subscriber]] that will receive the elements of the stream.
     */
   def subscribe[F2[x] >: F[x]: Async, O2 >: O](subscriber: Subscriber[O2]): Stream[F2, Nothing] =
-    interop.flow.subscribeAsStream[F2, O2](this, subscriber)
+    interop.flow.StreamSubscription.subscribe[F2, O2](this, subscriber)
 
   /** Emits all elements of the input except the first one.
     *
@@ -3001,7 +3001,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
 
   /** @see [[toPublisher]] */
   def toPublisherResource[F2[x] >: F[x]: Async, O2 >: O]: Resource[F2, Publisher[O2]] =
-    interop.flow.toPublisher(this)
+    interop.flow.StreamPublisher(this)
 
   /** Translates effect type from `F` to `G` using the supplied `FunctionK`.
     */
@@ -3911,7 +3911,7 @@ object Stream extends StreamLowPriority {
     *                  either the `Chunk` is filled or the publisher finishes.
     */
   def fromPublisher[F[_]]: interop.flow.syntax.FromPublisherPartiallyApplied[F] =
-    interop.flow.fromPublisher
+    new interop.flow.syntax.FromPublisherPartiallyApplied(dummy = true)
 
   /** Like `emits`, but works for any G that has a `Foldable` instance.
     */
@@ -4697,7 +4697,7 @@ object Stream extends StreamLowPriority {
     def unsafeToPublisher()(implicit
         runtime: IORuntime
     ): Publisher[A] =
-      interop.flow.unsafeToPublisher(self)
+      interop.flow.StreamPublisher.unsafe(self)
   }
 
   /** Projection of a `Stream` providing various ways to get a `Pull` from the `Stream`. */

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -5561,7 +5561,7 @@ object Stream extends StreamLowPriority {
     )(implicit
         F: Async[F]
     ): Resource[F, Processor[I, O]] =
-      interop.flow.pipeToProcessor(pipe = self, chunkSize)
+      interop.flow.StreamProcessor.fromPipe(pipe = self, chunkSize)
   }
 
   /** Provides operations on IO pipes for syntactic convenience. */
@@ -5581,7 +5581,7 @@ object Stream extends StreamLowPriority {
     )(implicit
         runtime: IORuntime
     ): Processor[I, O] =
-      interop.flow.unsafePipeToProcessor(pipe = self, chunkSize)
+      interop.flow.StreamProcessor.unsafeFromPipe(pipe = self, chunkSize)
   }
 
   /** Provides operations on pure pipes for syntactic convenience. */

--- a/core/shared/src/main/scala/fs2/interop/flow/ProcessorPipe.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/ProcessorPipe.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package interop
+package flow
+
+import cats.syntax.all.*
+
+import java.util.concurrent.Flow
+import cats.effect.Async
+
+private[flow] final class ProcessorPipe[F[_], I, O](
+    processor: Flow.Processor[I, O],
+    chunkSize: Int
+)(implicit
+    F: Async[F]
+) extends Pipe[F, I, O] {
+  override def apply(stream: Stream[F, I]): Stream[F, O] =
+    (
+      Stream.resource(StreamPublisher[F, I](stream)),
+      Stream.eval(StreamSubscriber[F, O](chunkSize))
+    ).flatMapN { (publisher, subscriber) =>
+      val initiateUpstreamProduction = F.delay(publisher.subscribe(processor))
+      val initiateDownstreamConsumption = F.delay(processor.subscribe(subscriber))
+
+      subscriber.stream(
+        subscribe = initiateUpstreamProduction >> initiateDownstreamConsumption
+      )
+    }
+}

--- a/core/shared/src/main/scala/fs2/interop/flow/ProcessorPipe.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/ProcessorPipe.scala
@@ -28,7 +28,7 @@ import cats.syntax.all.*
 import java.util.concurrent.Flow
 import cats.effect.Async
 
-private[flow] final class ProcessorPipe[F[_], I, O](
+private[fs2] final class ProcessorPipe[F[_], I, O](
     processor: Flow.Processor[I, O],
     chunkSize: Int
 )(implicit

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamProcessor.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamProcessor.scala
@@ -70,7 +70,7 @@ private[flow] object StreamProcessor {
   )(implicit
       runtime: IORuntime
   ): StreamProcessor[IO, I, O] = {
-    val streamSubscriber = StreamSubscriber[IO, I](chunkSize).unsafeRunSync()
+    val streamSubscriber = StreamSubscriber.unsafe[IO, I](chunkSize)
     val inputStream = streamSubscriber.stream(subscribe = IO.unit)
     val outputStream = pipe(inputStream)
     val streamPublisher = StreamPublisher.unsafe(outputStream)

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamProcessor.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamProcessor.scala
@@ -27,7 +27,7 @@ import java.util.concurrent.Flow
 import cats.effect.{Async, IO, Resource}
 import cats.effect.unsafe.IORuntime
 
-private[flow] final class StreamProcessor[F[_], I, O](
+private[fs2] final class StreamProcessor[F[_], I, O](
     streamSubscriber: StreamSubscriber[F, I],
     streamPublisher: StreamPublisher[F, O]
 ) extends Flow.Processor[I, O] {
@@ -47,7 +47,7 @@ private[flow] final class StreamProcessor[F[_], I, O](
     streamPublisher.subscribe(subscriber)
 }
 
-private[flow] object StreamProcessor {
+private[fs2] object StreamProcessor {
   def fromPipe[F[_], I, O](
       pipe: Pipe[F, I, O],
       chunkSize: Int

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamProcessor.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamProcessor.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package fs2
 package interop
 package flow

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamProcessor.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamProcessor.scala
@@ -1,0 +1,44 @@
+package fs2
+package interop
+package flow
+
+import java.util.concurrent.Flow
+import cats.effect.{Async, Resource}
+
+private[flow] final class StreamProcessor[F[_], I, O](
+    streamSubscriber: StreamSubscriber[F, I],
+    streamPublisher: StreamPublisher[F, O]
+) extends Flow.Processor[I, O] {
+  override def onSubscribe(subscription: Flow.Subscription): Unit =
+    streamSubscriber.onSubscribe(subscription)
+
+  override def onNext(i: I): Unit =
+    streamSubscriber.onNext(i)
+
+  override def onError(ex: Throwable): Unit =
+    streamSubscriber.onError(ex)
+
+  override def onComplete(): Unit =
+    streamSubscriber.onComplete()
+
+  override def subscribe(subscriber: Flow.Subscriber[? >: O <: Object]): Unit =
+    streamPublisher.subscribe(subscriber)
+}
+
+private[flow] object StreamProcessor {
+  def fromPipe[F[_], I, O](
+      pipe: Pipe[F, I, O],
+      chunkSize: Int
+  )(implicit
+      F: Async[F]
+  ): Resource[F, StreamProcessor[F, I, O]] =
+    for {
+      streamSubscriber <- Resource.eval(StreamSubscriber[F, I](chunkSize))
+      inputStream = streamSubscriber.stream(subscribe = F.unit)
+      outputStream = pipe(inputStream)
+      streamPublisher <- StreamPublisher(outputStream)
+    } yield new StreamProcessor(
+      streamSubscriber,
+      streamPublisher
+    )
+}

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamProcessor.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamProcessor.scala
@@ -42,7 +42,7 @@ private[flow] final class StreamProcessor[F[_], I, O](
   override def onComplete(): Unit =
     streamSubscriber.onComplete()
 
-  override def subscribe(subscriber: Flow.Subscriber[? >: O <: Object]): Unit =
+  override def subscribe(subscriber: Flow.Subscriber[? >: O]): Unit =
     streamPublisher.subscribe(subscriber)
 }
 

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamPublisher.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamPublisher.scala
@@ -41,7 +41,7 @@ import scala.util.control.NoStackTrace
   *
   * @see [[https://github.com/reactive-streams/reactive-streams-jvm#1-publisher-code]]
   */
-private[flow] sealed abstract class StreamPublisher[F[_], A] private (
+private[fs2] sealed abstract class StreamPublisher[F[_], A] private (
     stream: Stream[F, A]
 )(implicit
     F: Async[F]
@@ -64,7 +64,7 @@ private[flow] sealed abstract class StreamPublisher[F[_], A] private (
   }
 }
 
-private[flow] object StreamPublisher {
+private[fs2] object StreamPublisher {
   private final class DispatcherStreamPublisher[F[_], A](
       stream: Stream[F, A],
       dispatcher: Dispatcher[F]

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamPublisher.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamPublisher.scala
@@ -23,8 +23,7 @@ package fs2
 package interop
 package flow
 
-import cats.effect.IO
-import cats.effect.kernel.{Async, Resource}
+import cats.effect.{Async, IO, Resource}
 import cats.effect.std.Dispatcher
 import cats.effect.unsafe.IORuntime
 

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamSubscriber.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamSubscriber.scala
@@ -36,7 +36,7 @@ import scala.util.control.NoStackTrace
   *
   * @see [[https://github.com/reactive-streams/reactive-streams-jvm#2-subscriber-code]]
   */
-private[flow] final class StreamSubscriber[F[_], A] private (
+private[fs2] final class StreamSubscriber[F[_], A] private (
     chunkSize: Int,
     currentState: AtomicReference[(StreamSubscriber.State, () => Unit)]
 )(implicit
@@ -106,7 +106,7 @@ private[flow] final class StreamSubscriber[F[_], A] private (
   // Interop API.
 
   /** Creates a downstream [[Stream]] from this [[Subscriber]]. */
-  private[flow] def stream(subscribe: F[Unit]): Stream[F, A] = {
+  private[fs2] def stream(subscribe: F[Unit]): Stream[F, A] = {
     // Called when downstream has finished consuming records.
     val finalize =
       F.delay(nextState(input = Complete(canceled = true)))
@@ -324,7 +324,7 @@ private[flow] final class StreamSubscriber[F[_], A] private (
   }
 }
 
-private[flow] object StreamSubscriber {
+private[fs2] object StreamSubscriber {
   private final val noop = () => ()
 
   /** Instantiates a new [[StreamSubscriber]] for the given buffer size. */

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamSubscriber.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamSubscriber.scala
@@ -23,7 +23,7 @@ package fs2
 package interop
 package flow
 
-import cats.effect.kernel.Async
+import cats.effect.Async
 
 import java.util.Objects.requireNonNull
 import java.util.concurrent.Flow.{Subscriber, Subscription}

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamSubscriber.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamSubscriber.scala
@@ -330,7 +330,9 @@ private[flow] object StreamSubscriber {
   /** Instantiates a new [[StreamSubscriber]] for the given buffer size. */
   def apply[F[_], A](
       chunkSize: Int
-  )(implicit F: Async[F]): F[StreamSubscriber[F, A]] = {
+  )(implicit
+      F: Async[F]
+  ): F[StreamSubscriber[F, A]] = {
     require(chunkSize > 0, "The buffer size MUST be positive")
 
     F.delay {

--- a/core/shared/src/main/scala/fs2/interop/flow/StreamSubscription.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamSubscription.scala
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
   *
   * @see [[https://github.com/reactive-streams/reactive-streams-jvm#3-subscription-code]]
   */
-private[flow] final class StreamSubscription[F[_], A] private (
+private[fs2] final class StreamSubscription[F[_], A] private (
     stream: Stream[F, A],
     subscriber: Subscriber[A],
     requests: AtomicLong,
@@ -171,7 +171,7 @@ private[flow] final class StreamSubscription[F[_], A] private (
     }
 }
 
-private[flow] object StreamSubscription {
+private[fs2] object StreamSubscription {
   private final val Sentinel = () => ()
 
   // UNSAFE + SIDE-EFFECTING!

--- a/core/shared/src/main/scala/fs2/interop/flow/package.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/package.scala
@@ -25,7 +25,7 @@ package interop
 import cats.effect.{Async, IO, Resource}
 import cats.effect.unsafe.IORuntime
 
-import java.util.concurrent.Flow.{Publisher, Processor, Subscriber, defaultBufferSize}
+import java.util.concurrent.Flow.{Publisher, Subscriber, defaultBufferSize}
 
 /** Implementation of the reactive-streams protocol for fs2; based on Java Flow.
   *
@@ -197,51 +197,6 @@ package object flow {
       F: Async[F]
   ): Stream[F, Nothing] =
     StreamSubscription.subscribe(stream, subscriber)
-
-  /** Creates a [[Processor]] from a [[Pipe]].
-    *
-    * You are required to manually subscribe this [[Processor]] to an upstream [[Publisher]], and have at least one downstream [[Subscriber]] subscribe to the [[Consumer]].
-    *
-    * Closing the [[Resource]] means not accepting new subscriptions,
-    * but waiting for all active ones to finish consuming.
-    * Canceling the [[Resource.use]] means gracefully shutting down all active subscriptions.
-    * Thus, no more elements will be published.
-    *
-    * @see [[unsafePipeToProcessor]] for an unsafe version that returns a plain [[Processor]].
-    *
-    * @param pipe The [[Pipe]] which represents the [[Processor]] logic.
-    * @param chunkSize setup the number of elements asked each time from the upstream [[Publisher]].
-    *                  A high number may be useful if the publisher is triggering from IO,
-    *                  like requesting elements from a database.
-    *                  A high number will also lead to more elements in memory.
-    */
-  def pipeToProcessor[F[_], I, O](
-      pipe: Pipe[F, I, O],
-      chunkSize: Int
-  )(implicit
-      F: Async[F]
-  ): Resource[F, Processor[I, O]] =
-    StreamProcessor.fromPipe(pipe, chunkSize)
-
-  /** Creates a [[Processor]] from a [[Pipe]].
-    *
-    * You are required to manually subscribe this [[Processor]] to an upstream [[Publisher]], and have at least one downstream [[Subscriber]] subscribe to the [[Consumer]].
-    *
-    * @see [[pipeToProcessor]] for a safe version that returns a [[Resource]].
-    *
-    * @param pipe The [[Pipe]] which represents the [[Processor]] logic.
-    * @param chunkSize setup the number of elements asked each time from the upstream [[Publisher]].
-    *                  A high number may be useful if the publisher is triggering from IO,
-    *                  like requesting elements from a database.
-    *                  A high number will also lead to more elements in memory.
-    */
-  def unsafePipeToProcessor[I, O](
-      pipe: Pipe[IO, I, O],
-      chunkSize: Int
-  )(implicit
-      runtime: IORuntime
-  ): Processor[I, O] =
-    StreamProcessor.unsafeFromPipe(pipe, chunkSize)
 
   /** Creates a [[Pipe]] from the given [[Processor]]
     *

--- a/core/shared/src/main/scala/fs2/interop/flow/package.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/package.scala
@@ -198,24 +198,6 @@ package object flow {
   ): Stream[F, Nothing] =
     StreamSubscription.subscribe(stream, subscriber)
 
-  /** Creates a [[Pipe]] from the given [[Processor]]
-    *
-    * The input stream won't be consumed until you request elements from the output stream,
-    * and thus the processor is not initiated until then.
-    *
-    * @note The [[Pipe]] can be reused multiple times as long as the [[Processor]] can be reused.
-    * Each invocation of the pipe will create and manage its own internal [[Publisher]] and [[Subscriber]],
-    * and use them to subscribe to and from the [[Processor]] respectively.
-    *
-    * @param [[processor]] the [[Processor]] that represents the [[Pipe]] logic.
-    * @param chunkSize setup the number of elements asked each time from the upstream [[Publisher]].
-    *                  A high number may be useful if the publisher is triggering from IO,
-    *                  like requesting elements from a database.
-    *                  A high number will also lead to more elements in memory.
-    */
-  def processorToPipe[F[_]]: syntax.FromProcessorPartiallyApplied[F] =
-    new syntax.FromProcessorPartiallyApplied[F](dummy = true)
-
   /** A default value for the `chunkSize` argument,
     * that may be used in the absence of other constraints;
     * we encourage choosing an appropriate value consciously.

--- a/core/shared/src/main/scala/fs2/interop/flow/package.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/package.scala
@@ -25,8 +25,7 @@ package interop
 import cats.effect.{Async, IO, Resource}
 import cats.effect.unsafe.IORuntime
 
-import java.util.concurrent.Flow
-import java.util.concurrent.Flow.{Publisher, Subscriber, defaultBufferSize}
+import java.util.concurrent.Flow.{Publisher, Processor, Subscriber, defaultBufferSize}
 
 /** Implementation of the reactive-streams protocol for fs2; based on Java Flow.
   *
@@ -199,13 +198,22 @@ package object flow {
   ): Stream[F, Nothing] =
     StreamSubscription.subscribe(stream, subscriber)
 
-  /** TODO. */
+  /** Creates a [[Processor]] from a [[Pipe]].
+    *
+    * You are required to manually subscribe this [[Processor]] to an upstream [[Publisher]], and have at least one downstream [[Subscriber]] subscribe to the [[Consumer]].
+    *
+    * @param pipe The [[Pipe]] which represents the [[Processor]] logic.
+    * @param chunkSize setup the number of elements asked each time from the upstream [[Publisher]].
+    *                  A high number may be useful if the publisher is triggering from IO,
+    *                  like requesting elements from a database.
+    *                  A high number will also lead to more elements in memory.
+    */
   def pipeToProcessor[F[_], I, O](
       pipe: Pipe[F, I, O],
       chunkSize: Int
   )(implicit
       F: Async[F]
-  ): Resource[F, Flow.Processor[I, O]] =
+  ): Resource[F, Processor[I, O]] =
     StreamProcessor.fromPipe(pipe, chunkSize)
 
   /** A default value for the `chunkSize` argument,

--- a/core/shared/src/main/scala/fs2/interop/flow/package.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/package.scala
@@ -22,10 +22,10 @@
 package fs2
 package interop
 
-import cats.effect.IO
-import cats.effect.kernel.{Async, Resource}
+import cats.effect.{Async, IO, Resource}
 import cats.effect.unsafe.IORuntime
 
+import java.util.concurrent.Flow
 import java.util.concurrent.Flow.{Publisher, Subscriber, defaultBufferSize}
 
 /** Implementation of the reactive-streams protocol for fs2; based on Java Flow.
@@ -198,6 +198,15 @@ package object flow {
       F: Async[F]
   ): Stream[F, Nothing] =
     StreamSubscription.subscribe(stream, subscriber)
+
+  /** TODO. */
+  def pipeToProcessor[F[_], I, O](
+      pipe: Pipe[F, I, O],
+      chunkSize: Int
+  )(implicit
+      F: Async[F]
+  ): Resource[F, Flow.Processor[I, O]] =
+    StreamProcessor.fromPipe(pipe, chunkSize)
 
   /** A default value for the `chunkSize` argument,
     * that may be used in the absence of other constraints;

--- a/core/shared/src/main/scala/fs2/interop/flow/package.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/package.scala
@@ -243,6 +243,24 @@ package object flow {
   ): Processor[I, O] =
     StreamProcessor.unsafeFromPipe(pipe, chunkSize)
 
+  /** Creates a [[Pipe]] from the given [[Processor]]
+    *
+    * The input stream won't be consumed until you request elements from the output stream,
+    * and thus the processor is not initiated until then.
+    *
+    * @note The [[Pipe]] can be reused multiple times as long as the [[Processor]] can be reused.
+    * Each invocation of the pipe will create and manage its own internal [[Publisher]] and [[Subscriber]],
+    * and use them to subscribe to and from the [[Processor]] respectively.
+    *
+    * @param [[processor]] the [[Processor]] that represents the [[Pipe]] logic.
+    * @param chunkSize setup the number of elements asked each time from the upstream [[Publisher]].
+    *                  A high number may be useful if the publisher is triggering from IO,
+    *                  like requesting elements from a database.
+    *                  A high number will also lead to more elements in memory.
+    */
+  def processorToPipe[F[_]]: syntax.FromProcessorPartiallyApplied[F] =
+    new syntax.FromProcessorPartiallyApplied[F](dummy = true)
+
   /** A default value for the `chunkSize` argument,
     * that may be used in the absence of other constraints;
     * we encourage choosing an appropriate value consciously.

--- a/core/shared/src/main/scala/fs2/interop/flow/syntax.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/syntax.scala
@@ -25,7 +25,7 @@ package flow
 
 import cats.effect.{Async, Resource}
 
-import java.util.concurrent.Flow.{Processor, Publisher, Subscriber}
+import java.util.concurrent.Flow.{Publisher, Subscriber}
 
 object syntax {
   implicit final class PublisherOps[A](private val publisher: Publisher[A]) extends AnyVal {
@@ -46,6 +46,7 @@ object syntax {
       flow.subscribeStream(stream, subscriber)
   }
 
+  // TODO: Move to the Stream companion object when removing the deprecated flow package object and syntax.
   final class FromPublisherPartiallyApplied[F[_]](private val dummy: Boolean) extends AnyVal {
     def apply[A](
         publisher: Publisher[A],
@@ -56,15 +57,5 @@ object syntax {
       fromPublisher[F, A](chunkSize) { subscriber =>
         F.delay(publisher.subscribe(subscriber))
       }
-  }
-
-  final class FromProcessorPartiallyApplied[F[_]](private val dummy: Boolean) extends AnyVal {
-    def apply[I, O](
-        processor: Processor[I, O],
-        chunkSize: Int
-    )(implicit
-        F: Async[F]
-    ): Pipe[F, I, O] =
-      new ProcessorPipe(processor, chunkSize)
   }
 }

--- a/core/shared/src/main/scala/fs2/interop/flow/syntax.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/syntax.scala
@@ -23,9 +23,9 @@ package fs2
 package interop
 package flow
 
-import cats.effect.kernel.{Async, Resource}
+import cats.effect.{Async, Resource}
 
-import java.util.concurrent.Flow.{Publisher, Subscriber}
+import java.util.concurrent.Flow.{Processor, Publisher, Subscriber}
 
 object syntax {
   implicit final class PublisherOps[A](private val publisher: Publisher[A]) extends AnyVal {
@@ -56,5 +56,15 @@ object syntax {
       fromPublisher[F, A](chunkSize) { subscriber =>
         F.delay(publisher.subscribe(subscriber))
       }
+  }
+
+  final class FromProcessorPartiallyApplied[F[_]](private val dummy: Boolean) extends AnyVal {
+    def apply[I, O](
+        processor: Processor[I, O],
+        chunkSize: Int
+    )(implicit
+        F: Async[F]
+    ): Pipe[F, I, O] =
+      new ProcessorPipe(processor, chunkSize)
   }
 }

--- a/core/shared/src/test/scala/fs2/interop/flow/ProcessorPipeSpec.scala
+++ b/core/shared/src/test/scala/fs2/interop/flow/ProcessorPipeSpec.scala
@@ -32,8 +32,7 @@ final class ProcessorPipeSpec extends Fs2Suite {
     forAllF(Arbitrary.arbitrary[Seq[Int]], Gen.posNum[Int]) { (ints, bufferSize) =>
       // Since creating a Flow.Processor is very complex,
       // we will reuse our Pipe => Processor logic.
-      val processor = unsafePipeToProcessor[Int, Int](
-        pipe = stream => stream.map(_ * 1),
+      val processor = ((stream: Stream[IO, Int]) => stream.map(_ * 1)).unsafeToProcessor(
         chunkSize = bufferSize
       )
 

--- a/core/shared/src/test/scala/fs2/interop/flow/ProcessorPipeSpec.scala
+++ b/core/shared/src/test/scala/fs2/interop/flow/ProcessorPipeSpec.scala
@@ -36,7 +36,7 @@ final class ProcessorPipeSpec extends Fs2Suite {
         chunkSize = bufferSize
       )
 
-      val pipe = processorToPipe[IO](
+      val pipe = Pipe.fromProcessor[IO](
         processor,
         chunkSize = bufferSize
       )

--- a/core/shared/src/test/scala/fs2/interop/flow/ProcessorPipeSpec.scala
+++ b/core/shared/src/test/scala/fs2/interop/flow/ProcessorPipeSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package interop
+package flow
+
+import cats.effect.IO
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.effect.PropF.forAllF
+
+final class ProcessorPipeSpec extends Fs2Suite {
+  test("should process upstream input and propagate results to downstream") {
+    forAllF(Arbitrary.arbitrary[Seq[Int]], Gen.posNum[Int]) { (ints, bufferSize) =>
+      // Since creating a Flow.Processor is very complex,
+      // we will reuse our Pipe => Processor logic.
+      val processor = unsafePipeToProcessor[Int, Int](
+        pipe = stream => stream.map(_ * 1),
+        chunkSize = bufferSize
+      )
+
+      val pipe = processorToPipe[IO](
+        processor,
+        chunkSize = bufferSize
+      )
+
+      val inputStream = Stream.emits(ints)
+      val outputStream = pipe(inputStream)
+      val program = outputStream.compile.toVector
+
+      program.assertEquals(ints.toVector)
+    }
+  }
+}

--- a/core/shared/src/test/scala/fs2/interop/flow/StreamProcessorSpec.scala
+++ b/core/shared/src/test/scala/fs2/interop/flow/StreamProcessorSpec.scala
@@ -1,0 +1,38 @@
+package fs2
+package interop
+package flow
+
+import cats.effect.{IO, Resource}
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.effect.PropF.forAllF
+import java.util.concurrent.Flow.Publisher
+
+final class StreamProcessorSpec extends Fs2Suite {
+  test("should process upstream input and propagate results to downstream") {
+    forAllF(Arbitrary.arbitrary[Seq[Int]], Gen.posNum[Int]) { (ints, bufferSize) =>
+      val processor = pipeToProcessor[IO, Int, Int](
+        pipe = stream => stream.map(_ * 1),
+        chunkSize = bufferSize
+      )
+
+      val publisher = toPublisher(
+        Stream.emits(ints).covary[IO]
+      )
+
+      def subscriber(publisher: Publisher[Int]): IO[Vector[Int]] =
+        Stream
+          .fromPublisher[IO](
+            publisher,
+            chunkSize = bufferSize
+          )
+          .compile
+          .toVector
+
+      val program = Resource.both(processor, publisher).use { case (pr, p) =>
+        IO(p.subscribe(pr)) >> subscriber(pr)
+      }
+
+      program.assertEquals(ints.toVector)
+    }
+  }
+}

--- a/core/shared/src/test/scala/fs2/interop/flow/StreamProcessorSpec.scala
+++ b/core/shared/src/test/scala/fs2/interop/flow/StreamProcessorSpec.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package fs2
 package interop
 package flow

--- a/core/shared/src/test/scala/fs2/interop/flow/StreamProcessorSpec.scala
+++ b/core/shared/src/test/scala/fs2/interop/flow/StreamProcessorSpec.scala
@@ -31,10 +31,9 @@ import java.util.concurrent.Flow.Publisher
 final class StreamProcessorSpec extends Fs2Suite {
   test("should process upstream input and propagate results to downstream") {
     forAllF(Arbitrary.arbitrary[Seq[Int]], Gen.posNum[Int]) { (ints, bufferSize) =>
-      val processor = pipeToProcessor[IO, Int, Int](
-        pipe = stream => stream.map(_ * 1),
-        chunkSize = bufferSize
-      )
+      val pipe = (stream: Stream[IO, Int]) => stream.map(_ * 1)
+
+      val processor = pipe.toProcessor(chunkSize = bufferSize)
 
       val publisher = toPublisher(
         Stream.emits(ints).covary[IO]


### PR DESCRIPTION
Convenient helpers.

Roadmap:
- [x] safe version.
- [x] **Scaladoc**.
- [x] `unsafe` version.
- [x] Unit test.