### PR TITLE
fix(io): handle relative paths in Watcher by converting to absolute p…

### DIFF
--- a/io/jvm-native/src/main/scala/fs2/io/DeprecatedWatcher.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/DeprecatedWatcher.scala
@@ -263,17 +263,19 @@ object Watcher {
         types: Seq[Watcher.EventType],
         modifiers: Seq[WatchEvent.Modifier]
     ): F[F[Unit]] =
-      registerUntracked(path.getParent, types, modifiers).flatMap(key =>
-        track(
-          Registration(
-            path,
-            true,
-            key,
-            types,
-            modifiers,
-            false,
-            false,
-            F.unit
+      F.blocking(path.toAbsolutePath).flatMap(absolutePath =>
+        registerUntracked(absolutePath.getParent, types, modifiers).flatMap(key =>
+          track(
+            Registration(
+              absolutePath,
+              true,
+              key,
+              types,
+              modifiers,
+              false,
+              false,
+              F.unit
+            )
           )
         )
       )


### PR DESCRIPTION
# Fix: Handle Relative Paths in Watcher by Converting to Absolute Paths

## Which issue does this PR close?

- Closes #3472

## Rationale for this change

This update fixes a NullPointerException (NPE) that occurs when watching files with relative paths by converting them to absolute paths before registration. This ensures that the file watcher can handle relative paths correctly.

## What changes are included in this PR?

- **fix(io):** Handle relative paths in Watcher by converting to absolute paths
  - Fixes NPE when watching files with relative paths by converting them to absolute paths before registration.

## Are these changes tested?

Yes, the changes are tested to ensure that the Watcher can handle relative paths without causing a NullPointerException.

## Are there any user-facing changes?

No, there are no user-facing changes as this update is related to internal path handling improvements.

## Are there any breaking changes to public APIs?

No, there are no breaking changes to public APIs.

## Additional Information

Thanks for opening a PR!

If the CI build fails due to Scalafmt, run `sbt scalafmtAll` and push the changes (generally a good idea to run this prior to opening the PR).

It's also helpful to run `sbt prePR`, which runs tests, generates docs, and performs various checks.

Feel free to ask questions on the fs2 and fs2-dev channels on the [Typelevel Discord server](https://discord.gg/9V8FZTVZ9R).