### PR TITLE
Be more deffensive with the `StreamSubscriber` internal state

### DIFF
--- a/core/shared/src/main/scala/fs2/interop/flow/StreamSubscriber.scala
+++ b/core/shared/src/main/scala/fs2/interop/flow/StreamSubscriber.scala
@@ -252,9 +252,8 @@ private[flow] final class StreamSubscriber[F[_], A] private (
               inOnNextLoop = false
               buffer = null
               cb.apply(Right(None))
-            } else if (index == 0) {
+            } else if (buffer eq null) {
               inOnNextLoop = false
-              buffer = null
               cb.apply(Right(None))
             } else {
               val chunk = Chunk.array(buffer, offset = 0, length = index)


### PR DESCRIPTION
I think this fixes the flaky **flow** interop tests: #3541 #3542 
Related to #3449 

I think the main change is ensuring we reset the `StreamSubscriber` state BEFORE completing the callback with the `Chunk`.
But, I also made sure we reset the state in any place where we complete a callback, even with exceptions, just in case.

c.c. @armanbilge 