### PR TITLE
fix: avoid NPE when a relative path is provided to Watcher::watch

### DIFF
--- a/io/jvm-native/src/main/scala/fs2/io/DeprecatedWatcher.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/DeprecatedWatcher.scala
@@ -263,7 +263,7 @@ object Watcher {
         types: Seq[Watcher.EventType],
         modifiers: Seq[WatchEvent.Modifier]
     ): F[F[Unit]] =
-      registerUntracked(path.getParent, types, modifiers).flatMap(key =>
+      registerUntracked(path.toAbsolutePath.getParent, types, modifiers).flatMap(key =>
         track(
           Registration(
             path,

--- a/io/jvm-native/src/main/scala/fs2/io/file/Watcher.scala
+++ b/io/jvm-native/src/main/scala/fs2/io/file/Watcher.scala
@@ -288,7 +288,7 @@ object Watcher {
         types: Seq[Watcher.EventType],
         modifiers: Seq[WatchEvent.Modifier]
     ): F[F[Unit]] =
-      registerUntracked(path.toNioPath.getParent, types, modifiers).flatMap(key =>
+      registerUntracked(path.absolute.toNioPath.getParent(), types, modifiers).flatMap(key =>
         track(
           Registration(
             path.toNioPath,

--- a/io/jvm/src/test/scala/fs2/io/file/WatcherSuite.scala
+++ b/io/jvm/src/test/scala/fs2/io/file/WatcherSuite.scala
@@ -33,6 +33,22 @@ import java.nio.file.WatchEvent
 class WatcherSuite extends Fs2Suite with BaseFileSuite {
   override def munitIOTimeout = 1.minute
 
+  group("support watching a file") {
+    test("for relative paths without throwing NPE") {
+      val mkRelativePath = for {
+        cwd <- Files[IO].currentWorkingDirectory.toResource
+        file <- Files[IO].tempFile(Some(cwd), "", ".tmp", None)
+        relPath = cwd.relativize(file)
+      } yield relPath
+      mkRelativePath
+        .both(Watcher.default[IO])
+        .use { case (path, watcher) =>
+          watcher.watch(path)
+        }
+        .void
+    }
+  }
+
   group("supports watching a file") {
     test("for modifications") {
       Stream


### PR DESCRIPTION
Before this commit, `Watcher::watch` throws NPE when a path is relative path without a parent.
This commit updates watchFile methods to defensively convert a path into absolute path and adds a test to confirm it won't throw NPE.

It supersedes https://github.com/typelevel/fs2/pull/3553 by SanjayUG
