### PR TITLE
Implement `Socket#sendFile`

### DIFF
--- a/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -67,7 +67,7 @@ private[file] trait FileHandlePlatform[F[_]] {
 
 }
 
-class SyncFileHandle[F[_]](val chan: FileChannel)(implicit F: Sync[F]) extends FileHandle[F] {
+private[io] final class SyncFileHandle[F[_]](val chan: FileChannel)(implicit F: Sync[F]) extends FileHandle[F] {
   type Lock = FileLock
 
   override def force(metaData: Boolean): F[Unit] =

--- a/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -64,7 +64,7 @@ private[file] trait FileHandlePlatform[F[_]] {
     * @param lock the lock object which represents the locked file or region.
     */
   def unlock(lock: Lock): F[Unit]
-  
+
 }
 
 class SyncFileHandle[F[_]](val chan: FileChannel)(implicit F: Sync[F]) extends FileHandle[F] {

--- a/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -118,7 +118,6 @@ private[file] trait FileHandleCompanionPlatform {
 
       override def write(bytes: Chunk[Byte], offset: Long): F[Int] =
         F.blocking(chan.write(bytes.toByteBuffer, offset))
-
     }
 
   /** Creates a `FileHandle[F]` from a `java.nio.channels.SeekableByteChannel`. Because a `SeekableByteChannel` doesn't provide all the functionalities required by `FileHandle` some features like locking will be unavailable. */

--- a/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -28,6 +28,8 @@ import java.nio.channels.{FileChannel, FileLock, SeekableByteChannel}
 import java.nio.file.{OpenOption, Path => JPath}
 
 import cats.effect.kernel.{Async, Resource, Sync}
+import java.nio.channels.WritableByteChannel
+import java.nio.channels.ReadableByteChannel
 
 private[file] trait FileHandlePlatform[F[_]] {
 
@@ -64,6 +66,10 @@ private[file] trait FileHandlePlatform[F[_]] {
     * @param lock the lock object which represents the locked file or region.
     */
   def unlock(lock: Lock): F[Unit]
+
+  def transferTo(position: Long, count: Long, target: WritableByteChannel): F[Long]
+
+  def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long]
 
 }
 
@@ -118,6 +124,13 @@ private[file] trait FileHandleCompanionPlatform {
 
       override def write(bytes: Chunk[Byte], offset: Long): F[Int] =
         F.blocking(chan.write(bytes.toByteBuffer, offset))
+
+      override def transferTo(position: Long, count: Long, target: WritableByteChannel): F[Long] =
+        F.blocking(chan.transferTo(position, count, target))
+
+      override def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long] =
+        F.blocking(chan.transferFrom(src, position, count))
+    
     }
 
   /** Creates a `FileHandle[F]` from a `java.nio.channels.SeekableByteChannel`. Because a `SeekableByteChannel` doesn't provide all the functionalities required by `FileHandle` some features like locking will be unavailable. */
@@ -173,5 +186,10 @@ private[file] trait FileHandleCompanionPlatform {
             chan.write(bytes.toByteBuffer)
           }
         }
+        override def transferTo(position: Long, count: Long, target: WritableByteChannel): F[Long] =
+        F.raiseError(unsupportedOperationException)
+
+        override def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long] =
+        F.raiseError(unsupportedOperationException)
     }
 }

--- a/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -28,7 +28,6 @@ import java.nio.channels.{FileChannel, FileLock, SeekableByteChannel}
 import java.nio.file.{OpenOption, Path => JPath}
 
 import cats.effect.kernel.{Async, Resource, Sync}
