### PR TITLE
Fix linesLimited bypass when line completes in one chunk

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -553,11 +553,25 @@ object text {
           }
 
           maxLineLength match {
-            case Some((max, raiseThrowable)) if stringBuilder.length > max =>
-              Pull.raiseError[F](
-                new LineTooLongException(stringBuilder.length, max)
-              )(using raiseThrowable)
-            case _ =>
+            case Some((max, raiseThrowable)) =>
+              val tooLongLength =
+                (linesBuffer.iterator.map(_.length) ++ Iterator(stringBuilder.length))
+                  .filter(_ > max)
+                  .reduceOption(_ max _)
+              tooLongLength match {
+                case Some(length) =>
+                  Pull.raiseError[F](
+                    new LineTooLongException(length, max)
+                  )(using raiseThrowable)
+                case None =>
+                  Pull.output(Chunk.from(linesBuffer)) >> go(
+                    stream,
+                    stringBuilder,
+                    ignoreFirstCharNewLine,
+                    first = false
+                  )
+              }
+            case None =>
               Pull.output(Chunk.from(linesBuffer)) >> go(
                 stream,
                 stringBuilder,

--- a/core/shared/src/test/scala/fs2/TextSuite.scala
+++ b/core/shared/src/test/scala/fs2/TextSuite.scala
@@ -324,6 +324,15 @@ class TextSuite extends Fs2Suite {
         )
       }
     }
+
+    test("linesLimited rejects long lines completed in a single chunk") {
+      val longLine = "x" * 1000 + "\n"
+      val singleChunk = Stream.emit(longLine).covary[Fallible]
+      assert(singleChunk.through(text.linesLimited(10)).toList.isLeft)
+
+      val multiChunk = Stream.emits(longLine.toList.map(_.toString)).covary[Fallible]
+      assert(multiChunk.through(text.linesLimited(10)).toList.isLeft)
+    }
   }
 
   group("string2char / char2string") {


### PR DESCRIPTION
## Summary

- `text.linesLimited` only checked `stringBuilder.length` after processing each chunk, so lines flushed into `linesBuffer` inside `fillBuffers` (when a line and its terminator arrive in the same chunk) bypassed the limit.
- Check completed lines in `linesBuffer` as well as the pending builder before emitting output.
- Add regression test covering single-chunk vs per-character chunking (repro from #3725).

Fixes #3725

## Test plan

- [x] `sbt "coreJVM/testOnly fs2.TextSuite"` — 92 tests passed (JDK 17)
- [x] New test: `linesLimited rejects long lines completed in a single chunk`


Made with [Cursor](https://cursor.com)