### PR TITLE
Fix minor guide explanation

### DIFF
--- a/site/guide.md
+++ b/site/guide.md
@@ -284,7 +284,7 @@ Otherwise, we return a function which processes the next chunk in the stream. Th
 
 Sometimes, `scanChunksOpt` isn't powerful enough to express the stream transformation. Regardless of how complex the job, the `fs2.Pull` type can usually express it.
 
-The `Pull[F[_],O,R]` type represents a program that may pull values from one or more streams, write _output_ of type `O`, and return a _result_ of type `R`. It forms a monad in `R` and comes equipped with lots of other useful operations. See the
+The `Pull[F[_],O,R]` type represents a program that may pull values from one or more streams, write _output_ of type `O`, and return a _result_ of type `R`. It forms a monad in `F` and comes equipped with lots of other useful operations. See the
 [`Pull` class](https://github.com/functional-streams-for-scala/fs2/blob/main/core/shared/src/main/scala/fs2/Pull.scala)
 for the full set of operations on `Pull`.
 


### PR DESCRIPTION
This should be `F`, right?
