### PR TITLE
Optimise text.lines for longer lines, larger chunks use-cases

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -529,7 +529,6 @@ object text {
     def go(
         stream: Stream[F, String],
         stringBuilder: StringBuilder,
-        linesBuffer: ArrayBuffer[String],
         ignoreFirstCharNewLine: BoolWrapper,
         first: Boolean
     ): Pull[F, String, Unit] =
@@ -548,7 +547,7 @@ object text {
             else Pull.output1(result)
           }
         case Some((chunk, stream)) =>
-          linesBuffer.clear()
+          val linesBuffer = ArrayBuffer.empty[String]
           chunk.foreach { string =>
             fillBuffers(stringBuilder, linesBuffer, string, ignoreFirstCharNewLine)
           }
@@ -562,7 +561,6 @@ object text {
               Pull.output(Chunk.from(linesBuffer)) >> go(
                 stream,
                 stringBuilder,
-                linesBuffer,
                 ignoreFirstCharNewLine,
                 first = false
               )
@@ -574,7 +572,6 @@ object text {
         go(
           s,
           new StringBuilder(),
-          ArrayBuffer.empty[String],
           new BoolWrapper(false),
           first = true
         ).stream


### PR DESCRIPTION
The main idea is to avoid copying single characters, and instead copy string slices, that can use avx2 instructions.

The copy is still unavoidable unfortunately in JVM - AFAIK.

benchmarks running locally `-wi 3 -i 3 -f 1 -t 1`

Before:
```
LinesBenchmark.linesBenchmark                0            4  thrpt    3  122139.570 ± 236181.395  ops/s
LinesBenchmark.linesBenchmark                0           16  thrpt    3  134204.974 ±  76569.841  ops/s
LinesBenchmark.linesBenchmark                0           64  thrpt    3  133776.725 ± 137902.948  ops/s
LinesBenchmark.linesBenchmark                1            4  thrpt    3   44078.282 ±  46048.728  ops/s
LinesBenchmark.linesBenchmark                1           16  thrpt    3   95173.337 ±  31919.684  ops/s
LinesBenchmark.linesBenchmark                1           64  thrpt    3   91207.064 ± 134077.287  ops/s
LinesBenchmark.linesBenchmark               10            4  thrpt    3   11310.247 ±   6860.349  ops/s
LinesBenchmark.linesBenchmark               10           16  thrpt    3   53543.590 ±  12547.417  ops/s
LinesBenchmark.linesBenchmark               10           64  thrpt    3   66603.479 ±  66765.096  ops/s
LinesBenchmark.linesBenchmark              100            4  thrpt    3    1759.697 ±   1187.625  ops/s
LinesBenchmark.linesBenchmark              100           16  thrpt    3   10084.010 ±   6844.210  ops/s
LinesBenchmark.linesBenchmark              100           64  thrpt    3   15806.198 ±   3290.178  ops/s
```

After:
```
LinesBenchmark.linesBenchmark                0            4  thrpt    3  129302.595 ±  42736.093  ops/s
LinesBenchmark.linesBenchmark                0           16  thrpt    3  130886.744 ±  47487.794  ops/s
LinesBenchmark.linesBenchmark                0           64  thrpt    3  123490.463 ± 156930.971  ops/s
LinesBenchmark.linesBenchmark                1            4  thrpt    3   41200.649 ±  10262.513  ops/s
LinesBenchmark.linesBenchmark                1           16  thrpt    3   87733.636 ± 111704.611  ops/s
LinesBenchmark.linesBenchmark                1           64  thrpt    3   94767.345 ±  62120.286  ops/s
LinesBenchmark.linesBenchmark               10            4  thrpt    3   12385.057 ±   7146.545  ops/s
LinesBenchmark.linesBenchmark               10           16  thrpt    3   49429.892 ±  33859.569  ops/s
LinesBenchmark.linesBenchmark               10           64  thrpt    3   75037.094 ± 107270.451  ops/s
LinesBenchmark.linesBenchmark              100            4  thrpt    3    1699.683 ±    544.435  ops/s
LinesBenchmark.linesBenchmark              100           16  thrpt    3   13667.955 ±   3294.870  ops/s
LinesBenchmark.linesBenchmark              100           64  thrpt    3   31498.156 ±  13943.473  ops/s
```
