### PR TITLE
Add `unfoldChunkLoop` and `unfoldChunkLoopEval`, more (downstream) efficient versions of `unfoldLoop` and `unfoldLoopEval`.

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4202,6 +4202,17 @@ object Stream extends StreamLowPriority {
     go(start).stream
   }
 
+  /** Like [[unfoldLoop]], but more efficient downstream as it outputs chunks. */
+  def unfoldChunkLoop[F[x] <: Pure[x], S, O](
+      start: S
+  )(f: S => (Chunk[O], Option[S])): Stream[F, O] = {
+    def go(s: S): Pull[F, O, Unit] = f(s) match {
+      case (o, None)    => Pull.output(o)
+      case (o, Some(t)) => Pull.output(o) >> go(t)
+    }
+    go(start).stream
+  }
+
   /** Like [[unfoldLoop]], but takes an effectful function. */
   def unfoldLoopEval[F[_], S, O](start: S)(f: S => F[(O, Option[S])]): Stream[F, O] = {
     def go(s: S): Pull[F, O, Unit] =


### PR DESCRIPTION
This removes the need to call `.unchunks` if outputting chunks, and also adds symmetry to `unfoldEval` and its chunk variant `unfoldChunkEval`.