-import java.nio.channels.WritableByteChannel
 import java.nio.channels.ReadableByteChannel
 
 private[file] trait FileHandlePlatform[F[_]] {

--- a/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -67,7 +67,8 @@ private[file] trait FileHandlePlatform[F[_]] {
 
 }
 
-private[io] final class SyncFileHandle[F[_]](val chan: FileChannel)(implicit F: Sync[F]) extends FileHandle[F] {
+private[io] final class SyncFileHandle[F[_]](val chan: FileChannel)(implicit F: Sync[F])
+    extends FileHandle[F] {
   type Lock = FileLock
 
   override def force(metaData: Boolean): F[Unit] =

--- a/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -67,8 +67,6 @@ private[file] trait FileHandlePlatform[F[_]] {
     */
   def unlock(lock: Lock): F[Unit]
 
-  def transferTo(position: Long, count: Long, target: WritableByteChannel): F[Long]
-
   def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long]
 
 }
@@ -124,9 +122,6 @@ private[file] trait FileHandleCompanionPlatform {
 
       override def write(bytes: Chunk[Byte], offset: Long): F[Int] =
         F.blocking(chan.write(bytes.toByteBuffer, offset))
-
-      override def transferTo(position: Long, count: Long, target: WritableByteChannel): F[Long] =
-        F.blocking(chan.transferTo(position, count, target))
 
       override def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long] =
         F.blocking(chan.transferFrom(src, position, count))
@@ -185,8 +180,6 @@ private[file] trait FileHandleCompanionPlatform {
             chan.write(bytes.toByteBuffer)
           }
         }
-      override def transferTo(position: Long, count: Long, target: WritableByteChannel): F[Long] =
-        F.raiseError(unsupportedOperationException)
 
       override def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long] =
         F.raiseError(unsupportedOperationException)

--- a/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -130,7 +130,7 @@ private[file] trait FileHandleCompanionPlatform {
 
       override def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long] =
         F.blocking(chan.transferFrom(src, position, count))
-    
+
     }
 
   /** Creates a `FileHandle[F]` from a `java.nio.channels.SeekableByteChannel`. Because a `SeekableByteChannel` doesn't provide all the functionalities required by `FileHandle` some features like locking will be unavailable. */
@@ -186,10 +186,10 @@ private[file] trait FileHandleCompanionPlatform {
             chan.write(bytes.toByteBuffer)
           }
         }
-        override def transferTo(position: Long, count: Long, target: WritableByteChannel): F[Long] =
+      override def transferTo(position: Long, count: Long, target: WritableByteChannel): F[Long] =
         F.raiseError(unsupportedOperationException)
 
-        override def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long] =
+      override def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long] =
         F.raiseError(unsupportedOperationException)
     }
 }

--- a/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/FileHandlePlatform.scala
@@ -28,7 +28,6 @@ import java.nio.channels.{FileChannel, FileLock, SeekableByteChannel}
 import java.nio.file.{OpenOption, Path => JPath}
 
 import cats.effect.kernel.{Async, Resource, Sync}
-import java.nio.channels.ReadableByteChannel
 
 private[file] trait FileHandlePlatform[F[_]] {
 
@@ -65,8 +64,6 @@ private[file] trait FileHandlePlatform[F[_]] {
     * @param lock the lock object which represents the locked file or region.
     */
   def unlock(lock: Lock): F[Unit]
-
-  def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long]
 
 }
 
@@ -122,8 +119,6 @@ private[file] trait FileHandleCompanionPlatform {
       override def write(bytes: Chunk[Byte], offset: Long): F[Int] =
         F.blocking(chan.write(bytes.toByteBuffer, offset))
 
-      override def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long] =
-        F.blocking(chan.transferFrom(src, position, count))
     }
 
   /** Creates a `FileHandle[F]` from a `java.nio.channels.SeekableByteChannel`. Because a `SeekableByteChannel` doesn't provide all the functionalities required by `FileHandle` some features like locking will be unavailable. */
@@ -179,8 +174,5 @@ private[file] trait FileHandleCompanionPlatform {
             chan.write(bytes.toByteBuffer)
           }
         }
-
-      override def transferFrom(src: ReadableByteChannel, position: Long, count: Long): F[Long] =
-        F.raiseError(unsupportedOperationException)
     }
 }

--- a/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/net/SocketPlatform.scala
@@ -31,7 +31,6 @@ import cats.syntax.all._
 import java.net.InetSocketAddress
 import java.nio.channels.{AsynchronousSocketChannel, CompletionHandler}
 import java.nio.{Buffer, ByteBuffer}
