### PR TITLE
clarify chunkN doc about allowFewer

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -446,7 +446,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   /** Outputs chunks of size `n`.
     *
     * Chunks from the source stream are split as necessary.
-    * If `allowFewer` is true, the last chunk that is emitted, upon completion of the stream, may have less than `n` elements.
+    * If `allowFewer` is true, the last chunk that is emitted, upon completion of the stream, may have fewer than `n` elements.
     *
     * Note: the emitted chunk may be a composite chunk (i.e., an instance of `Chunk.Queue`) and
     * hence may not have O(1) lookup by index. Consider calling `.map(_.compact)` if indexed

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -446,7 +446,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   /** Outputs chunks of size `n`.
     *
     * Chunks from the source stream are split as necessary.
-    * If `allowFewer` is true, the last chunk that is emitted may have less than `n` elements.
+    * If `allowFewer` is true, the last chunk that is emitted, upon completion of the stream, may have less than `n` elements.
     *
     * Note: the emitted chunk may be a composite chunk (i.e., an instance of `Chunk.Queue`) and
     * hence may not have O(1) lookup by index. Consider calling `.map(_.compact)` if indexed


### PR DESCRIPTION
Just clarifying in the docs that using `chunkN` with `allowFewer=true` will only emit the smaller chunk when it is the last chunk in the stream *and* the stream is completed (`chunkN` builds on `unconsMin` which only returns a partial chunk once it hits the end of the stream)