### PR TITLE
Added `DatagramSocket` for Native with Polling

### DIFF
--- a/io/native/src/main/scala/fs2/io/internal/ipmulticast.scala
+++ b/io/native/src/main/scala/fs2/io/internal/ipmulticast.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.io.internal
+
+import scala.scalanative.unsafe._
+import netinetin.in_addr
+import netinetin.in6_addr
+
+@extern
+private[io] object Ipmulticast {
+
+  def IP_ADD_MEMBERSHIP: CInt = extern
+  def IP_DROP_MEMBERSHIP: CInt = extern
+
+  def IP_ADD_SOURCE_MEMBERSHIP: CInt = extern
+  def IP_DROP_SOURCE_MEMBERSHIP: CInt = extern
+  def IP_BLOCK_SOURCE: CInt = extern
+  def IP_UNBLOCK_SOURCE: CInt = extern
+
+  def IPV6_ADD_MEMBERSHIP: CInt = extern
+  def IPV6_DROP_MEMBERSHIP: CInt = extern
+
+  def IP_MULTICAST_TTL: CInt = extern
+
+  type ip_mreq = CStruct2[
+    in_addr,
+    in_addr
+  ]
+
+  type ip_mreq_source = CStruct3[
+    in_addr,
+    in_addr,
+    in_addr
+  ]
+
+  type ipv6_mreq = CStruct2[
+    in6_addr,
+    CInt
+  ]
+}
+
+private[io] object IpmulticastOps {
+  import Ipmulticast._
+
+  implicit final class ip_mreqOps(val ip_mreq: Ptr[ip_mreq]) extends AnyVal {
+    def imr_multiaddr: in_addr = ip_mreq._1
+    def imr_multiaddr_=(imr_multiaddr: in_addr): Unit = ip_mreq._1 = imr_multiaddr
+    def imr_address: in_addr = ip_mreq._2
+    def imr_address_=(imr_address: in_addr): Unit = ip_mreq._2 = imr_address
+  }
+
+  implicit final class ip_mreq_sourceOps(val mreq: Ptr[ip_mreq_source]) extends AnyVal {
+    def imr_multiaddr: in_addr = mreq._1
+    def imr_multiaddr_=(imr_multiaddr: in_addr): Unit = mreq._1 = imr_multiaddr
+
+    def imr_interface: in_addr = mreq._2
+    def imr_interface_=(imr_interface: in_addr): Unit = mreq._2 = imr_interface
+
+    def imr_sourceaddr: in_addr = mreq._3
+    def imr_sourceaddr_=(imr_sourceaddr: in_addr): Unit = mreq._3 = imr_sourceaddr
+  }
+
+  implicit final class ipv6_mreqOps(val mreq: Ptr[ipv6_mreq]) extends AnyVal {
+    def ipv6mr_multiaddr: in6_addr = mreq._1
+    def ipv6mr_multiaddr_=(ipv6mr_multiaddr: in6_addr): Unit = mreq._1 = ipv6mr_multiaddr
+
+    def ipv6mr_ifindex: CInt = mreq._2
+    def ipv6mr_ifindex_=(ipv6mr_ifindex: CInt): Unit = mreq._2 = ipv6mr_ifindex
+  }
+
+}

