### PR TITLE
Fix duplicate elements emitted by timeoutWith after timeout fires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ project/project
 .vscode
 .bsp
 node_modules
+hs_err_pid*.log

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -5223,7 +5223,7 @@ object Stream extends StreamLowPriority {
               case Some((Left(_), next))      => f(skipStaleTimeouts(next))
               case None                       => Pull.done
             }
-        // After a timeout, skip any further queued timeouts, then resume normal processing
+        /** After a timeout, skip any further queued timeouts, then resume normal processing */
         def skipStaleTimeouts(timedPull: Pull.Timed[F, O]): Pull[F, O2, Unit] =
           timedPull.uncons.flatMap {
             case Some((Right(elems), next)) => Pull.output(elems) >> go(next)

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -5220,9 +5220,16 @@ object Stream extends StreamLowPriority {
           timedPull.timeout(t) >>
             timedPull.uncons.flatMap {
               case Some((Right(elems), next)) => Pull.output(elems) >> go(next)
-              case Some((Left(_), next))      => f(go(next))
+              case Some((Left(_), next))      => f(skipStaleTimeouts(next))
               case None                       => Pull.done
             }
+        // After a timeout, skip any further queued timeouts, then resume normal processing
+        def skipStaleTimeouts(timedPull: Pull.Timed[F, O]): Pull[F, O2, Unit] =
+          timedPull.uncons.flatMap {
+            case Some((Right(elems), next)) => Pull.output(elems) >> go(next)
+            case Some((Left(_), next))      => skipStaleTimeouts(next)
+            case None                       => Pull.done
+          }
         go(timedPull)
       }
   }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -5223,6 +5223,7 @@ object Stream extends StreamLowPriority {
               case Some((Left(_), next))      => f(skipStaleTimeouts(next))
               case None                       => Pull.done
             }
