### PR TITLE
Fix resource leak in `Scope`.

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/Scope.scala
+++ b/core/shared/src/main/scala/fs2/internal/Scope.scala
@@ -258,10 +258,10 @@ private[fs2] final class Scope[F[_]] private (
     * finalized after this scope is closed, but they will get finalized shortly after. See [[ScopedResource]] for
     * more details.
     */
-  def close(ec: Resource.ExitCase): F[Either[Throwable, Unit]] = 
+  def close(ec: Resource.ExitCase): F[Either[Throwable, Unit]] =
     F.uncancelable(_ => close_(ec))
 
-  private def close_(ec: Resource.ExitCase): F[Either[Throwable, Unit]] = {
+  private def close_(ec: Resource.ExitCase): F[Either[Throwable, Unit]] =
     state.modify(s => Scope.State.closed -> s).flatMap {
       case previous: Scope.State.Open[F] =>
         for {
@@ -272,7 +272,6 @@ private[fs2] final class Scope[F[_]] private (
         } yield CompositeFailure.fromResults(resultChildren, resultResources)
       case _: Scope.State.Closed[F] => F.pure(Right(()))
     }
-  }
 
   /** Like `openAncestor` but returns self if open. */
   private def openScope: F[Scope[F]] =

--- a/core/shared/src/main/scala/fs2/internal/Scope.scala
+++ b/core/shared/src/main/scala/fs2/internal/Scope.scala
@@ -258,7 +258,7 @@ private[fs2] final class Scope[F[_]] private (
     * finalized after this scope is closed, but they will get finalized shortly after. See [[ScopedResource]] for
     * more details.
     */
-  def close(ec: Resource.ExitCase): F[Either[Throwable, Unit]] =
+  def close(ec: Resource.ExitCase): F[Either[Throwable, Unit]] = F.uncancelable { _ =>
     state.modify(s => Scope.State.closed -> s).flatMap {
       case previous: Scope.State.Open[F] =>
         for {
@@ -269,6 +269,7 @@ private[fs2] final class Scope[F[_]] private (
         } yield CompositeFailure.fromResults(resultChildren, resultResources)
       case _: Scope.State.Closed[F] => F.pure(Right(()))
     }
+  }
 
   /** Like `openAncestor` but returns self if open. */
   private def openScope: F[Scope[F]] =


### PR DESCRIPTION
I minimized a bug I had to this.
```scala
IO.ref(0).flatMap { ref =>
  val res = Stream.resource(Resource.make(ref.update(_ + 1))(_ => ref.update(_ - 1)))

  (0 to 100000).toList.parTraverse_ { _ =>
    val fa = res.evalMap(_ => IO.sleep(10.millis)).take(10).compile.drain
    IO.race(fa, IO.sleep(90.millis))
  } >> ref.get.map(assertEquals(_, 0))
}
```
The `Ref` will sometimes not contain 0. I tried the same test with the following fix and it does not occur anymore.

### Explanation (or rather my hypothesis)
If cancellation of the stream occurs between `state.modify` and the subsequent `flatMap` then the scope's state is `Closed`, thus when the root scope is cancelled and traverses the scope tree, the node is now `Closed`, but the finalizers for the attached resources were never run.

I can't seem to come up with a good test for this.