### PR TITLE
Add more resources to the documentation

### DIFF
--- a/site/_sidebar.md
+++ b/site/_sidebar.md
@@ -9,6 +9,6 @@
 - [Scodec](scodec.md)
 - [API Reference](api-reference.md)
 - [FAQ](faq.md)
-- [Documentation](documentation.md)
+- [More Resources](documentation.md)
 - [Adopters](adopters.md)
 - [Ecosystem](ecosystem.md)

--- a/site/documentation.md
+++ b/site/documentation.md
@@ -1,7 +1,10 @@
-# Documentation
+# More resources
 
-#### Talks and Presentations
+The [aquascape project](https://zainab-ali.github.io/aquascape/reference/) contains a reference guide of FS2 operators.
 
+### Talks and Presentations
+
+* [How slow is your tram?](https://www.youtube.com/watch?v=E-gnY0weqsk), a talk by [Michał Pawlik][majik-p] from [Scalar](https://www.scalar-conf.com/) in Warsaw, 2024.
 * [A sky full of streams](https://www.youtube.com/watch?v=oluPEFlXumw), a talk by [Jakub Kozłowski][kubukoz] at [Scala World](https://scala.world), a conference in the Lake District in the UK, in September 2019. Slides are available [on Speakerdeck](https://speakerdeck.com/kubukoz/a-sky-full-of-streams).
 * [FS2 - Crash course](https://www.youtube.com/watch?v=tbShO8eIXbI), a talk by [Łukasz Byczyński][lukasz-byczynski] from [Scalar](https://scalar-conf.com) in Warsaw, in April 2019. [Examples are available on the author's GitHub](https://github.com/lukaszbyczynski/scalar-fs2-cc).
 * [Declarative Control Flow with fs2 Stream](https://www.youtube.com/watch?v=YSN__0VEsaw), a talk by [Fabio Labella][systemfw] at the [Typelevel Summit](https://typelevel.org/event/2018-03-summit-boston/), celebrated in Boston in March 2018. Slides available at the author's [Github](https://github.com/SystemFw/TL-Summit-Boston-2018).
@@ -11,8 +14,9 @@
 * [Compositional Streaming with FS2](https://www.youtube.com/watch?v=oFk8-a1FSP0), a talk by [Michael Pilquist][mpilquist] at [Scale by the Bay](http://scala.bythebay.io/), November 2016. [Slides](https://speakerdeck.com/mpilquist/compositional-streaming-with-fs2).
 
 
-#### Tutorials
+### Tutorials
 
+* [Functional Stream Processing Workshop Repository](https://github.com/zainab-ali/functional-stream-processing-workshop/tree/main) contains the exercises for the corresponding [Functional Stream Processing in Scala book](https://pureasync.gumroad.com/l/functional-stream-processing-in-scala) by [Zainab Ali][zainab-ali]. Variants of the workshop were given at Scalar 2024, Lambda World 2024 and Scala Days 2025. 
 * [Basic streams and combinators in fs2](https://www.youtube.com/watch?v=TmhIabcu6Fs), a tutorial by [Jakub Kozłowski][kubukoz] introducing basic Stream operations and constructors.
 * [Sharding a stream of values using Fs2](https://www.youtube.com/watch?v=FWYXqYQWAc0), a tutorial by [Gabriel Volpe][gvolpe] showcasing a specific use-case of fs2 streams.
 * [An introduction to FS2 Streams](https://www.youtube.com/watch?v=B1wb4fIdtn4), a REPL-demo tutorial given by [Michael Pilquist][mpilquist] for the [Scala Toronto](https://www.meetup.com/scalator/events/254059603/) Meetup group, on September 2018.
@@ -22,7 +26,7 @@
   * [Part 3: Concurrency](https://www.youtube.com/watch?v=8YxcB6PIUDg).
 
 
-#### Blog Posts and Short Articles
+### Blog Posts and Short Articles
 * [Leverage FS2 API to write to a file](https://davidfrancoeur.com/post/file-writing-fs2/) by [David Francoeur][francoeurdavid] describes writing data to files using the FS2 API.
 * [Build a Stream to fetch everything behind an offset paged API](https://davidfrancoeur.com/post/paged-api-fs2/) by [David Francoeur][francoeurdavid] describes how to gather all issues for a Gitlab project.
 * [Scala FS2 — handle broken CSV lines](https://medium.com/se-notes-by-alexey-novakov/scala-fs2-handle-broken-csv-lines-8d8c4defcd88) by [Alexey Novakov][alexey_novakov] describes processing fragmented text data using FS2.
@@ -30,20 +34,21 @@
 * [Inference Driven Design](https://mpilquist.github.io/blog/2018/07/04/fs2/), by [Michael Pilquist][mpilquist], describes some of the tradeoffs in designing the API and the code of FS2, used to work around some of the problems in the Scala compiler.
 * [Tips for working with FS2](https://underscore.io/blog/posts/2018/03/20/fs2.html), by [Pere Villega](https://github.com/pvillega),
 * [A streaming library with a superpower: FS2 and functional programming](https://medium.freecodecamp.org/a-streaming-library-with-a-superpower-fs2-and-functional-programming-6f602079f70a).
-* [No leftovers: Working with pulls in fs2](https://blog.kebab-ca.se/chapters/fs2/overview.html), by [Zainab Ali](https://github.com/zainab-ali).
+* [No leftovers: Working with pulls in fs2](https://blog.kebab-ca.se/chapters/fs2/overview.html), by [Zainab Ali][zainab-ali].
 
-#### Books
+### Books
 
+* [Functional Stream Processing in Scala with cats-effect and FS2](https://pureasync.gumroad.com/l/functional-stream-processing-in-scala) by [Zainab Ali][zainab-ali] is a comprehensive guide to stream processing with FS2.
 * [Practical FP in Scala: A hands-on approach](https://leanpub.com/pfp-scala) by [Gabriel Volpe][gvolpe] contains a section on effectful, concurrent streaming with FS2.
 
-#### Related Academic Research
+### Related Academic Research
 
 * [Stream Fusion, to Completeness](https://arxiv.org/abs/1612.06668), by Oleg Kyseliov et al. In _Principles of Programming Languages (POPL)_, January 2017. [DBLP](https://dblp.uni-trier.de/rec/bibtex/conf/popl/KiselyovBPS17).
 
 * [Iteratees](http://okmij.org/ftp/Haskell/Iteratee/describe.pdf), by Oleg Kyseliov, in _International Symposium of Functional and Logic Programming (FLOPS)_. [DBLP](https://dblp.uni-trier.de/rec/bibtex/conf/flops/Kiselyov12). [Author's webpage](http://okmij.org/ftp/Haskell/Iteratee/).
 
 
-#### Related Scala Libraries
+### Related Scala Libraries
 
 * FS2 was originally called [Scalaz-Stream](https://github.com/scalaz/scalaz-stream).
 * [Monix](https://monix.io/) defines a special type for lazy, pull-based streaming, called `monix.tail.Iterant`.
@@ -51,7 +56,7 @@
 * There are various other iteratee-style libraries for doing compositional, streaming I/O in Scala, notably the [`scalaz/iteratee`](https://github.com/scalaz/scalaz/tree/scalaz-seven/iteratee) package and [iteratees in Play](https://www.playframework.com/documentation/2.0/Iteratees).
 * [Akka-Streams](https://doc.akka.io/docs/akka/2.5/stream/index.html)
 
-#### Related Haskell Libraries
+### Related Haskell Libraries
 
 Since Haskell is the purely functional lazily-evaluated programming language _par excellance_, it is no wonder that many of the ideas in FS2 were first tried and developed in there.
 
@@ -70,6 +75,8 @@ Since Haskell is the purely functional lazily-evaluated programming language _pa
 [lukasz-byczynski]: https://github.com/lukaszbyczynski
 [francoeurdavid]: https://twitter.com/francoeurdavid
 [alexey_novakov]: https://twitter.com/alexey_novakov
+[majik-p]: https://github.com/majk-p
+[zainab-ali]: https://github.com/zainab-ali
 
 ### Older References ###
 


### PR DESCRIPTION
This adds links to aquascape, my functional stream processing book and a few recent talks.

Once the videos are out, it would be great to add a few more:
 - https://scaladays.org/editions/2025/talks/scala-and-arpeggio-audio-processing
 - https://scaladays.org/editions/2025/talks/taking-the-plunge-a-deep

The heading levels have been changed so that links appear on the sidebar:
<img width="500" height="404" alt="image" src="https://github.com/user-attachments/assets/04285701-6936-4b31-a187-9eb77d9e9e8a" />
