### PR TITLE
fix `flake.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           imports = [ typelevel-nix.typelevelShell ];
           name = "fs2-shell";
           typelevelShell = {
-            jdk.package = pkgs.jdk23;
+            jdk.package = pkgs.jdk17;
             nodejs.enable = true;
             native.enable = true;
             native.libraries = [ pkgs.zlib pkgs.s2n-tls pkgs.openssl ];

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ typelevel-nix.overlay ];
+          overlays = [ typelevel-nix.overlays.default ];
         };
       in
       {
@@ -18,7 +18,7 @@
           imports = [ typelevel-nix.typelevelShell ];
           name = "fs2-shell";
           typelevelShell = {
-            jdk.package = pkgs.jdk17;
+            jdk.package = pkgs.jdk23;
             nodejs.enable = true;
             native.enable = true;
             native.libraries = [ pkgs.zlib pkgs.s2n-tls pkgs.openssl ];


### PR DESCRIPTION
Fix `flake.nix`. It wasn't working before.

After changes, I can open a nix shell as expected.