+
         /** After a timeout, skip any further queued timeouts, then resume normal processing */
         def skipStaleTimeouts(timedPull: Pull.Timed[F, O]): Pull[F, O2, Unit] =
           timedPull.uncons.flatMap {

--- a/hs_err_pid9072.log
+++ b/hs_err_pid9072.log
@@ -1,0 +1,243 @@
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 2147483648 bytes. Error detail: G1 virtual space
+# Possible reasons:
+#   The system is out of physical RAM or swap space
+#   This process is running with CompressedOops enabled, and the Java Heap may be blocking the growth of the native heap
+# Possible solutions:
+#   Reduce memory load on the system
+#   Increase physical memory or swap space
+#   Check if swap backing store is full
+#   Decrease Java heap size (-Xmx/-Xms)
+#   Decrease number of Java threads
+#   Decrease Java thread stack sizes (-Xss)
+#   Set larger code cache with -XX:ReservedCodeCacheSize=
+#   JVM is running with Zero Based Compressed Oops mode in which the Java heap is
+#     placed in the first 32GB address space. The Java Heap base address is the
+#     maximum limit for the native heap growth. Please use -XX:HeapBaseMinAddress
+#     to set the Java Heap base and to place the Java Heap above 32GB virtual address.
+# This output file may be truncated or incomplete.
+#
+#  Out of Memory Error (os_windows.cpp:3713), pid=9072, tid=320
+#
+# JRE version:  (21.0.8+9) (build )
+# Java VM: OpenJDK 64-Bit Server VM (21.0.8+9-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, windows-amd64)
+# No core dump will be written. Minidumps are not enabled by default on client versions of Windows
+#
+
+---------------  S U M M A R Y ------------
+
+Command Line: -Djline.terminal=jline.UnsupportedTerminal -Dsbt.log.noformat=true -Dfile.encoding=UTF-8 -Dgrouping.with.qualified.names.enabled=true -Dseparate.prod.test.sources.enabled=true -Didea.managed=true -Dfile.encoding=UTF-8 -Xms2g -Xmx4g -XX:MaxMetaspaceSize=512m C:/Users/user/AppData/Roaming/JetBrains/IntelliJIdea2025.3/plugins/Scala/launcher/sbt-launch.jar
+
+Host: AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  , 8 cores, 5G,  Windows 11 , 64 bit Build 26100 (10.0.26100.8115)
+Time: Mon Apr  6 11:23:09 2026 India Standard Time elapsed time: 2.529452 seconds (0d 0h 0m 2s)
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x000002aab9d7f540):  JavaThread "Unknown thread" [_thread_in_vm, id=320, stack(0x000000efe1d00000,0x000000efe1e00000) (1024K)]
+
+Stack: [0x000000efe1d00000,0x000000efe1e00000]
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+V  [jvm.dll+0x6d2449]
+V  [jvm.dll+0x8ae341]
+V  [jvm.dll+0x8b08be]
+V  [jvm.dll+0x8b0fa3]
+V  [jvm.dll+0x280c96]
+V  [jvm.dll+0x6cec15]
+V  [jvm.dll+0x6c2c3a]
+V  [jvm.dll+0x35867a]
+V  [jvm.dll+0x360246]
+V  [jvm.dll+0x3b1f9e]
+V  [jvm.dll+0x3b2248]
+V  [jvm.dll+0x32c8fc]
+V  [jvm.dll+0x32d45b]
+V  [jvm.dll+0x8775d9]
+V  [jvm.dll+0x3bed71]
+V  [jvm.dll+0x8605d3]
+V  [jvm.dll+0x4530ee]
+V  [jvm.dll+0x454d31]
+C  [jli.dll+0x5278]
+C  [ucrtbase.dll+0x37b0]
+C  [KERNEL32.DLL+0x2e8d7]
+C  [ntdll.dll+0x8c3fc]
+
+
+---------------  P R O C E S S  ---------------
+
+Threads class SMR info:
+_java_thread_list=0x00007fff33f311c8, length=0, elements={
+}
+
+Java Threads: ( => current thread )
+Total: 0
+
+Other Threads:
+  0x000002aabc2f0980 WorkerThread "GC Thread#0"                     [id=20788, stack(0x000000efe1e00000,0x000000efe1f00000) (1024K)]
+  0x000002aabc301960 ConcurrentGCThread "G1 Main Marker"            [id=8652, stack(0x000000efe1f00000,0x000000efe2000000) (1024K)]
+  0x000002aabc302460 WorkerThread "G1 Conc#0"                       [id=10084, stack(0x000000efe2000000,0x000000efe2100000) (1024K)]
+
+[error occurred during error reporting (printing all threads), id 0xc0000005, EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x00007fff3362f137]
+VM state: not at safepoint (not fully initialized)
+
+VM Mutex/Monitor currently owned by a thread:  ([mutex/lock_event])
+[0x00007fff33fa5558] Heap_lock - owner thread: 0x000002aab9d7f540
+
+Heap address: 0x0000000700000000, size: 4096 MB, Compressed Oops mode: Zero based, Oop shift amount: 3
+
+CDS archive(s) mapped at: [0x0000000000000000-0x0000000000000000-0x0000000000000000), size 0, SharedBaseAddress: 0x0000000800000000, ArchiveRelocationMode: 1.
+Narrow klass base: 0x0000000000000000, Narrow klass shift: 0, Narrow klass range: 0x0
+
+GC Precious Log:
+ CardTable entry size: 512
+ Card Set container configuration: InlinePtr #cards 4 size 8 Array Of Cards #cards 16 size 48 Howl #buckets 8 coarsen threshold 3686 Howl Bitmap #cards 512 size 80 coarsen threshold 460 Card regions per heap region 1 cards per card region 4096
+
+Heap:
+ garbage-first heap   total 0K, used 0K [0x0000000700000000, 0x0000000800000000)
+  region size 2048K, 0 young (0K), 0 survivors (0K)
+
+[error occurred during error reporting (printing heap information), id 0xc0000005, EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x00007fff33a1bba9]
+GC Heap History (0 events):
+No events
+
+Dll operation events (1 events):
+Event: 0.070 Loaded shared library C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin\java.dll
+
+Deoptimization events (0 events):
+No events
+
+Classes loaded (0 events):
+No events
+
+Classes unloaded (0 events):
+No events
+
+Classes redefined (0 events):
+No events
+
+Internal exceptions (0 events):
+No events
+
+ZGC Phase Switch (0 events):
+No events
+
+VM Operations (0 events):
+No events
+
+Memory protections (0 events):
+No events
+
+Nmethod flushes (0 events):
+No events
+
+Events (0 events):
+No events
+
+
+Dynamic libraries:
+0x00007ff722e20000 - 0x00007ff722e2e000 	C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin\java.exe
+0x00007fffa4820000 - 0x00007fffa4a87000 	C:\WINDOWS\SYSTEM32\ntdll.dll
+0x00007fffa4000000 - 0x00007fffa40c9000 	C:\WINDOWS\System32\KERNEL32.DLL
+0x00007fffa1b40000 - 0x00007fffa1f34000 	C:\WINDOWS\System32\KERNELBASE.dll
+0x00007fffa23b0000 - 0x00007fffa24fb000 	C:\WINDOWS\System32\ucrtbase.dll
+0x00007fff561d0000 - 0x00007fff561ee000 	C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin\VCRUNTIME140.dll
+0x00007fff561b0000 - 0x00007fff561c8000 	C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin\jli.dll
+0x00007fffa3a60000 - 0x00007fffa3c25000 	C:\WINDOWS\System32\USER32.dll
+0x00007fffa2230000 - 0x00007fffa2257000 	C:\WINDOWS\System32\win32u.dll
+0x00007fffa33f0000 - 0x00007fffa341b000 	C:\WINDOWS\System32\GDI32.dll
+0x00007fffa1a10000 - 0x00007fffa1b3a000 	C:\WINDOWS\System32\gdi32full.dll
+0x00007fffa2500000 - 0x00007fffa25a3000 	C:\WINDOWS\System32\msvcp_win.dll
+0x00007fff93710000 - 0x00007fff939a3000 	C:\WINDOWS\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.8115_none_3e075c82e3354f9c\COMCTL32.dll
+0x00007fffa30b0000 - 0x00007fffa3159000 	C:\WINDOWS\System32\msvcrt.dll
+0x00007fffa3480000 - 0x00007fffa34b2000 	C:\WINDOWS\System32\IMM32.DLL
+0x00007fff616f0000 - 0x00007fff616fc000 	C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin\vcruntime140_1.dll
+0x00007fff4aff0000 - 0x00007fff4b07d000 	C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin\msvcp140.dll
+0x00007fff332f0000 - 0x00007fff34087000 	C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin\server\jvm.dll
+0x00007fffa4450000 - 0x00007fffa4506000 	C:\WINDOWS\System32\ADVAPI32.dll
+0x00007fffa4510000 - 0x00007fffa45b7000 	C:\WINDOWS\System32\sechost.dll
+0x00007fffa4190000 - 0x00007fffa42a8000 	C:\WINDOWS\System32\RPCRT4.dll
+0x00007fffa43b0000 - 0x00007fffa4430000 	C:\WINDOWS\System32\WS2_32.dll
+0x00007fffa0f40000 - 0x00007fffa0f9e000 	C:\WINDOWS\SYSTEM32\POWRPROF.dll
+0x00007fff9ab80000 - 0x00007fff9ab8b000 	C:\WINDOWS\SYSTEM32\VERSION.dll
+0x00007fff99550000 - 0x00007fff99586000 	C:\WINDOWS\SYSTEM32\WINMM.dll
+0x00007fffa0f20000 - 0x00007fffa0f34000 	C:\WINDOWS\SYSTEM32\UMPDC.dll
+0x00007fff9fe80000 - 0x00007fff9fe9b000 	C:\WINDOWS\SYSTEM32\kernel.appcore.dll
+0x00007fff616b0000 - 0x00007fff616ba000 	C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin\jimage.dll
+0x00007fff96630000 - 0x00007fff96872000 	C:\WINDOWS\SYSTEM32\DBGHELP.DLL
+0x00007fffa2d20000 - 0x00007fffa30a2000 	C:\WINDOWS\System32\combase.dll
+0x00007fffa3f20000 - 0x00007fffa3ff7000 	C:\WINDOWS\System32\OLEAUT32.dll
+0x00007fff91270000 - 0x00007fff912ab000 	C:\WINDOWS\SYSTEM32\dbgcore.DLL
+0x00007fffa1960000 - 0x00007fffa1a05000 	C:\WINDOWS\System32\bcryptPrimitives.dll
+0x00007fff4aeb0000 - 0x00007fff4aecf000 	C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin\java.dll
+
+JVMTI agents: none
+
+dbghelp: loaded successfully - version: 4.0.5 - missing functions: none
+symbol engine: initialized successfully - sym options: 0x614 - pdb path: .;C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin;C:\WINDOWS\SYSTEM32;C:\WINDOWS\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.8115_none_3e075c82e3354f9c;C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin\server
+
+VM Arguments:
+jvm_args: -Djline.terminal=jline.UnsupportedTerminal -Dsbt.log.noformat=true -Dfile.encoding=UTF-8 -Dgrouping.with.qualified.names.enabled=true -Dseparate.prod.test.sources.enabled=true -Didea.managed=true -Dfile.encoding=UTF-8 -Xms2g -Xmx4g -XX:MaxMetaspaceSize=512m 
+java_command: C:/Users/user/AppData/Roaming/JetBrains/IntelliJIdea2025.3/plugins/Scala/launcher/sbt-launch.jar
+java_class_path (initial): C:/Users/user/AppData/Roaming/JetBrains/IntelliJIdea2025.3/plugins/Scala/launcher/sbt-launch.jar
+Launcher Type: SUN_STANDARD
+
+[Global flags]
+     intx CICompilerCount                          = 4                                         {product} {ergonomic}
+   size_t CompressedClassSpaceSize                 = 436207616                                 {product} {ergonomic}
+     uint ConcGCThreads                            = 2                                         {product} {ergonomic}
+     uint G1ConcRefinementThreads                  = 8                                         {product} {ergonomic}
+   size_t G1HeapRegionSize                         = 2097152                                   {product} {ergonomic}
+    uintx GCDrainStackTargetSize                   = 64                                        {product} {ergonomic}
+   size_t InitialHeapSize                          = 2147483648                                {product} {command line}
+   size_t MarkStackSize                            = 4194304                                   {product} {ergonomic}
+   size_t MaxHeapSize                              = 4294967296                                {product} {command line}
+   size_t MaxMetaspaceSize                         = 536870912                                 {product} {command line}
+   size_t MinHeapDeltaBytes                        = 2097152                                   {product} {ergonomic}
+   size_t MinHeapSize                              = 2147483648                                {product} {command line}
+    uintx NonNMethodCodeHeapSize                   = 5839372                                {pd product} {ergonomic}
+    uintx NonProfiledCodeHeapSize                  = 122909434                              {pd product} {ergonomic}
+    uintx ProfiledCodeHeapSize                     = 122909434                              {pd product} {ergonomic}
+    uintx ReservedCodeCacheSize                    = 251658240                              {pd product} {ergonomic}
+     bool SegmentedCodeCache                       = true                                      {product} {ergonomic}
+   size_t SoftMaxHeapSize                          = 4294967296                             {manageable} {ergonomic}
+     bool UseCompressedOops                        = true                           {product lp64_product} {ergonomic}
+     bool UseG1GC                                  = true                                      {product} {ergonomic}
+     bool UseLargePagesIndividualAllocation        = false                                  {pd product} {ergonomic}
+
+Logging:
+Log output configuration:
+ #0: stdout all=warning uptime,level,tags foldmultilines=false
+ #1: stderr all=off uptime,level,tags foldmultilines=false
+
+Environment Variables:
+JAVA_HOME=C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot
+PATH=C:\MinGW\bin;D:\depot_tools;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Users\user\AppData\Local\Microsoft\WindowsApps;C:\Program Files\Git\bin;C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\bin;C:\Users\user\AppData\Local\nvm;C:\nvm4w\nodejs;;C:\Program Files\Docker\Docker\resources\bin;D:\depot_tools;C:\Users\user\AppData\Local\nvm;C:\nvm4w\nodejs;C:\Users\user\AppData\Local\Programs\Microsoft VS Code\bin;C:\Users\user\AppData\Local\JetBrains\Toolbox\scripts
+USERNAME=user
+OS=Windows_NT
+PROCESSOR_IDENTIFIER=AMD64 Family 23 Model 24 Stepping 1, AuthenticAMD
+TMP=C:\Users\user\AppData\Local\Temp
+TEMP=C:\Users\user\AppData\Local\Temp
+
+
+
+
+Periodic native trim disabled
+
+---------------  S Y S T E M  ---------------
+
+OS:
+ Windows 11 , 64 bit Build 26100 (10.0.26100.8115)
+OS uptime: 2 days 22:41 hours
+Hyper-V role detected
+
+CPU: total 8 (initial active 8) (8 cores per cpu, 2 threads per core) family 23 model 24 stepping 1 microcode 0x810810e, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4a, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, clmul, bmi1, bmi2, adx, sha, fma, vzeroupper, clflush, clflushopt, hv, rdtscp, f16c
+Processor Information for the first 8 processors :
+  Max Mhz: 2100, Current Mhz: 2100, Mhz Limit: 2100
+
+Memory: 4k page, system-wide physical 6030M (1213M free)
+TotalPageFile size 23722M (AvailPageFile size 1878M)
+current process WorkingSet (physical memory assigned to process): 12M, peak: 12M
+current process commit charge ("private bytes"): 60M, peak: 2108M
+
+vm_info: OpenJDK 64-Bit Server VM (21.0.8+9-LTS) for windows-amd64 JRE (21.0.8+9-LTS), built on 2025-07-15T00:00:00Z by "admin" with MS VC++ 17.7 (VS2022)
+
+END.


### PR DESCRIPTION
I found this bug on running sbt test , this is a flaky bug.

In def Timeoutwith, the **merge** in timed buffers data chunks concurrently, and the timeout handler passes these buffered chunks to both the timeout function f and the normal go loop. Because of this, timeoutOnPullTo ,timeoutOnPullWithand, timeoutWith can emit duplicate elements after a timeout fires. 

Changes made in **stream.scala**

I made a fix introducing skipStaleTimeouts which skips any further queued timeouts and resumes normal processing with the first data chunk. This will prevent duplicate emission in timeoutOnPullTo and timeoutOnPullWith.


