### PR TITLE
Fix `writeUtf8Lines` evaluates leading effects in the input stream twice

### DIFF
--- a/io/shared/src/main/scala/fs2/io/file/Files.scala
+++ b/io/shared/src/main/scala/fs2/io/file/Files.scala
@@ -464,8 +464,13 @@ sealed trait Files[F[_]] extends FilesPlatform[F] {
   def writeUtf8Lines(path: Path, flags: Flags): Pipe[F, String, Nothing] = in =>
     in.pull.uncons
       .flatMap {
-        case Some(_) =>
-          in.intersperse(lineSeparator).append(Stream[F, String](lineSeparator)).underlying
+        case Some((next, rest)) =>
+          Stream
+            .chunk(next)
+            .append(rest)
+            .intersperse(lineSeparator)
+            .append(Stream[F, String](lineSeparator))
+            .underlying
         case None => Pull.done
       }
       .stream


### PR DESCRIPTION
Fixes #3488.

There was a problem with `writeUtf8Lines` executing `in.pull.uncons` and evaluating leading effects, but discarding the result and using `in`.

(Sorry if it is difficult to read due to the use of translation software.)