### PR TITLE
fix: IO docs, echoServer should use flatMap on bind

### DIFF
--- a/site/io.md
+++ b/site/io.md
@@ -135,7 +135,7 @@ Now let's implement a server application that communicates with the client app w
 import cats.effect.Concurrent
 
 def echoServer[F[_]: Concurrent: Network]: F[Unit] =
-  Stream.resource(Network[F].bind(SocketAddress.port(port"5555"))).map { serverSocket =>
+  Stream.resource(Network[F].bind(SocketAddress.port(port"5555"))).flatMap { serverSocket =>
     serverSocket.accept.map { clientSocket =>
       clientSocket.reads
         .through(text.utf8.decode)


### PR DESCRIPTION
The current example doesn't work, I can't connect on the TCP server:

```
❯ telnet localhost 5555
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
Connection closed by foreign host.
```