### PR TITLE
Stream merge blocking downstream work.

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2000,6 +2000,107 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     Stream.force(fstream)
   }
 
+  /** Implementation of [[merge]], however allows specifying how to combine the output stream.
+    * This can be used to control how chunks are emitted downstream. See [[mergeAndAwaitDownstream]] for example.
+    *
+    * @param f The function that combines the output stream and a finalizer for the chunk.
+    *          This way we can controll when to pull pull next chunk from upstream.
+    */
+  private def merge_[F2[x] >: F[x], O2 >: O](
+      that: Stream[F2, O2]
+  )(
+      f: (Stream[F2, O2], F2[Unit]) => Stream[F2, O2]
+  )(implicit F: Concurrent[F2]): Stream[F2, O2] =
+    Stream.force {
+      // `State` describes the state of an upstream stream (`this` and `that` are both upstream streams)
+      // None            : the stream has not yet terminated
+      // Some(Left(t))   : the stream terminated with an error
+      // Some(Right(())) : the stream terminated successfully
+      type State = Option[Either[Throwable, Unit]]
+      for {
+        // `bothStates` keeps track of the state of `this` and `that` stream
+        // so we can terminate downstream when both upstreams terminate.
+        bothStates <- SignallingRef.of[F2, (State, State)]((None, None))
+        // `output` is used to send chunks from upstreams to downstream.
+        // It sends streams, not chunks, to tie each chunk with a finalizer
+        output <- Channel.synchronous[F2, Stream[F2, O2]]
+        // `stopDef` is used to interrupt the upstreams if a) any of the
+        // upstreams raises an error, or b) the downstream terminates.
+        stopDef <- Deferred[F2, Unit]
+      } yield {
+        val signalStop: F2[Unit] = stopDef.complete(()).void
+        val stop: F2[Either[Throwable, Unit]] = stopDef.get.as(Right(()))
+        def complete(result: Either[Throwable, Unit]): F2[Unit] =
+          bothStates.update {
+            case (None, None)  => (Some(result), None)
+            case (other, None) => (other, Some(result))
+            case _             => sys.error("impossible")
+          }
+        val bothStopped: PartialFunction[(State, State), Either[Throwable, Unit]] = {
+          case (Some(r1), Some(r2)) => CompositeFailure.fromResults(r1, r2)
+        }
+        def run(s: Stream[F2, O2]): F2[Unit] =
+          // `guard` ensures we do not pull another chunk until the previous one has been produced for downstream.
+          Semaphore[F2](1).flatMap { guard =>
+            def sendChunk(chk: Chunk[O2]): F2[Unit] =
+              output.send(f(Stream.chunk(chk), guard.release)) >> guard.acquire
+
+            (Stream.exec(guard.acquire) ++ s.chunks.foreach(sendChunk))
+              // Stop when the other upstream has errored or the downstream has completed.
+              // This may also interrupt the initial call to `guard.acquire` as the call is made at the
+              // beginning of the stream.
+              .interruptWhen(stop)
+              .compile
+              .drain
+              .attempt
+              .flatMap {
+                case r @ Left(_) =>
+                  // On error, interrupt the other upstream and downstream.
+                  complete(r) >> signalStop
+                case r @ Right(()) => complete(r)
+              }
+          }
+
+        val waitForBoth: F2[Unit] = bothStates.discrete
+          .collect(bothStopped)
+          .head
+          .rethrow
+          .compile
+          .drain
+          .guarantee(output.close.void)
+
+        // There is no need to clean up these fibers. If the downstream is cancelled,
+        // both streams will stop gracefully and the fibers will complete.
+        val setup: F2[Fiber[F2, Throwable, Unit]] =
+          run(this).start >> run(that).start >> waitForBoth.start
+        Stream.bracket(setup)(wfb => signalStop >> wfb.joinWithUnit) >> output.stream.flatten
+          .interruptWhen(stop)
+      }
+    }
+
+  /** Like [[merge]], but ensures that each chunk is fully consumed downstream before pulling the next chunk from the same side.
+    * This looses the equivalence with `Stream(this, that).parJoinUnbounded` but can be useful when we need to never read ahead from
+    * the merged streams.
+    *
+    * @note Pay attention to possible deadlocks of "this" or "that" when using this function, notably in parallel processing
+    *       as unless the chunk is fully processed / scope of the chunk is released, the next chunk will not be pulled.
+    *
+    * @example {{{
+    * scala> import scala.concurrent.duration._, cats.effect.IO, cats.effect.unsafe.implicits.global
+    * scala> import cats.effect._
+    * scala> Ref.of[IO, Int](0).flatMap{ ref =>
+    *      |   fs2.Stream.never[IO].mergeAndAwaitDownstream(fs2.Stream.repeatEval(ref.get)).evalMap(value => {
+    *      |     IO.sleep(1.second) >> ref.set(value + 1) as value
+    *      |   }).take(6).compile.toVector
+    *      | }.unsafeRunSync()
+    * res0: Vector[Int] = Vector(0, 1, 2, 3, 4, 5)
+    * }}}
+    */
+  def mergeAndAwaitDownstream[F2[x] >: F[x], O2 >: O](
+      that: Stream[F2, O2]
+  )(implicit F: Concurrent[F2]): Stream[F2, O2] =
+    merge_(that) { case (s, fin) => s.onFinalize(fin) }
+
   /** Interleaves the two inputs nondeterministically. The output stream
     * halts after BOTH `s1` and `s2` terminate normally, or in the event
     * of an uncaught failure on either `s1` or `s2`. Has the property that
@@ -2034,74 +2135,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
   def merge[F2[x] >: F[x], O2 >: O](
       that: Stream[F2, O2]
   )(implicit F: Concurrent[F2]): Stream[F2, O2] =
-    Stream.force {
-      // `State` describes the state of an upstream stream (`this` and `that` are both upstream streams)
-      // None            : the stream has not yet terminated
-      // Some(Left(t))   : the stream terminated with an error
-      // Some(Right(())) : the stream terminated successfully
-      type State = Option[Either[Throwable, Unit]]
-      for {
-        // `bothStates` keeps track of the state of `this` and `that` stream
-        // so we can terminate downstream when both upstreams terminate.
-        bothStates <- SignallingRef.of[F2, (State, State)]((None, None))
-        // `output` is used to send chunks from upstreams to downstream.
-        // It sends streams, not chunks, to tie each chunk with a finalizer
-        output <- Channel.synchronous[F2, Stream[F2, O2]]
-        // `stopDef` is used to interrupt the upstreams if a) any of the
-        // upstreams raises an error, or b) the downstream terminates.
-        stopDef <- Deferred[F2, Unit]
-      } yield {
-        val signalStop: F2[Unit] = stopDef.complete(()).void
-        val stop: F2[Either[Throwable, Unit]] = stopDef.get.as(Right(()))
-        def complete(result: Either[Throwable, Unit]): F2[Unit] =
-          bothStates.update {
-            case (None, None)  => (Some(result), None)
-            case (other, None) => (other, Some(result))
-            case _             => sys.error("impossible")
-          }
-        val bothStopped: PartialFunction[(State, State), Either[Throwable, Unit]] = {
-          case (Some(r1), Some(r2)) => CompositeFailure.fromResults(r1, r2)
-        }
-        def run(s: Stream[F2, O2]): F2[Unit] =
-          // `guard` ensures we do not pull another chunk until the previous one has been produced for downstream.
-          Semaphore[F2](1).flatMap { guard =>
-            def sendChunk(chk: Chunk[O2]): F2[Unit] = {
-              val outStr = Stream.exec(guard.release) ++ Stream.chunk(chk)
-              output.send(outStr) >> guard.acquire
-            }
-
-            (Stream.exec(guard.acquire) ++ s.chunks.foreach(sendChunk))
-              // Stop when the other upstream has errored or the downstream has completed.
-              // This may also interrupt the initial call to `guard.acquire` as the call is made at the
-              // beginning of the stream.
-              .interruptWhen(stop)
-              .compile
-              .drain
-              .attempt
-              .flatMap {
-                case r @ Left(_) =>
-                  // On error, interrupt the other upstream and downstream.
-                  complete(r) >> signalStop
-                case r @ Right(()) => complete(r)
-              }
-          }
-
-        val waitForBoth: F2[Unit] = bothStates.discrete
-          .collect(bothStopped)
-          .head
-          .rethrow
-          .compile
-          .drain
-          .guarantee(output.close.void)
-
-        // There is no need to clean up these fibers. If the downstream is cancelled,
-        // both streams will stop gracefully and the fibers will complete.
-        val setup: F2[Fiber[F2, Throwable, Unit]] =
-          run(this).start >> run(that).start >> waitForBoth.start
-        Stream.bracket(setup)(wfb => signalStop >> wfb.joinWithUnit) >> output.stream.flatten
-          .interruptWhen(stop)
-      }
-    }
+    merge_(that) { case (s, fin) => Stream.exec(fin) ++ s }
 
   /** Like `merge`, but halts as soon as _either_ branch halts. */
   def mergeHaltBoth[F2[x] >: F[x]: Concurrent, O2 >: O](

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2063,7 +2063,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
           case (Some(r1), Some(r2)) => CompositeFailure.fromResults(r1, r2)
         }
         def run(s: Stream[F2, O2]): F2[Unit] =
