### PR TITLE
Fix for https://github.com/typelevel/fs2/issues/3590

### DIFF
--- a/io/jvm/src/main/scala/fs2/io/net/SelectingSocketGroup.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SelectingSocketGroup.scala
@@ -22,7 +22,7 @@
 package fs2
 package io.net
 
-import scala.concurrent.duration.*
+import scala.concurrent.duration._
 
 import cats.effect.LiftIO
 import cats.effect.Selector

--- a/io/jvm/src/main/scala/fs2/io/net/SelectingSocketGroup.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SelectingSocketGroup.scala
@@ -22,6 +22,8 @@
 package fs2
 package io.net
 
+import scala.concurrent.duration.*
+
 import cats.effect.LiftIO
 import cats.effect.Selector
 import cats.effect.kernel.Async
@@ -100,7 +102,9 @@ private final class SelectingSocketGroup[F[_]: LiftIO: Dns](selector: Selector)(
   ): Resource[F, (SocketAddress[IpAddress], Stream[F, Socket[F]])] =
     Resource
       .make(F.delay(selector.provider.openServerSocketChannel())) { ch =>
-        F.delay(ch.close())
+        def waitForDeregistration: F[Unit] =
+          F.delay(ch.isRegistered()).ifM(F.sleep(2.millis) >> waitForDeregistration, F.unit)
+        F.delay(ch.close()) >> waitForDeregistration
       }
       .evalMap { serverCh =>
         val configure = address.traverse(_.resolve).flatMap { ip =>

--- a/io/jvm/src/main/scala/fs2/io/net/SelectingSocketGroup.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/SelectingSocketGroup.scala
@@ -103,6 +103,8 @@ private final class SelectingSocketGroup[F[_]: LiftIO: Dns](selector: Selector)(
     Resource
       .make(F.delay(selector.provider.openServerSocketChannel())) { ch =>
         def waitForDeregistration: F[Unit] =
+          // sleep time set to be short enough to not noticeably delay shutdown but long enough to
+          // give the runtime/cpu time to do something else; some guesswork involved here
           F.delay(ch.isRegistered()).ifM(F.sleep(2.millis) >> waitForDeregistration, F.unit)
         F.delay(ch.close()) >> waitForDeregistration
       }


### PR DESCRIPTION
This is a potential fix for https://github.com/typelevel/fs2/issues/3590 which has been plaguing us for some time.

The key insight here is from https://github.com/typelevel/fs2/issues/3590#issuecomment-3215038469 and the JavaDoc for `SelectableChannel.isRegistered` which says:

> Due to the inherent delay between key cancellation and channel deregistration, a channel may remain registered for some time after all of its keys have been cancelled.  A channel may also remain registered for some time after it is closed.

This implies that even after the channel is closed, the port may still be bound in the OS, and subsequent attempts to bind that port may fail.

I couldn't find evidence of a way to be notified when a channel is no longer registered beyond simply polling, but since this is likely to happen at the end of a server's life (with the exception of any case where an application repeatedly opens servers on the same port), a short interval of polling (using the IO runtime's non-blocking sleep) is acceptable.