--- a/io/native/src/main/scala/fs2/io/net/FdPollingDatagramSocket.scala
+++ b/io/native/src/main/scala/fs2/io/net/FdPollingDatagramSocket.scala
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package io
+package net
+
+import cats.effect.{Async, FileDescriptorPollHandle, IO, LiftIO, Resource}
+import fs2.io.internal.ResizableBuffer
+import com.comcast.ip4s.GenSocketAddress
+import fs2.io.internal.SocketHelpers
+import com.comcast.ip4s._
+
+import scala.scalanative.unsafe._
+import scala.scalanative.posix.sys.socket._
+import scala.scalanative.unsigned._
+import fs2.io.internal.NativeUtil._
+
+import scala.scalanative.libc.errno._
+import fs2.io.internal.syssocket.{connect => sconnect}
+import fs2.io.net.FdPollingDatagramSocket._
+import java.net.{NetworkInterface => JNetworkInterface}
+import cats.syntax.all._
+
+private final class FdPollingDatagramSocket[F[_]: LiftIO] private (
+    val fd: Int,
+    handle: FileDescriptorPollHandle,
+    readBuffer: ResizableBuffer[F],
+    val address: GenSocketAddress
+)(implicit F: Async[F])
+    extends DatagramSocket[F] {
+
+  def localAddress: F[SocketAddress[IpAddress]] =
+    F.pure(address.asIpUnsafe)
+
+  def supportedOptions: F[Set[SocketOption.Key[?]]] = SocketHelpers.DatagramSupportedOptions
+
+  def getOption[A](key: SocketOption.Key[A]) =
+    SocketHelpers.getOption[F, A](fd, key)
+
+  def setOption[A](key: SocketOption.Key[A], value: A) =
+    SocketHelpers.setOption(fd, key, value)
+
+  def readGen: F[GenDatagram] = read.map(_.toGenDatagram)
+  def connect(address: GenSocketAddress) =
+    F.delay {
+      SocketHelpers.toSockaddr(address.asIpUnsafe) { (addr, len) =>
+        val res = sconnect(fd, addr, len)
+        if (res < 0) {
+          val e = errno
+          throw errnoToThrowable(e)
+        }
+      }
+    }
+
+  def disconnect: F[Unit] = F.delay {
+    SocketHelpers.disconnectSockaddr { (addr, len) =>
+      val res = sconnect(fd, addr, len)
+      if (res < 0) {
+        val e = errno
+        throw errnoToThrowable(e)
+      }
+    }
+  }
+
+  override def read: F[Datagram] = readBuffer.get(DefaultReadSize).use { buf =>
+    handle
+      .pollReadRec(()) { _ =>
+        IO {
+          val addrBuf = stackalloc[sockaddr_storage]()
+          val addrLen = stackalloc[socklen_t]()
+          !addrLen = sizeof[sockaddr_storage].toUInt
+
+          val nBytes = recvfrom(
+            fd,
+            buf,
+            DefaultReadSize.toULong,
+            MSG_DONTWAIT,
+            addrBuf.asInstanceOf[Ptr[sockaddr]],
+            addrLen
+          )
+          if (nBytes < 0) Left(())
+          else {
+            val remote =
+              SocketHelpers.toSocketAddress(addrBuf.asInstanceOf[Ptr[sockaddr]], addrBuf._1.toInt)
+            val bytes = Chunk.fromBytePtr(buf, nBytes.toInt)
+            Right(Datagram(remote.asIpUnsafe, bytes))
+          }
+        }
+      }
+      .to
+  }
+
+  def reads: Stream[F, Datagram] = Stream.repeatEval(read)
+
+  def write(bytes: Chunk[Byte]): F[Unit] = {
+    val Chunk.ArraySlice(buf, offset, length) = bytes.toArraySlice
+
+    def go(pos: Int): IO[Either[Int, Unit]] =
+      IO {
+        val sent = send(
+          fd,
+          buf.atUnsafe(offset + pos),
+          (length - pos).toULong,
+          0
+        )
+        if (sent < 0) Left(pos)
+        else Right(sent)
+      }.flatMap {
+        case Right(sent) =>
+          val newPos = pos + sent
+          if (newPos < length) go(newPos.toInt)
+          else IO.pure(Right(()))
+        case Left(pos) =>
+          IO.pure(Left(pos))
+      }
+
+    handle.pollWriteRec(0)(go(_)).to
+  }
+
+  def write(bytes: Chunk[Byte], address: GenSocketAddress): F[Unit] = {
+    val Chunk.ArraySlice(buf, offset, length) = bytes.toArraySlice
+
+    def go(pos: Int): IO[Either[Int, Unit]] =
+      IO {
+        SocketHelpers.toSockaddr(address.asIpUnsafe) { (addr, len) =>
+          val sent = sendto(
+            fd,
+            buf.atUnsafe(offset + pos),
+            (length - pos).toULong,
+            0,
+            addr,
+            len
+          )
+          if (sent < 0) Left(pos)
+          else Right(sent)
+        }
+      }.flatMap {
+        case Right(sent) =>
+          val newPos = pos + sent
+          if (newPos < length) go(newPos.toInt)
+          else IO.pure(Right(()))
+        case Left(pos) =>
+          IO.pure(Left(pos))
+      }
+
+    handle.pollWriteRec(0)(go(_)).to
+  }
+
+  def writes: Pipe[F, Datagram, Nothing] =
+    _.foreach(write)
+  
+  def join(
+      join: MulticastJoin[IpAddress],
+      interface: NetworkInterface
+  ): F[GroupMembership] =
+    F.delay {
+      val groupAddress = join.fold(
+        j => {
+          SocketHelpers.join(fd, j.group.address, interface)
+          j.group.address
+        },
+        j => {
+          SocketHelpers.join(fd, j.group.address, interface, j.source)
+          j.group.address
+        }
+      )
+      new GroupMembership {
+        def drop = join.fold(
+          j => SocketHelpers.drop(fd, j.group.address, interface),
+          j => SocketHelpers.drop(fd, j.group.address, interface, j.source)
+        )
+        def block(source: IpAddress) = SocketHelpers.block(fd, groupAddress, interface, source)
+
+        def unblock(source: IpAddress) = SocketHelpers.unblock(fd, groupAddress, interface, source)
+      }
+    }
+
+  def join(j: MulticastJoin[IpAddress], interface: JNetworkInterface): F[GroupMembership] =
+    join(j, NetworkInterface.fromJava(interface))
+}
+
+private object FdPollingDatagramSocket {
+  private final val DefaultReadSize = 65507
+  private final val MSG_DONTWAIT = 0x40
+
+  def apply[F[_]: LiftIO](
+      fd: Int,
+      handle: FileDescriptorPollHandle,
+      address: GenSocketAddress
+  )(implicit F: Async[F]): Resource[F, DatagramSocket[F]] = for {
+    buffer <- ResizableBuffer(DefaultReadSize)
+  } yield new FdPollingDatagramSocket(fd, handle, buffer, address)
+}