-import fs2.io.file.FileHandle
 
 private[net] trait SocketCompanionPlatform {
   private[net] def forAsync[F[_]: Async](

--- a/io/jvm/src/main/scala/fs2/io/net/SelectingSocket.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SelectingSocket.scala
@@ -79,7 +79,7 @@ private final class SelectingSocket[F[_]: LiftIO] private (
     F.delay {
       ch.shutdownInput(); ()
     }
-  override def sendfile(
+  override def sendFile(
       file: FileHandle[F],
       offset: Long,
       count: Long,
@@ -103,7 +103,7 @@ private final class SelectingSocket[F[_]: LiftIO] private (
       Stream.eval(writeMutex.lock.surround(go(offset, count))).drain
 
     case _ =>
-      super.sendfile(file, offset, count, chunkSize)
+      super.sendFile(file, offset, count, chunkSize)
   }
 }
 

--- a/io/jvm/src/main/scala/fs2/io/net/SelectingSocket.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SelectingSocket.scala
@@ -91,8 +91,7 @@ private final class SelectingSocket[F[_]: LiftIO] private (
       def go(currOffset: Long, remaining: Long): F[Unit] =
         if (remaining <= 0) F.unit
         else {
-          val toTransfer = remaining.min(chunkSize.toLong)
-          F.blocking(fileChannel.transferTo(currOffset, toTransfer, ch)).flatMap { written =>
+          F.blocking(fileChannel.transferTo(currOffset, remaining, ch)).flatMap { written =>
             if (written > 0) {
               go(currOffset + written, remaining - written)
             } else {
@@ -119,8 +118,7 @@ private final class SelectingSocket[F[_]: LiftIO] private (
       def go(currOffset: Long, remaining: Long): F[Unit] =
         if (remaining <= 0) F.unit
         else {
-          val toTransfer = remaining.min(chunkSize.toLong)
-          F.blocking(fileChannel.transferFrom(ch, currOffset, toTransfer)).flatMap { readBytes =>
+          F.blocking(fileChannel.transferFrom(ch, currOffset, remaining)).flatMap { readBytes =>
             if (readBytes > 0) {
               go(currOffset + readBytes, remaining - readBytes)
             } else {

--- a/io/jvm/src/main/scala/fs2/io/net/SelectingSocket.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SelectingSocket.scala
@@ -100,7 +100,7 @@ private final class SelectingSocket[F[_]: LiftIO] private (
           }
         }
 
-      Stream.eval(writeMutex.lock.surround(go(offset, count))).drain
+      Stream.exec(writeMutex.lock.surround(go(offset, count)))
 
     case _ =>
       super.sendFile(file, offset, count, chunkSize)

--- a/io/jvm/src/main/scala/fs2/io/net/SelectingSocket.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SelectingSocket.scala
@@ -105,33 +105,6 @@ private final class SelectingSocket[F[_]: LiftIO] private (
     case _ =>
       super.sendfile(file, offset, count, chunkSize)
   }
-
-  override def recvfile(
-      file: FileHandle[F],
-      offset: Long,
-      count: Long,
-      chunkSize: Int
-  ): Stream[F, Nothing] = file match {
-    case syncFileHandle: SyncFileHandle[F] =>
-      val fileChannel = syncFileHandle.chan
-
-      def go(currOffset: Long, remaining: Long): F[Unit] =
-        if (remaining <= 0) F.unit
-        else {
-          F.blocking(fileChannel.transferFrom(ch, currOffset, remaining)).flatMap { readBytes =>
-            if (readBytes > 0) {
-              go(currOffset + readBytes, remaining - readBytes)
-            } else {
-              selector.select(ch, OP_READ).to *> go(currOffset, remaining)
-            }
-          }
-        }
-
-      Stream.eval(readMutex.lock.surround(go(offset, count))).drain
-
-    case _ =>
-      super.recvfile(file, offset, count, chunkSize)
-  }
 }
 
 private object SelectingSocket {

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -135,7 +135,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
           ch.shutdownInput(); ()
         }
       )
-    override def sendfile(
+    override def sendFile(
         file: FileHandle[F],
         offset: Long,
         count: Long,
@@ -158,7 +158,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
         Stream.eval(writeMutex.lock.surround(go(offset, count))).drain
 
       case _ =>
-        super.sendfile(file, offset, count, chunkSize)
+        super.sendFile(file, offset, count, chunkSize)
     }
   }
 }

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -138,7 +138,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
       F.blocking {
         ch.shutdownInput(); ()
       }
-    def sendfile(
+    override def sendfile(
         file: FileHandle[F],
         offset: Long,
         count: Long,
@@ -159,7 +159,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
 
       transferChunks(offset, count).drain
     }
-    def recvfile(
+    override def recvfile(
         file: FileHandle[F],
         offset: Long,
         count: Long,

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -179,7 +179,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
           else {
             val toTransfer = remaining.min(chunkSize.toLong)
             F.blocking(fileChannel.transferFrom(ch, currOffset, toTransfer)).flatMap { readBytes =>
-              if (readBytes > 0) F.unit
+              if (readBytes == 0) F.unit
               else {
                 go(currOffset + readBytes, remaining - readBytes)
               }

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -135,9 +135,9 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
           ch.shutdownInput(); ()
         }
       )
-      F.blocking {
-        ch.shutdownInput(); ()
-      }
+    F.blocking {
+      ch.shutdownInput(); ()
+    }
     override def sendfile(
         file: FileHandle[F],
         offset: Long,

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -155,7 +155,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
             }
           }
 
-        Stream.eval(writeMutex.lock.surround(go(offset, count))).drain
+        Stream.exec(writeMutex.lock.surround(go(offset, count)))
 
       case _ =>
         super.sendFile(file, offset, count, chunkSize)

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -135,9 +135,6 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
           ch.shutdownInput(); ()
         }
       )
-    F.blocking {
-      ch.shutdownInput(); ()
-    }
     override def sendfile(
         file: FileHandle[F],
         offset: Long,

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -34,7 +34,6 @@ import fs2.io.net.Socket
 import fs2.io.evalOnVirtualThreadIfAvailable
 import java.nio.ByteBuffer
 import java.nio.channels.SocketChannel
-import fs2.io.file.FileHandle
 
 private[unixsocket] trait UnixSocketsCompanionPlatform {
   def forIO: UnixSockets[IO] = forLiftIO

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -160,6 +160,5 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
       case _ =>
         super.sendfile(file, offset, count, chunkSize)
     }
-
   }
 }

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -150,8 +150,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
         def go(currOffset: Long, remaining: Long): F[Unit] =
           if (remaining <= 0) F.unit
           else {
-            val toTransfer = remaining.min(chunkSize.toLong)
-            F.blocking(fileChannel.transferTo(currOffset, toTransfer, ch)).flatMap { written =>
+            F.blocking(fileChannel.transferTo(currOffset, remaining, ch)).flatMap { written =>
               if (written == 0) F.unit
               else {
                 go(currOffset + written, remaining - written)
@@ -177,8 +176,7 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
         def go(currOffset: Long, remaining: Long): F[Unit] =
           if (remaining <= 0) F.unit
           else {
-            val toTransfer = remaining.min(chunkSize.toLong)
-            F.blocking(fileChannel.transferFrom(ch, currOffset, toTransfer)).flatMap { readBytes =>
+            F.blocking(fileChannel.transferFrom(ch, currOffset, remaining)).flatMap { readBytes =>
               if (readBytes == 0) F.unit
               else {
                 go(currOffset + readBytes, remaining - readBytes)

--- a/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/unixsocket/UnixSocketsPlatform.scala
@@ -34,6 +34,7 @@ import fs2.io.net.Socket
 import fs2.io.evalOnVirtualThreadIfAvailable
 import java.nio.ByteBuffer
 import java.nio.channels.SocketChannel
+import fs2.io.file.FileHandle
 
 private[unixsocket] trait UnixSocketsCompanionPlatform {
   def forIO: UnixSockets[IO] = forLiftIO
@@ -134,5 +135,44 @@ private[unixsocket] trait UnixSocketsCompanionPlatform {
           ch.shutdownInput(); ()
         }
       )
+      F.blocking {
+        ch.shutdownInput(); ()
+      }
+   def sendfile(file: FileHandle[F], offset: Long, count: Long, chunkSize: Int): Stream[F, Nothing] = {
+  def transferChunks(offset: Long, remaining: Long): Stream[F, Unit] =
+    if (remaining <= 0) Stream.empty
+    else {
+      val toTransfer = remaining.min(chunkSize.toLong)
+      Stream.eval(writeMutex.lock.surround {
+      file.transferTo(offset, toTransfer, ch)
+      }).flatMap { written =>
+        transferChunks(offset + written, remaining - written)
+      }
+    }
+
+  transferChunks(offset, count).drain
+}
+def recvfile(
+    file: FileHandle[F],
+    offset: Long,
+    count: Long,
+    chunkSize: Int
+): Stream[F, Nothing] = {
+
+  def go(offset: Long, remaining: Long): Stream[F, Nothing] =
+    if (remaining <= 0) Stream.empty
+    else {
+      val toTransfer = remaining.min(chunkSize.toLong)
+      Stream.eval(writeMutex.lock.surround {
+        file.transferFrom(ch, offset, toTransfer)
+      }).flatMap { readBytes =>
+        go(offset + readBytes, remaining - readBytes)
+      }
+    }
+
+  go(offset, count)
+}
+
+
   }
 }

--- a/io/shared/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/shared/src/main/scala/fs2/io/net/Socket.scala
@@ -80,7 +80,7 @@ trait Socket[F[_]] {
     * @param count the maximum number of bytes to transfer
     * @param chunkSize the size of each chunk to read
     */
-  def sendfile(
+  def sendFile(
       file: FileHandle[F],
       offset: Long,
       count: Long,

--- a/io/shared/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/shared/src/main/scala/fs2/io/net/Socket.scala
@@ -24,6 +24,7 @@ package io
 package net
 
 import com.comcast.ip4s.{IpAddress, SocketAddress}
+import fs2.io.file.FileHandle
 
 /** Provides the ability to read/write from a TCP socket in the effect `F`.
   */
@@ -69,6 +70,8 @@ trait Socket[F[_]] {
   /** Writes the supplied stream of bytes to this socket via `write` semantics.
     */
   def writes: Pipe[F, Byte, Nothing]
+
+  def sendfile(file: FileHandle[F], chunkSize: Long): F[Unit]
 }
 
 object Socket extends SocketCompanionPlatform

--- a/io/shared/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/shared/src/main/scala/fs2/io/net/Socket.scala
@@ -98,37 +98,6 @@ trait Socket[F[_]] {
 
     go(offset, count).through(writes)
   }
-
-  /** Reads from a socket and writes to a file.
-    * Streams the socket data of the specified size and writes them to the file.
-    * The stream terminates when the socket signals end of input or the specified count is reached.
-    *
-    * @param file the file handle to write to
-    * @param offset the starting position in the file
-    * @param count the maximum number of bytes to transfer
-    * @param chunkSize the size of each chunk to read
-    */
-  def recvfile(
-      file: FileHandle[F],
-      offset: Long,
-      count: Long,
-      chunkSize: Int
-  ): Stream[F, Nothing] = {
-
-    def go(currOffset: Long, remaining: Long): Stream[F, Nothing] =
-      if (remaining > 0)
-        Stream.eval(read(math.min(remaining, chunkSize.toLong).toInt)).flatMap {
-          case Some(chunk) if chunk.nonEmpty =>
-            Stream.eval(file.write(chunk, currOffset)) >> go(
-              currOffset + chunk.size,
-              remaining - chunk.size
-            )
-          case _ => Stream.empty
-        }
-      else Stream.empty
-
-    go(offset, count)
-  }
 }
 
 object Socket extends SocketCompanionPlatform

--- a/io/shared/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/shared/src/main/scala/fs2/io/net/Socket.scala
@@ -71,8 +71,8 @@ trait Socket[F[_]] {
     */
   def writes: Pipe[F, Byte, Nothing]
 
-  /** Reads a file in chunks and writes it to a socket.
-    * Streams the file contents in chunks of the specified size and sends them over the socket.
+  /** Reads a file and writes it to a socket.
+    * Streams the file contents of the specified size and sends them over the socket.
     * The stream terminates when the entire file has reached end of file or the specified count is reached.
     *
     * @param file the file handle to read from
@@ -100,7 +100,7 @@ trait Socket[F[_]] {
   }
 
   /** Reads from a socket and writes to a file.
-    * Streams the socket data in chunks of the specified size and writes them to the file.
+    * Streams the socket data of the specified size and writes them to the file.
     * The stream terminates when the socket signals end of input or the specified count is reached.
     *
     * @param file the file handle to write to

--- a/io/shared/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/shared/src/main/scala/fs2/io/net/Socket.scala
@@ -85,7 +85,7 @@ trait Socket[F[_]] {
       offset: Long,
       count: Long,
       chunkSize: Int
-  ): Stream[F, Unit] = {
+  ): Stream[F, Nothing] = {
 
     def go(currOffset: Long, remaining: Long): Stream[F, Byte] =
       if (remaining > 0)
@@ -113,9 +113,9 @@ trait Socket[F[_]] {
       offset: Long,
       count: Long,
       chunkSize: Int
-  ): Stream[F, Unit] = {
+  ): Stream[F, Nothing] = {
 
-    def go(currOffset: Long, remaining: Long): Stream[F, Unit] =
+    def go(currOffset: Long, remaining: Long): Stream[F, Nothing] =
       if (remaining > 0)
         Stream.eval(read(math.min(remaining, chunkSize.toLong).toInt)).flatMap {
           case Some(chunk) if chunk.nonEmpty =>

--- a/io/shared/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/shared/src/main/scala/fs2/io/net/Socket.scala
@@ -25,7 +25,6 @@ package net
 
 import com.comcast.ip4s.{IpAddress, SocketAddress}
 import fs2.io.file.FileHandle
-import cats.effect.Concurrent
 
 /** Provides the ability to read/write from a TCP socket in the effect `F`.
   */

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -325,6 +325,5 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
           assertEquals(received, expected)
         }
     }
-
   }
 }

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -285,7 +285,7 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
         }
       }
     }
-    test("sendfile - sends data from file to socket from the offset") {
+    test("sendFile - sends data from file to socket from the offset") {
       val content = "Hello, world!"
       val offset = 7L
       val count = 5L
@@ -314,7 +314,7 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
           }
           val clientStream =
             Stream.resource(Files[IO].open(tempFile, Flags.Read)).flatMap { fileHandle =>
-              client.sendfile(fileHandle, offset, count, chunkSize).drain ++
+              client.sendFile(fileHandle, offset, count, chunkSize).drain ++
                 Stream.eval(client.endOfOutput)
             }
           serverStream.concurrently(clientStream)

--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -29,6 +29,7 @@ import com.comcast.ip4s._
 
 import scala.concurrent.duration._
 import scala.concurrent.TimeoutException
+import fs2.io.file._
 
 class SocketSuite extends Fs2Suite with SocketSuitePlatform {
 
@@ -284,5 +285,87 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
         }
       }
     }
+    test("sendfile - sends data from file to socket from the offset") {
+      val content = "Hello, world!"
+      val offset = 7L
+      val count = 5L
+      val expected = "world"
+      val chunkSize = 2
+
+      val setup = for {
+        tempFile <- Files[IO].tempFile
+        _ <- Stream
+          .emits(content.getBytes)
+          .covary[IO]
+          .through(Files[IO].writeAll(tempFile))
+          .compile
+          .drain
+          .toResource
+        serverSetup <- Network[IO].serverResource(Some(ip"127.0.0.1"))
+        (bindAddress, server) = serverSetup
+        client <- Network[IO].client(bindAddress)
+      } yield (tempFile, server, client)
+
+      Stream
+        .resource(setup)
+        .flatMap { case (tempFile, server, client) =>
+          val serverStream = server.head.flatMap { socket =>
+            Stream.eval(socket.reads.through(text.utf8.decode).compile.string)
+          }
+          val clientStream =
+            Stream.resource(Files[IO].open(tempFile, Flags.Read)).flatMap { fileHandle =>
+              client.sendfile(fileHandle, offset, count, chunkSize).drain ++
+                Stream.eval(client.endOfOutput)
+            }
+          serverStream.concurrently(clientStream)
+        }
+        .compile
+        .lastOrError
+        .map { received =>
+          assertEquals(received, expected)
+        }
+    }
+    test("recvfile - send data from socket to file from the offset") {
+      val content = "Hello, world!"
+      val offset = 0L
+      val count = 5L
+      val expected = "Hello"
+      val chunkSize = 2
+
+      val setup = for {
+        tempFile <- Files[IO].tempFile
+        serverSetup <- Network[IO].serverResource(Some(ip"127.0.0.1"))
+        (bindAddress, server) = serverSetup
+        client <- Network[IO].client(bindAddress)
+      } yield (tempFile, server, client)
+
+      Stream
+        .resource(setup)
+        .flatMap { case (tempFile, server, client) =>
+          val serverStream = server.head.flatMap { socket =>
+            Stream.eval(socket.write(Chunk.array(content.getBytes))) >>
+              Stream.eval(socket.endOfOutput)
+          }
+
+          val clientStream =
+            Stream.resource(Files[IO].open(tempFile, Flags.Write)).flatMap { fileHandle =>
+              client.recvfile(fileHandle, offset, count, chunkSize).drain
+            }
+
+          val checkFile = Files[IO]
+            .readAll(tempFile, chunkSize, Flags.Read)
+            .through(text.utf8.decode)
+            .compile
+            .string
+
+          clientStream.concurrently(serverStream).drain ++ Stream.eval(checkFile)
+        }
+        .compile
+        .lastOrError
+        .map { received =>
+          assertEquals(received, expected)
+        }
+    }
+
   }
 }


### PR DESCRIPTION
Added efficient transfer of a file to the network for jvm platform using `transferTo` and `transferFrom` methods of filechannel.
part of #3171 