### PR TITLE
Fix some deprecation warn messages

### DIFF
--- a/io/jvm/src/main/scala/fs2/io/net/NetworkPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/NetworkPlatform.scala
@@ -47,8 +47,8 @@ private[net] trait NetworkPlatform[F[_]] {
     * @param threadFactory factory used to create fixed threads
     */
   @deprecated(
-    "3.13.0",
-    "Explicitly managed socket groups are no longer supported; use connect and bind operations on Network instead"
+    "Explicitly managed socket groups are no longer supported; use connect and bind operations on Network instead",
+    "3.13.0"
   )
   def socketGroup(
       threadCount: Int = 1,
@@ -65,8 +65,8 @@ private[net] trait NetworkPlatform[F[_]] {
     * @param threadFactory factory used to create selector thread
     */
   @deprecated(
-    "3.13.0",
-    "Explicitly managed socket groups are no longer supported; use bindDatagramSocket operation on Network instead"
+    "Explicitly managed socket groups are no longer supported; use bindDatagramSocket operation on Network instead",
+    "3.13.0"
   )
   def datagramSocketGroup(
       threadFactory: ThreadFactory = ThreadFactories.named("fs2-udp", true)

--- a/io/jvm/src/main/scala/fs2/io/net/tls/DTLSSocket.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/tls/DTLSSocket.scala
@@ -99,8 +99,8 @@ object DTLSSocket {
         override def address = socket.address
 
         @deprecated(
-          "3.13.0",
-          "Use address instead, which returns GenSocketAddress instead of F[SocketAddress[IpAddress]]. If ip and port are needed, call .asIpUnsafe"
+          "Use address instead, which returns GenSocketAddress instead of F[SocketAddress[IpAddress]]. If ip and port are needed, call .asIpUnsafe",
+          "3.13.0"
         )
         override def localAddress: F[SocketAddress[IpAddress]] = socket.localAddress
 

--- a/io/jvm/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
+++ b/io/jvm/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
@@ -88,11 +88,11 @@ private[tls] trait TLSSocketCompanionPlatform { self: TLSSocket.type =>
       def endOfInput: F[Unit] =
         socket.endOfInput
 
-      @deprecated("3.13.0", "Use address instead")
+      @deprecated("Use address instead", "3.13.0")
       def localAddress: F[SocketAddress[IpAddress]] =
         socket.localAddress
 
-      @deprecated("3.13.0", "Use peerAddress instead")
+      @deprecated("Use peerAddress instead", "3.13.0")
       def remoteAddress: F[SocketAddress[IpAddress]] =
         socket.remoteAddress
 
@@ -120,7 +120,7 @@ private[tls] trait TLSSocketCompanionPlatform { self: TLSSocket.type =>
       def applicationProtocol: F[String] =
         engine.applicationProtocol
 
-      @deprecated("3.13.0", "No replacement; sockets are open until they are finalized")
+      @deprecated("No replacement; sockets are open until they are finalized", "3.13.0")
       def isOpen: F[Boolean] = socket.isOpen
     }
 }

--- a/io/native/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
+++ b/io/native/src/main/scala/fs2/io/net/tls/TLSSocketPlatform.scala
@@ -85,11 +85,11 @@ private[tls] trait TLSSocketCompanionPlatform { self: TLSSocket.type =>
       def endOfInput: F[Unit] =
         socket.endOfInput
 
-      @deprecated("3.13.0", "Use address instead")
+      @deprecated("Use address instead", "3.13.0")
       def localAddress: F[SocketAddress[IpAddress]] =
         socket.localAddress
 
-      @deprecated("3.13.0", "Use peerAddress instead")
+      @deprecated("Use peerAddress instead", "3.13.0")
       def remoteAddress: F[SocketAddress[IpAddress]] =
         socket.remoteAddress
 
@@ -112,7 +112,7 @@ private[tls] trait TLSSocketCompanionPlatform { self: TLSSocket.type =>
 
       def applicationProtocol: F[String] = connection.applicationProtocol
 
-      @deprecated("3.13.0", "No replacement; sockets are open until they are finalized")
+      @deprecated("No replacement; sockets are open until they are finalized", "3.13.0")
       def isOpen: F[Boolean] = socket.isOpen
     }
 }

--- a/io/shared/src/main/scala/fs2/io/net/DatagramSocket.scala
+++ b/io/shared/src/main/scala/fs2/io/net/DatagramSocket.scala
@@ -79,8 +79,8 @@ trait DatagramSocket[F[_]] extends DatagramSocketPlatform[F] {
 
   /** Returns the local address of this udp socket. */
   @deprecated(
-    "3.13.0",
-    "Use address instead, which returns GenSocketAddress instead of F[SocketAddress[IpAddress]]. If ip and port are needed, call .asIpUnsafe"
+    "Use address instead, which returns GenSocketAddress instead of F[SocketAddress[IpAddress]]. If ip and port are needed, call .asIpUnsafe",
+    "3.13.0"
   )
   def localAddress: F[SocketAddress[IpAddress]]
 

--- a/io/shared/src/main/scala/fs2/io/net/DatagramSocketGroup.scala
+++ b/io/shared/src/main/scala/fs2/io/net/DatagramSocketGroup.scala
@@ -35,7 +35,7 @@ trait DatagramSocketGroup[F[_]] {
     * @param options              socket options to apply to the underlying socket
     * @param protocolFamily       protocol family to use when opening the supporting `DatagramChannel`
     */
-  @deprecated("3.13.0", "Use Network[F].bindDatagramSocket instead")
+  @deprecated("Use Network[F].bindDatagramSocket instead", "3.13.0")
   def openDatagramSocket(
       address: Option[Host] = None,
       port: Option[Port] = None,

--- a/io/shared/src/main/scala/fs2/io/net/Socket.scala
+++ b/io/shared/src/main/scala/fs2/io/net/Socket.scala
@@ -96,18 +96,18 @@ trait Socket[F[_]] extends SocketInfo[F] {
 
   // Deprecated members
 
-  @deprecated("3.13.0", "No replacement; sockets are open until they are finalized")
+  @deprecated("No replacement; sockets are open until they are finalized", "3.13.0")
   def isOpen: F[Boolean]
 
   @deprecated(
-    "3.13.0",
-    "Use address instead, which returns GenSocketAddress instead of F[SocketAddress[IpAddress]]. If ip and port are needed, call .asIpUnsafe"
+    "Use address instead, which returns GenSocketAddress instead of F[SocketAddress[IpAddress]]. If ip and port are needed, call .asIpUnsafe",
+    "3.13.0"
   )
   def localAddress: F[SocketAddress[IpAddress]]
 
   @deprecated(
-    "3.13.0",
-    "Use peerAddress instead, which returns GenSocketAddress instead of F[SocketAddress[IpAddress]]. If ip and port are needed, call .asIpUnsafe"
+    "Use peerAddress instead, which returns GenSocketAddress instead of F[SocketAddress[IpAddress]]. If ip and port are needed, call .asIpUnsafe",
+    "3.13.0"
   )
   def remoteAddress: F[SocketAddress[IpAddress]]
 }

--- a/io/shared/src/main/scala/fs2/io/net/SocketGroup.scala
+++ b/io/shared/src/main/scala/fs2/io/net/SocketGroup.scala
@@ -38,7 +38,7 @@ trait SocketGroup[F[_]] {
     * @param to      address of remote server
     * @param options socket options to apply to the underlying socket
     */
-  @deprecated("3.13.0", "Use Network[F].connect instead")
+  @deprecated("Use Network[F].connect instead", "3.13.0")
   def client(
       to: SocketAddress[Host],
       options: List[SocketOption] = List.empty
@@ -54,7 +54,7 @@ trait SocketGroup[F[_]] {
     * @param port               port to bind
     * @param options socket options to apply to the underlying socket
     */
-  @deprecated("3.13.0", "Use Network[F].bindAndAccept instead")
+  @deprecated("Use Network[F].bindAndAccept instead", "3.13.0")
   def server(
       address: Option[Host] = None,
       port: Option[Port] = None,
@@ -65,7 +65,7 @@ trait SocketGroup[F[_]] {
     *
     * Make sure to handle errors in the client socket Streams.
     */
-  @deprecated("3.13.0", "Use Network[F].bind instead")
+  @deprecated("Use Network[F].bind instead", "3.13.0")
   def serverResource(
       address: Option[Host] = None,
       port: Option[Port] = None,


### PR DESCRIPTION
We've all been there — `deprecated since` and `deprecated message` got mixed up.