### PR TITLE
Delete SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,0 @@
-# Security Policy
-
-## Reporting a Vulnerability
-
-To report a potential security vulnerability, email details to mpilquist@gmail.com. Upon confirmation of the vulnerability, we'll use the [Github coordinated disclosure process](https://docs.github.com/en/code-security/security-advisories/about-coordinated-disclosure-of-security-vulnerabilities) to collaborate and publish an advisory.


### PR DESCRIPTION
Instead, we can inherit the org-wide `SECURITY.md` document.

https://github.com/typelevel/.github/blob/main/SECURITY.md