### PR TITLE
Change repeatN to support n=0

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2574,9 +2574,9 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * }}}
     */
   def repeatN(n: Long): Stream[F, O] = {
-    require(n > 0, "n must be > 0") // same behaviour as sliding
-    if (n > 1) this ++ repeatN(n - 1)
-    else this
+    require(n >= 0, "n must be >= 0")
+    if (n > 0) this ++ repeatN(n - 1)
+    else Stream.empty
   }
 
   /** Converts a `Stream[F,Either[Throwable,O]]` to a `Stream[F,O]`, which emits right values and fails upon the first `Left(t)`.

--- a/core/shared/src/test/scala/fs2/StreamSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamSuite.scala
@@ -590,7 +590,7 @@ class StreamSuite extends Fs2Suite {
 
   property("repeatN") {
     forAll(
-      Gen.chooseNum(1, 200),
+      Gen.chooseNum(0, 200),
       Gen.chooseNum(1, 200).flatMap(i => Gen.listOfN(i, arbitrary[Int]))
     ) { (n: Int, testValues: List[Int]) =>
       assertEquals(


### PR DESCRIPTION
While putting together a couple of simple Stream example, I was surprised that `repeatN(0)` fails with an error instead of completing with an empty Stream. I would have expected it to work as `repeat.take(0)` would do.

I'm opening this PR to get some feedback about this proposal. I'm happy to discuss possible consequences of this change.

Apart from avoiding surprises or confusion on the user side, I don't have any real use cases in mind where this would be necessary to have
