### PR TITLE
Wrote test and fixed the bug for conflate chunk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.tools.mima.core._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion := "3.12"
+ThisBuild / tlBaseVersion := "3.13"
 
 ThisBuild / organization := "co.fs2"
 ThisBuild / organizationName := "Functional Streams for Scala"

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -576,7 +576,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val underlying: Pull[F,
     * The `chunkLimit` parameter controls backpressure on the source stream.
     */
   def conflateChunks[F2[x] >: F[x]: Concurrent](chunkLimit: Int): Stream[F2, Chunk[O]] =
-    Stream.eval(Channel.bounded[F2, Chunk[O]](chunkLimit)).flatMap { chan =>
+    Stream.eval(Channel.bounded[F2, Chunk[O]](chunkLimit - 1)).flatMap { chan =>
       val producer = chunks.through(chan.sendAll)
       val consumer = chan.stream.chunks.map(_.combineAll)
       consumer.concurrently(producer)

--- a/core/shared/src/test/scala/fs2/StreamConflateSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamConflateSuite.scala
@@ -23,6 +23,7 @@ package fs2
 
 import cats.effect.IO
 import cats.effect.testkit.TestControl
+import cats.syntax.all._
 
 import scala.concurrent.duration._
 
@@ -44,4 +45,23 @@ class StreamConflateSuite extends Fs2Suite {
         )
     )
   }
+  test("conflateChunks respects chunk limit") {
+
+    (1 to 1000).toList.traverse_ { _ =>
+      Stream(1, 2, 3, 4, 5, 6, 7)
+        .covary[IO]
+        .chunkLimit(1)
+        .unchunks
+        .conflateChunks(3)
+        .compile
+        .toList
+        .map { chunks =>
+          assert(
+            chunks.forall(_.size <= 3),
+            s"Expected all chunks <= 3, but got: $chunks"
+          )
+        }
+    }
+  }
+
 }

--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -416,7 +416,7 @@ private[fs2] trait FilesCompanionPlatform {
         .chunkN(options.chunkSize)
         .flatMap(Stream.chunk)
     }
-   // want to run ci pipeline
+
     override def writeAll(path: Path, _flags: Flags): Pipe[F, Byte, Nothing] =
       in =>
         in.through {

--- a/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
+++ b/io/js/src/main/scala/fs2/io/file/FilesPlatform.scala
@@ -416,7 +416,7 @@ private[fs2] trait FilesCompanionPlatform {
         .chunkN(options.chunkSize)
         .flatMap(Stream.chunk)
     }
-
+   // want to run ci pipeline
     override def writeAll(path: Path, _flags: Flags): Pipe[F, Byte, Nothing] =
       in =>
         in.through {


### PR DESCRIPTION
Bug Number - 3661

The main cause of the bug was Channel.bounded when pulled, emits buffered values (additional value) that appends values from blocked producers. So, Channel.bounded(3) can emit (n+1), 4  elements for higher iterations.

Proposed fix : I made a fix Channel.bounded (chunklimit -1) ensures the emitted chunk never exceeds chunklimit.
         Stream.eval(Channel.bounded[F2, **Chunk[O]](chunkLimit-** 1)).flatMap { chan =>
I wrote a test Conflate chunk respect chunklimit , for 1000 iterations which passed the test with the above fix. 