### PR TITLE
Backport 3591

### DIFF
--- a/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
+++ b/io/shared/src/test/scala/fs2/io/net/tcp/SocketSuite.scala
@@ -269,6 +269,18 @@ class SocketSuite extends Fs2Suite with SocketSuitePlatform {
       }
     }
 
+    test("sockets are released at the end of the resource scope") {
+      val f =
+        Network[IO].serverResource(port = Some(port"9071")).use { case (bindAddress, clients) =>
+          clients.foreach(_ => IO.sleep(1.second)).compile.drain.background.surround {
+            Network[IO].client(bindAddress).use { client =>
+              client.read(1).assertEquals(None)
+            }
+          }
+        }
+      f >> f >> f
+    }
+
     test("endOfOutput / endOfInput ignores ENOTCONN") {
       Network[IO].serverResource().use { case (bindAddress, clients) =>
         Network[IO].client(bindAddress).surround(IO.sleep(100.millis)).background.surround {


### PR DESCRIPTION
This backports https://github.com/typelevel/fs2/pull/3591 to the series/release/3.12 branch

It does not include subsequent updates made to fix deprecation warnings, but I am happy to port those too, although maybe those warnings only become warnings with other changes made later (I don't see them in my IDE and didn't notice them in the output from scalac either).