-          // `guard` ensures we do not pull another chunk until the previous one has been consumed downstream.
+          // `guard` ensures we do not pull another chunk until the previous one has been produced for downstream.
           Semaphore[F2](1).flatMap { guard =>
             def sendChunk(chk: Chunk[O2]): F2[Unit] = {
               val outStr = Stream.exec(guard.release) ++ Stream.chunk(chk)

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2066,7 +2066,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
           // `guard` ensures we do not pull another chunk until the previous one has been consumed downstream.
           Semaphore[F2](1).flatMap { guard =>
             def sendChunk(chk: Chunk[O2]): F2[Unit] = {
-              val outStr = Stream.chunk(chk).onFinalize(guard.release)
+              val outStr = Stream.exec(guard.release) ++ Stream.chunk(chk)
               output.send(outStr) >> guard.acquire
             }
 

--- a/core/shared/src/test/scala/fs2/StreamMergeSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamMergeSuite.scala
@@ -276,11 +276,15 @@ class StreamMergeSuite extends Fs2Suite {
         .compile
         .toVector
 
-    run(
-      (Stream.emit(1) ++ Stream.sleep_[IO](50.millis) ++ Stream.emit(2)).merge(
-        Stream.never[IO]
+    TestControl
+      .executeEmbed(
+        run(
+          (Stream.emit(1) ++ Stream.sleep_[IO](50.millis) ++ Stream.emit(2)).merge(
+            Stream.never[IO]
+          )
+        )
       )
-    ).assertEquals(Vector(1, 2))
+      .assertEquals(Vector(1, 2))
   }
 
   test("issue #3598") {

--- a/core/shared/src/test/scala/fs2/StreamMergeSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamMergeSuite.scala
@@ -247,15 +247,16 @@ class StreamMergeSuite extends Fs2Suite {
     // Create stream for each int that comes in,
     // then run them in parallel
     // Where we return the int value and then wait (Simulating some work that never ends, or ends in long time.).
-    def run(source: Stream[IO, Int]): IO[Vector[Int]] = {
-      source.map { a =>
-        Stream.emit(a) ++
-        Stream.never[IO]
-      }.parJoinUnbounded
-      .timeoutOnPullTo(200.millis, Stream.empty)
-      .compile
-      .toVector
-    }
+    def run(source: Stream[IO, Int]): IO[Vector[Int]] =
+      source
+        .map { a =>
+          Stream.emit(a) ++
+            Stream.never[IO]
+        }
+        .parJoinUnbounded
+        .timeoutOnPullTo(200.millis, Stream.empty)
+        .compile
+        .toVector
 
     run(
       (Stream.emit(1) ++ Stream.sleep_[IO](50.millis) ++ Stream.emit(2)).merge(
@@ -273,14 +274,13 @@ class StreamMergeSuite extends Fs2Suite {
     case object Tick2 extends Data
 
     def splitHead[F[_], O](in: fs2.Stream[F, O]): fs2.Stream[F, (O, fs2.Stream[F, O])] =
-      in.pull.uncons1
-      .flatMap {
+      in.pull.uncons1.flatMap {
         case Some((head, tail)) => fs2.Pull.output(Chunk((head, tail)))
-        case None => fs2.Pull.done
-      }
-      .stream
+        case None               => fs2.Pull.done
+      }.stream
 
-    val source = Stream.emits(1 to 2).evalMap(i => IO(Item(i)).delayBy(100.millis)) ++ Stream.never[IO]
+    val source =
+      Stream.emits(1 to 2).evalMap(i => IO(Item(i)).delayBy(100.millis)) ++ Stream.never[IO]
 
     val timer = fs2.Stream.awakeEvery[IO](50.millis).map(_ => Tick1)
     val timer2 = fs2.Stream.awakeEvery[IO](50.millis).map(_ => Tick2)
@@ -288,19 +288,22 @@ class StreamMergeSuite extends Fs2Suite {
     val sources = timer2.mergeHaltBoth(source.mergeHaltBoth(timer))
 
     splitHead(sources)
-    .flatMap { case (head, tail) =>
-      splitHead(tail).flatMap { case (head2, tail) =>
-        Stream.emit(head) ++ Stream.emit(head2) ++ tail
-      }.parEvalMap(3) { i =>
-       IO(i)
+      .flatMap { case (head, tail) =>
+        splitHead(tail)
+          .flatMap { case (head2, tail) =>
+            Stream.emit(head) ++ Stream.emit(head2) ++ tail
+          }
+          .parEvalMap(3) { i =>
+            IO(i)
+          }
       }
-    }
-    .interruptAfter(230.millis)
-    .compile
-    .toVector.assert { data =>
-      data.count(_.isInstanceOf[Item]) == 2 &&
-      data.count(_.isInstanceOf[Tick1.type]) == 4 &&
-      data.count(_.isInstanceOf[Tick2.type]) == 4
-    }
+      .interruptAfter(230.millis)
+      .compile
+      .toVector
+      .assert { data =>
+        data.count(_.isInstanceOf[Item]) == 2 &&
+        data.count(_.isInstanceOf[Tick1.type]) == 4 &&
+        data.count(_.isInstanceOf[Tick2.type]) == 4
+      }
   }
 }

--- a/core/shared/src/test/scala/fs2/StreamMergeSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamMergeSuite.scala
@@ -224,7 +224,7 @@ class StreamMergeSuite extends Fs2Suite {
     }
   }
 
-  test("merge not emit ahead") {
+  test("merge not emit ahead more than 1 chunk") {
     forAllF { (v: Int) =>
       Ref
         .of[IO, Int](v)
@@ -236,8 +236,8 @@ class StreamMergeSuite extends Fs2Suite {
             .repeatEval(ref.get)
             .merge(Stream.never[IO])
             .evalMap(sleepAndSet)
-            .take(2)
-            .assertEmits(List(v, v + 1))
+            .take(6)
+            .assertEmits(List(v, v, v + 1, v + 1, v + 2, v + 2))
         }
     }
   }


### PR DESCRIPTION
Stream merge does not block until scope is closed, but only until the chunk is read from the output channel.

Merge was waiting for the resulting chunk to be fully processed, this introduced a scope (resource) to the stream, which then if leased for further parallel processing would cause the merge to be waiting forever (until the parallel processing finished).

Here I am changing that we are only guarding the production of values from merge. Instead of guarding the whole processing of the chunk, we are only guarding the chunk up to the point where it is read from the output of the merge. 

This also fixes #3598. 

This is now aligned with documentation of merge where `Stream(this, that).parJoinUnbounded` == `this merge that`