### PR TITLE
Fix #3076 parEvalMap resource scoping

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -238,19 +238,19 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     */
   def broadcastThrough[F2[x] >: F[x]: Concurrent, O2](pipes: Pipe[F2, O, O2]*): Stream[F2, O2] = {
     assert(pipes.nonEmpty, s"pipes should not be empty")
-    underlying.uncons.flatMap {
-      case Some((hd, tl)) =>
+    extendScopeThrough { source =>
+      Stream.force {
         for {
           // topic: contains the chunk that the pipes are processing at one point.
           // until and unless all pipes are finished with it, won't move to next one
-          topic <- Pull.eval(Topic[F2, Chunk[O]])
+          topic <- Topic[F2, Chunk[O]]
           // Coordination: neither the producer nor any consumer starts
           // until and unless all consumers are subscribed to topic.
-          allReady <- Pull.eval(CountDownLatch[F2](pipes.length))
+          allReady <- CountDownLatch[F2](pipes.length)
+        } yield {
+          val checkIn = allReady.release >> allReady.await
 
-          checkIn = allReady.release >> allReady.await
-
-          dump = (pipe: Pipe[F2, O, O2]) =>
+          def dump(pipe: Pipe[F2, O, O2]): Stream[F2, O2] =
             Stream.resource(topic.subscribeAwait(1)).flatMap { sub =>
               // Wait until all pipes are ready before consuming.
               // Crucial: checkin is not passed to the pipe,
@@ -258,19 +258,13 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
               Stream.exec(checkIn) ++ pipe(sub.unchunks)
             }
 
-          dumpAll: Stream[F2, O2] <-
-            Pull.extendScopeTo(Stream(pipes: _*).map(dump).parJoinUnbounded)
-
-          chunksStream = Stream.chunk(hd).append(tl.stream).chunks
-
+          val dumpAll: Stream[F2, O2] = Stream(pipes: _*).map(dump).parJoinUnbounded
           // Wait until all pipes are checked in before pulling
-          pump = Stream.exec(allReady.await) ++ topic.publish(chunksStream)
-
-          _ <- dumpAll.concurrently(pump).underlying
-        } yield ()
-
-      case None => Pull.done
-    }.stream
+          val pump = Stream.exec(allReady.await) ++ topic.publish(source.chunks)
+          dumpAll.concurrently(pump)
+        }
+      }
+    }
   }
 
   /** Behaves like the identity function, but requests `n` elements at a time from the input.
@@ -2331,75 +2325,65 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       channel: F2[Channel[F2, F2[Either[Throwable, O2]]]],
       isOrdered: Boolean,
       f: O => F2[O2]
-  )(implicit F: Concurrent[F2]): Stream[F2, O2] = {
-    val action =
-      (
-        Semaphore[F2](concurrency),
-        channel,
-        Deferred[F2, Unit],
-        Deferred[F2, Unit]
-      ).mapN { (semaphore, channel, stop, end) =>
-        def initFork(release: F2[Unit]): F2[Either[Throwable, O2] => F2[Unit]] = {
-          def ordered: F2[Either[Throwable, O2] => F2[Unit]] = {
-            def send(v: Deferred[F2, Either[Throwable, O2]]) =
-              (el: Either[Throwable, O2]) => v.complete(el).void
+  )(implicit F: Concurrent[F2]): Stream[F2, O2] =
+    extendScopeThrough { source =>
+      Stream.force {
+        (
+          Semaphore[F2](concurrency),
+          channel,
+          Deferred[F2, Unit],
+          Deferred[F2, Unit]
+        ).mapN { (semaphore, channel, stop, end) =>
+          def initFork(release: F2[Unit]): F2[Either[Throwable, O2] => F2[Unit]] = {
+            def ordered: F2[Either[Throwable, O2] => F2[Unit]] = {
+              def send(v: Deferred[F2, Either[Throwable, O2]]) =
+                (el: Either[Throwable, O2]) => v.complete(el).void
 
-            Deferred[F2, Either[Throwable, O2]]
-              .flatTap(value => channel.send(release *> value.get))
-              .map(send)
-          }
-
-          def unordered: Either[Throwable, O2] => F2[Unit] =
-            (el: Either[Throwable, O2]) => release <* channel.send(F.pure(el))
-
-          if (isOrdered) ordered else F.pure(unordered)
-        }
-
-        val releaseAndCheckCompletion =
-          semaphore.release *>
-            semaphore.available.flatMap {
-              case `concurrency` => channel.close *> end.complete(()).void
-              case _             => F.unit
+              Deferred[F2, Either[Throwable, O2]]
+                .flatTap(value => channel.send(release *> value.get))
+                .map(send)
             }
 
-        def forkOnElem(el: O): F2[Unit] =
-          F.uncancelable { poll =>
-            poll(semaphore.acquire) <*
-              Deferred[F2, Unit].flatMap { pushed =>
-                val init = initFork(pushed.complete(()).void)
-                poll(init).onCancel(releaseAndCheckCompletion).flatMap { send =>
-                  val action = F.catchNonFatal(f(el)).flatten.attempt.flatMap(send) *> pushed.get
-                  F.start(stop.get.race(action) *> releaseAndCheckCompletion)
-                }
-              }
+            def unordered: Either[Throwable, O2] => F2[Unit] =
+              (el: Either[Throwable, O2]) => release <* channel.send(F.pure(el))
+
+            if (isOrdered) ordered else F.pure(unordered)
           }
 
-        underlying.uncons.flatMap {
-          case Some((hd, tl)) =>
-            for {
-              foreground <- Pull.extendScopeTo(
-                channel.stream.evalMap(_.rethrow).onFinalize(stop.complete(()) *> end.get)
-              )
-              background = Stream
-                .exec(semaphore.acquire) ++
-                Stream
-                  .chunk(hd)
-                  .append(tl.stream)
-                  .interruptWhen(stop.get.map(_.asRight[Throwable]))
-                  .foreach(forkOnElem)
-                  .onFinalizeCase {
-                    case ExitCase.Succeeded => releaseAndCheckCompletion
-                    case _                  => stop.complete(()) *> releaseAndCheckCompletion
+          val releaseAndCheckCompletion =
+            semaphore.release *>
+              semaphore.available.flatMap {
+                case `concurrency` => channel.close *> end.complete(()).void
+                case _             => F.unit
+              }
+
+          def forkOnElem(el: O): F2[Unit] =
+            F.uncancelable { poll =>
+              poll(semaphore.acquire) <*
+                Deferred[F2, Unit].flatMap { pushed =>
+                  val init = initFork(pushed.complete(()).void)
+                  poll(init).onCancel(releaseAndCheckCompletion).flatMap { send =>
+                    val action = F.catchNonFatal(f(el)).flatten.attempt.flatMap(send) *> pushed.get
+                    F.start(stop.get.race(action) *> releaseAndCheckCompletion)
                   }
-              _ <- foreground.concurrently(background).underlying
-            } yield ()
+                }
+            }
 
-          case None => Pull.done
-        }.stream
+          val background =
+            Stream.exec(semaphore.acquire) ++
+              source
+                .interruptWhen(stop.get.map(_.asRight[Throwable]))
+                .foreach(forkOnElem)
+                .onFinalizeCase {
+                  case ExitCase.Succeeded => releaseAndCheckCompletion
+                  case _                  => stop.complete(()) *> releaseAndCheckCompletion
+                }
+
+          val foreground = channel.stream.evalMap(_.rethrow)
+          foreground.onFinalize(stop.complete(()) *> end.get).concurrently(background)
+        }
       }
-
-    Stream.force(action)
-  }
+    }
 
   /** Concurrent zip.
     *
@@ -2474,12 +2458,13 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     */
   def prefetchN[F2[x] >: F[x]: Concurrent](
       n: Int
-  ): Stream[F2, O] =
+  ): Stream[F2, O] = extendScopeThrough { source =>
     Stream.eval(Channel.bounded[F2, Chunk[O]](n)).flatMap { chan =>
       chan.stream.unchunks.concurrently {
-        chunks.through(chan.sendAll)
+        source.chunks.through(chan.sendAll)
       }
     }
+  }
 
   /** Prints each element of this stream to standard out, converting each element to a `String` via `Show`. */
   def printlns[F2[x] >: F[x], O2 >: O](implicit
@@ -2939,6 +2924,23 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
       s2: Stream[F2, O2]
   )(f: (Stream[F, O], Stream[F2, O2]) => Stream[F2, O3]): Stream[F2, O3] =
     f(this, s2)