--- a/io/native/src/main/scala/fs2/io/net/FdPollingIpDatagramSocketsProvider.scala
+++ b/io/native/src/main/scala/fs2/io/net/FdPollingIpDatagramSocketsProvider.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2013 Functional Streams for Scala
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package io
+package net
+
+import com.comcast.ip4s._
+import cats.effect.LiftIO
+import cats.effect.kernel.Async
+import cats.effect.kernel.Resource
+import cats.syntax.all._
+import fs2.io.internal.SocketHelpers
+import fs2.io.internal.syssocket.{bind => sbind}
+
+import scala.scalanative.posix.sys.socket.{bind => _, connect => _, accept => _, _}
+import fs2.io.internal.NativeUtil.guard_
+
+private final class FdPollingIpDatagramSocketsProvider[F[_]: Dns: LiftIO](implicit F: Async[F])
+    extends IpDatagramSocketsProvider[F] {
+
+  override def bindDatagramSocket(
+      address: SocketAddress[Host],
+      options: List[SocketOption]
+  ): Resource[F, DatagramSocket[F]] = for {
+    poller <- Resource.eval(fileDescriptorPoller[F])
+    resolvedHost <- Resource.eval(address.host.resolve)
+    ipv4 = resolvedHost.isInstanceOf[Ipv4Address]
+    fd <- SocketHelpers.openNonBlocking(if (ipv4) AF_INET else AF_INET6, SOCK_DGRAM)
+    _ <- Resource.eval(options.traverse(so => SocketHelpers.setOption(fd, so.key, so.value)))
+    handle <- poller.registerFileDescriptor(fd, true, true).mapK(LiftIO.liftK)
+    _ <- Resource.eval {
+       F.delay {
+        val resolvedAddress = SocketAddress(resolvedHost, address.port)
+        SocketHelpers.toSockaddr(resolvedAddress) { (addr, len) =>
+          guard_(sbind(fd, addr, len))
+        }
+      }
+
+    }
+    datagram <- FdPollingDatagramSocket(
+      fd,
+      handle,
+      SocketHelpers.getAddress(fd, if (ipv4) AF_INET else AF_INET6)
+    )
+  } yield datagram
+}

--- a/io/native/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/native/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -37,9 +37,7 @@ private[net] trait NetworkCompanionPlatform extends NetworkLowPriority { self: N
         new FdPollingIpSocketsProvider[F]()(Dns.forAsync, implicitly, implicitly)
       protected def mkUnixSocketsProvider = new FdPollingUnixSocketsProvider[F]
       protected def mkIpDatagramSocketsProvider =
-        throw new UnsupportedOperationException(
-          "Datagram sockets not currently supported on Native"
-        )
+        new FdPollingIpDatagramSocketsProvider[F]()(Dns.forAsync, implicitly, implicitly)
       protected def mkUnixDatagramSocketsProvider =
         throw new UnsupportedOperationException(
           "Unix datagram sockets not currently supported on Native"


### PR DESCRIPTION
### Add Datagram Socket Support with Polling

This PR adds support for datagram sockets with polling for native. The key changes include:

- **`FdPollingDatagramSocket.scala`**: Defines an interface for datagram sockets.
- **`FdPollingIpDatagramSocketsProvider.scala`**: Creates and binds IP-based datagram sockets.
- **`IpMulticast.scala`**: Provides types for low-level multicast support (`ip_mreq`, `ip_mreq_source`, etc.).
- **`SocketHelpers.scala`**:
  - Adds `join`, `drop`,`block` and `unblock` helpers for multicast`.
  - Adds new `SocketOptions` for datagramSockets.
  - Adds `setIpOption` and `getIpOption`
