### PR TITLE
Update Guide snippet error

### DIFF
--- a/site/guide.md
+++ b/site/guide.md
@@ -428,7 +428,7 @@ import cats.effect.IO
 Stream(1,2,3).merge(Stream.eval(IO { Thread.sleep(200); 4 })).compile.toVector.unsafeRunSync()
 ```
 
-Oops, we need a `cats.effect.ContextShift[IO]` in implicit scope. Let's add that:
+Oops, we need a `cats.effect.unsafe.IORuntime` in implicit scope. Let's add that:
 
 ```scala mdoc
 import cats.effect.IO


### PR DESCRIPTION
The output on [the Guide/Concurrency page](https://fs2.io/#/guide?id=concurrency) currently shows
```
Stream(1,2,3).merge(Stream.eval(IO { Thread.sleep(200); 4 })).compile.toVector.unsafeRunSync()
// error: Could not find an implicit IORuntime.
// 
// Instead of calling unsafe methods directly, consider using cats.effect.IOApp, which
// runs your IO. If integrating with non-functional code or experimenting in a REPL / Worksheet,
// add the following import:
```
and the text `Oops, we need a cats.effect.ContextShift[IO] in implicit scope.`.

The text was [last updated August 2018](https://github.com/typelevel/fs2/commit/e05a62fab9beb1a417ae80de87ab88eeaa112f95#diff-bc466a168b95b1a628addcbeceb5d0208b95b605692e475b93c143d7658aa904R374), before cats-effect 3, which [changed ContextShift](https://typelevel.org/cats-effect/docs/migration-guide#contextshift). I updated it to refer to [IORuntime](https://typelevel.org/cats-effect/api/3.x/cats/effect/unsafe/IORuntime.html).