+
+  /** Transforms this stream, explicitly extending the current scope through the given pipe.
+    *
+    * Use this when implementing a pipe where the resulting stream is not directly constructed from
+    * the source stream, e.g. when sending the source stream through a Channel and returning the
+    * channel's stream.
+    */
+  def extendScopeThrough[F2[x] >: F[x], O2](
+      f: Stream[F, O] => Stream[F2, O2]
+  )(implicit F: MonadError[F2, Throwable]): Stream[F2, O2] =
+    this.pull.peek
+      .flatMap {
+        case Some((_, tl)) => Pull.extendScopeTo(f(tl))
+        case None          => Pull.extendScopeTo(f(Stream.empty))
+      }
+      .flatMap(_.underlying)
+      .stream
 
   /** Fails this stream with a `TimeoutException` if it does not complete within given `timeout`. */
   def timeout[F2[x] >: F[x]: Temporal](

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -1328,6 +1328,20 @@ class StreamCombinatorsSuite extends Fs2Suite {
         )
         .assertEquals(4.seconds)
     }
+
+    test("scope propagation") {
+      Deferred[IO, Unit]
+        .flatMap { d =>
+          Stream
+            .bracket(IO.unit)(_ => d.complete(()).void)
+            .prefetch
+            .evalMap(_ => IO.sleep(1.second) >> d.complete(()))
+            .timeout(5.seconds)
+            .compile
+            .last
+        }
+        .assertEquals(Some(true))
+    }
   }
 
   test("range") {


### PR DESCRIPTION
This is a continuation of https://github.com/typelevel/fs2/pull/3512

### Original description

Updates `parEvalMap*`, `broadcastThrough` and `prefetch` to extend the resource scope past the channel/topic used to implement concurrency for these operators.

In all cases the solution is the same:

* use underlying.uncons.flatMap to get into a Pull context with access to the source stream
* setup the new foreground stream with Pull.extendScopeTo to pull the scope across to the new stream

I have abstracted this solution to a new `extendScopeThrough` method, which works as `through` except propagating the scope to the new stream. It appears we should be doing this for any stream combinator where the resulting stream is not directly derived from the current stream (e.g. any combinator that uses an internal buffer, channel, topic, or such).

I also had to fix the cancallation safety of extendScopeTo (see https://github.com/typelevel/fs2/issues/3474). The StreamSuite "resource safety test 4" started failing after my changes, presumably because the scope started propagating far enough to actually get hit by cancellation.

There is at least conflateChunks broken the same way but I'd like to validate this solution is correct before I continue trying to chase down all the places the fix should be applied.

---

In this PR, the implementation of the `extendScopeThrough` is changed (because @reardonj found that the original one was not handling more complicated cases correctly): 

* instead of `extendScopeTo`, a new method is defined and used: `Pull.bindAcquireToScope`
* `bindAcquireToScope` "walks" the tree of pulls and updates every `Pull.Acquire` to use `scope.acquireResource`, binding all acquisitions to the provided scope.

---

I can say I don't really know what I'm doing here :) - it was a desperate attempt to fix the issue. But it seems to have worked.

Given that - this PR really needs a review by someone who knows how all this works (scopes, pulls, etc).
* does this approach even make sense (walking the Pull tree)?
* am I missing something?
* is there a better way?

---

There is one kind of `Pull` that I do not know how to process: `Pull.Translate`. At the very least, we don't have a `MonadThrow` for `G`, which is needed to call `bindAcquireToScope` recursively.

---

TODO
* [ ] clean up debug `println`s
* [ ] figure out `Pull.Translate` 